### PR TITLE
feat: add mn.debug.host parameter to mn:run command

### DIFF
--- a/src/main/java/io/micronaut/build/RunMojo.java
+++ b/src/main/java/io/micronaut/build/RunMojo.java
@@ -104,6 +104,12 @@ public class RunMojo extends AbstractMojo {
     private int debugPort;
 
     /**
+     * The host where remote debuggers can connect.
+     */
+    @Parameter(property = "mn.debug.host", defaultValue = "127.0.0.1")
+    private String debugHost;
+
+    /**
      * List of inclusion/exclusion paths that should not trigger an application restart. Check the
      * <a href="https://maven.apache.org/ref/3.3.9/maven-model/apidocs/org/apache/maven/model/FileSet.html">FileSet</a>
      * documentation for more details.
@@ -386,7 +392,7 @@ public class RunMojo extends AbstractMojo {
 
         if (debug) {
             String suspend = debugSuspend ? "y" : "n";
-            args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=" + suspend + ",address=" + debugPort);
+            args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=" + suspend + ",address=" + debugHost + ":" + debugPort);
         }
 
         if (jvmArguments != null && !jvmArguments.isEmpty()) {

--- a/src/site/asciidoc/examples/run.adoc
+++ b/src/site/asciidoc/examples/run.adoc
@@ -94,6 +94,7 @@ Debugging options can be specified on the command line directly:
 
 * Running in debug mode: `mvn mn:run -Dmn.debug`.
 * Changing the debugger port: `mvn mn:run -Dmn.debug -Dmn.debug.port=5006`.
+* Changing the debugger host: `mvn mn:run -Dmn.debug -Dmn.debug.host=192.168.1.8` or `mvn mn:run -Dmn.debug -Dmn.debug.host=*`
 * Suspending the debugger execution: `mn:run -Dmn.debug -Dmn.debug.suspend`.
 
 ==== Other options


### PR DESCRIPTION
Add a parameter to specify the debugger host.

Example: `mvn mn:run -Dmn.debug -Dmn.debug.host=192.168.1.8` or `mvn mn:run -Dmn.debug -Dmn.debug.host=*`

Closes #84 