### PR TITLE
Set specific GraalVM version for tests to avoid getting it from Micronaut BOM

### DIFF
--- a/src/it/dockerfile-docker-native-lambda/pom.xml
+++ b/src/it/dockerfile-docker-native-lambda/pom.xml
@@ -19,6 +19,7 @@
     <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
     <exec.mainClass>io.micronaut.function.aws.runtime.MicronautLambdaRuntime</exec.mainClass>
     <micronaut.runtime>lambda</micronaut.runtime>
+    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-netty/pom.xml
+++ b/src/it/dockerfile-docker-native-netty/pom.xml
@@ -20,6 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
+    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-oracle-function/pom.xml
+++ b/src/it/dockerfile-docker-native-oracle-function/pom.xml
@@ -20,6 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
+    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/package-native-image/pom.xml
+++ b/src/it/package-native-image/pom.xml
@@ -20,6 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
+    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This fixes the broken tests after the upgrade to GraalVM 21.1.0. See https://github.com/micronaut-projects/micronaut-maven-plugin/commit/5e2b3398b85c879cff235cbb041b8172f0adc36f