### PR TITLE
Set GraalVM version in plugin instead of getting it from Micronaut BOM

### DIFF
--- a/src/it/dockerfile-docker-native-lambda/pom.xml
+++ b/src/it/dockerfile-docker-native-lambda/pom.xml
@@ -19,7 +19,6 @@
     <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
     <exec.mainClass>io.micronaut.function.aws.runtime.MicronautLambdaRuntime</exec.mainClass>
     <micronaut.runtime>lambda</micronaut.runtime>
-    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-netty/pom.xml
+++ b/src/it/dockerfile-docker-native-netty/pom.xml
@@ -20,7 +20,6 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-oracle-function/pom.xml
+++ b/src/it/dockerfile-docker-native-oracle-function/pom.xml
@@ -20,7 +20,6 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/package-native-image/pom.xml
+++ b/src/it/package-native-image/pom.xml
@@ -20,7 +20,6 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.1.0</graal.version>
   </properties>
 
   <repositories>

--- a/src/main/java/io/micronaut/build/AbstractDockerMojo.java
+++ b/src/main/java/io/micronaut/build/AbstractDockerMojo.java
@@ -30,6 +30,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     public static final String DEFAULT_GRAAL_DOCKER_VERSION = "java11";
     public static final String LATEST_TAG = "latest";
 
+    private static final String GRAALVM_VERSION = "21.1.0";
+
     protected final MavenProject mavenProject;
     protected final JibConfigurationService jibConfigurationService;
     protected final ApplicationConfigurationService applicationConfigurationService;
@@ -84,7 +86,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     }
 
     protected String graalVmVersion() {
-        return mavenProject.getProperties().getProperty("graal.version");
+        return GRAALVM_VERSION;
     }
 
     protected String graalVmJvmVersion() {


### PR DESCRIPTION
As discussed at the last engineering meeting, this PR changes how we define GraalVM version. Instead of getting if from Micronaut BOM, the plugin sets it.

I have some mixed feelings about this change:
- Doing this allows us to test new GraalVM versions, and release new versions of the plugin without waiting for a Micronaut version to include the new GraalVM version in the BOM. For example for Micronaut 2.5.0 we are going to update GraalVM to 21.1.0, but, as it is not in the BOM yet, if we update the plugin, the tests fail.
Now, giving it a second though maybe doing something like this https://github.com/micronaut-projects/micronaut-maven-plugin/commit/c75b2d19193056a78736bac75c656e71f540b7c4 is enough for the tests.
- With this change users won't be able to override the version in their `pom.xml` files setting `<graal.version>` property. But, even if they can do it now, that doesn't mean the GraalVM version they select works with Micronaut. I think it's better if we are in control of this, because we know which GraalVM version works with every Micronaut release. The "worst" thing that can happen is that we need to do a new release of this plugin to update the GraalVM version, which I don't think it's a big deal because that's exactly what we do every three months when there is a new GraalVM version.

So, before merging this I would like to get some feedback from @jameskleeh that suggested the change and also from @alvarosanchez that did this and decided to get the GraalVM version from the BOM.