### PR TITLE
Use alpine-glibc:3.12 as base image

### DIFF
--- a/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -6,7 +6,7 @@ COPY classes /home/app/classes
 COPY dependency/* /home/app/libs/
 RUN native-image -H:Class=io.micronaut.build.examples.Application -H:Name=application --no-fallback -cp "/home/app/libs/*:/home/app/classes/"
 
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.12
 RUN apk update && apk add libstdc++
 COPY --from=builder /home/app/application /app/application
 

--- a/src/main/resources/dockerfiles/DockerfileNative
+++ b/src/main/resources/dockerfiles/DockerfileNative
@@ -9,7 +9,7 @@ ARG CLASS_NAME
 ARG GRAALVM_ARGS=""
 RUN native-image ${GRAALVM_ARGS} -H:Class=${CLASS_NAME} -H:Name=application --no-fallback -cp "/home/app/libs/*:/home/app/classes/"
 
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.12
 RUN apk update && apk add libstdc++
 COPY --from=builder /home/app/application /app/application
 


### PR DESCRIPTION
The `latest` version of `frolvlad/alpine-glibc` (3.13) is not compatible with GraalVM and application fail with a segmentation fault. This PR sets the version to the previous one that works (3.12)

More info: https://github.com/oracle/graal/issues/3159