### PR TITLE
Fix case where port is defined as an expression

### DIFF
--- a/src/main/java/io/micronaut/build/jib/JibMicronautExtension.java
+++ b/src/main/java/io/micronaut/build/jib/JibMicronautExtension.java
@@ -44,10 +44,15 @@ public class JibMicronautExtension implements JibMavenPluginExtension<Void> {
         builder.setBaseImage(from);
 
         ApplicationConfigurationService applicationConfigurationService = new ApplicationConfigurationService(mavenData.getMavenProject());
-        int port = Integer.parseInt(applicationConfigurationService.getServerPort());
-        if (port > 0) {
-            logger.log(ExtensionLogger.LogLevel.LIFECYCLE, "Exposing port: " + port);
-            builder.addExposedPort(Port.tcp(port));
+        try {
+            int port = Integer.parseInt(applicationConfigurationService.getServerPort());
+            if (port > 0) {
+                logger.log(ExtensionLogger.LogLevel.LIFECYCLE, "Exposing port: " + port);
+                builder.addExposedPort(Port.tcp(port));
+            }
+        } catch (NumberFormatException e) {
+            // ignore, can't automatically expose port
+            logger.log(ExtensionLogger.LogLevel.LIFECYCLE, "Dynamically resolved port present. Ensure the port is correctly exposed in the <container> configuration. See https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#example for an example.");
         }
 
         switch (runtime.getBuildStrategy()) {


### PR DESCRIPTION
If the port in the application config is an expression like `"${FOO_BAR:8090}"` then the plugin fails 
with an exception like:

```
 error running extension 'io.micronaut.build.jib.JibMicronautExtension': extension crashed: For input string: "${FOO_BAR:8090}" -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.google.cloud.tools:jib-maven-plugin:2.7.1:dockerBuild (default-dockerBuild)
```

This PR resolves that by catching the exception and suggesting configuring the exposed port manually
