### PR TITLE
New goal (executed automatically) to generate GraalVM resources file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.3.9</maven.version>
+        <maven.resources-plugin.version>3.2.0</maven.resources-plugin.version>
         <site.path>${project.artifactId}</site.path>
         <site.name>${project.name}</site.name>
         <site.description>${project.description}</site.description>
@@ -129,6 +130,11 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.6.1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>${maven.resources-plugin.version}</version>
         </dependency>
 
         <dependency>
@@ -451,6 +457,7 @@
                             <settingsFile>src/it/settings.xml</settingsFile>
                             <scriptVariables>
                                 <nativeImagePluginVersion>${native-image-plugin.version}</nativeImagePluginVersion>
+                                <pluginVersion>${version}</pluginVersion>
                             </scriptVariables>
                             <goals>
                                 <goal>clean</goal>

--- a/src/it/package-docker-native/verify.groovy
+++ b/src/it/package-docker-native/verify.groovy
@@ -1,4 +1,5 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
+assert log.text.contains("micronaut-maven-plugin:${pluginVersion}:graalvm-resources")
 assert log.text.contains("Using BASE_IMAGE_RUN: frolvlad/alpine-glibc:alpine-3.12")
 assert log.text.contains("Successfully tagged alvarosanchez/demo:0.1")

--- a/src/it/package-native-image/openapi.properties
+++ b/src/it/package-native-image/openapi.properties
@@ -1,0 +1,1 @@
+swagger-ui.enabled=true

--- a/src/it/package-native-image/pom.xml
+++ b/src/it/package-native-image/pom.xml
@@ -124,6 +124,13 @@
 <!--      <scope>runtime</scope>-->
 <!--    </dependency>-->
 
+    <!-- Open API -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -144,6 +151,11 @@
               <groupId>io.micronaut</groupId>
               <artifactId>micronaut-graal</artifactId>
               <version>${micronaut.version}</version>
+            </path>
+            <path>
+              <groupId>io.micronaut.openapi</groupId>
+              <artifactId>micronaut-openapi</artifactId>
+              <version>${micronaut.openapi.version}</version>
             </path>
           </annotationProcessorPaths>
           <compilerArgs>

--- a/src/it/package-native-image/src/main/java/io/micronaut/build/examples/Application.java
+++ b/src/it/package-native-image/src/main/java/io/micronaut/build/examples/Application.java
@@ -3,6 +3,15 @@ package io.micronaut.build.examples;
 import io.micronaut.runtime.Micronaut;
 import io.micronaut.build.examples.greeter.Greeter;
 
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.info.*;
+
+@OpenAPIDefinition(
+    info = @Info(
+            title = "app",
+            version = "0.0"
+    )
+)
 public class Application {
 
     public static void main(String[] args) {

--- a/src/it/package-native-image/verify.groovy
+++ b/src/it/package-native-image/verify.groovy
@@ -5,6 +5,12 @@ assert log.text.contains("micronaut-maven-plugin:${pluginVersion}:graalvm-resour
 //assert log.text.contains("--no-fallback")
 //assert log.text.contains("-H:Class=io.micronaut.build.examples.Application")
 //assert log.text.contains("-H:Name=package-native-image")
+File resourceConfigFile = new File(basedir, 'target/classes/META-INF/native-image/io.micronaut.build.examples/package-native-image/resource-config.json')
+def resourceConfigJson = new groovy.json.JsonSlurper().parse(resourceConfigFile)
+
+assert resourceConfigJson.resources.pattern.any { it == "\\Qapplication.yml\\E" }
+assert resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/app-0.0.yml\\E" }
+assert resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/views/swagger-ui/index.html\\E" }
 
 File fatJar = new File(basedir, "target/package-native-image-0.1.jar")
 assert fatJar.exists()

--- a/src/it/package-native-image/verify.groovy
+++ b/src/it/package-native-image/verify.groovy
@@ -1,6 +1,7 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("native-image-maven-plugin:${nativeImagePluginVersion}:native-image")
+assert log.text.contains("micronaut-maven-plugin:${pluginVersion}:graalvm-resources")
 //assert log.text.contains("--no-fallback")
 //assert log.text.contains("-H:Class=io.micronaut.build.examples.Application")
 //assert log.text.contains("-H:Name=package-native-image")

--- a/src/main/java/io/micronaut/build/GraalVMResourcesMojo.java
+++ b/src/main/java/io/micronaut/build/GraalVMResourcesMojo.java
@@ -1,0 +1,139 @@
+package io.micronaut.build;
+
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.resources.ResourcesMojo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * <p>Generate GraalVM <code>resources-config.json</code> with all the resources included in the application</p>
+ * <p><strong>WARNING</strong>: this goal is not intended to be executed directly.</p>
+ *
+ * @author Iván López
+ * @since 2.0
+ */
+@Mojo(name = GraalVMResourcesMojo.GRAALVM_RESOURCES)
+public class GraalVMResourcesMojo extends ResourcesMojo {
+
+    public static final String GRAALVM_RESOURCES = "graalvm-resources";
+
+    private static final String META_INF = "META-INF";
+    private static final String RESOURCES = "resources";
+    private static final String PATTERN = "pattern";
+    private static final String RESOURCE_CONFIG_JSON = "resource-config.json";
+    private static final List<String> EXCLUDED_META_INF_DIRECTORIES = Arrays.asList("native-image", "services");
+
+    private final ObjectWriter writer = new ObjectMapper().writer(new DefaultPrettyPrinter());
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        Set<String> resourcesToAdd = new HashSet<>();
+
+        // Application resources (src/main/resources)
+        for (Resource resource : getResources()) {
+            resourcesToAdd.addAll(findResourceFiles(Paths.get(resource.getDirectory()).toFile()));
+        }
+
+        // Generated resources (like openapi)
+        Path metaInfPath = getOutputDirectory().toPath().resolve(META_INF);
+        resourcesToAdd.addAll(findResourceFiles(metaInfPath.toFile(), Collections.singletonList(META_INF)));
+
+        Path nativeImagePath = buildNativeImagePath();
+        Path graalVMResourcesPath = metaInfPath.resolve(nativeImagePath).toAbsolutePath();
+
+        Map<String, Object> json = new HashMap<>();
+        List<Map> resourceList = resourcesToAdd.stream()
+                .map(this::mapToGraalResource)
+                .collect(Collectors.toList());
+
+        json.put(RESOURCES, resourceList);
+
+        try {
+            Files.createDirectories(graalVMResourcesPath);
+            File resourceConfigFile = graalVMResourcesPath.resolve(RESOURCE_CONFIG_JSON).toFile();
+            getLog().info("Generating " + resourceConfigFile.getAbsolutePath());
+            writer.writeValue(resourceConfigFile, json);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("There was an error generating GraalVM resource-config.json file", e);
+        }
+    }
+
+    private Set<String> findResourceFiles(File folder) {
+        return this.findResourceFiles(folder, null);
+    }
+
+    private Set<String> findResourceFiles(File folder, List<String> filePath) {
+        Set<String> resourceFiles = new HashSet<>();
+
+        if (filePath == null) {
+            filePath = new ArrayList<>();
+        }
+
+        if (folder.exists()) {
+            File[] files = folder.listFiles();
+
+            if (files != null) {
+                boolean isMetaInfDirectory = folder.getName().equals(META_INF);
+
+                for (File element : files) {
+                    boolean isExcludedDirectory = EXCLUDED_META_INF_DIRECTORIES.contains(element.getName());
+                    // Exclude some directories in 'META-INF' like 'native-image' and 'services' but process other
+                    // 'META-INF' files and directories, for example, to include swagger-ui.
+                    if (!isMetaInfDirectory || !isExcludedDirectory) {
+                        if (element.isDirectory()) {
+                            List<String> paths = new ArrayList<>(filePath);
+                            paths.add(element.getName());
+
+                            resourceFiles.addAll(findResourceFiles(element, paths));
+                        } else {
+                            String joinedDirectories = String.join("/", filePath);
+                            String elementName = joinedDirectories.isEmpty() ? element.getName() : joinedDirectories + "/" + element.getName();
+
+                            resourceFiles.add(elementName);
+                        }
+                    }
+                }
+            }
+        }
+
+        return resourceFiles;
+    }
+
+    private Path buildNativeImagePath() {
+        String group = project.getGroupId();
+        String module = project.getArtifactId();
+
+        return Paths.get("native-image", group, module);
+    }
+
+    private Map<String, String> mapToGraalResource(String resourceName) {
+        Map<String, String> result = new HashMap<>();
+
+        if (resourceName.contains("*")) {
+            result.put(PATTERN, resourceName);
+        } else {
+            result.put(PATTERN, "\\Q" + resourceName + "\\E");
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/io/micronaut/build/GraalVMResourcesMojo.java
+++ b/src/main/java/io/micronaut/build/GraalVMResourcesMojo.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.resources.ResourcesMojo;
 
 import java.io.File;
@@ -43,8 +44,16 @@ public class GraalVMResourcesMojo extends ResourcesMojo {
 
     private final ObjectWriter writer = new ObjectMapper().writer(new DefaultPrettyPrinter());
 
+    @Parameter(property = "micronaut.native-image.skip-resources", defaultValue = "false")
+    private Boolean nativeImageSkipResources;
+
     @Override
     public void execute() throws MojoExecutionException {
+        if (nativeImageSkipResources) {
+            getLog().info("Skipping generation of resource-config.json");
+            return;
+        }
+
         Set<String> resourcesToAdd = new HashSet<>();
 
         // Application resources (src/main/resources)

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -18,7 +18,8 @@
                                 org.apache.maven.plugins:maven-resources-plugin:resources
                             </process-resources>
                             <compile>
-                                org.apache.maven.plugins:maven-compiler-plugin:compile
+                                org.apache.maven.plugins:maven-compiler-plugin:compile,
+                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
                             </compile>
                             <process-test-resources>
                                 org.apache.maven.plugins:maven-resources-plugin:testResources
@@ -61,7 +62,8 @@
                                 org.apache.maven.plugins:maven-resources-plugin:resources
                             </process-resources>
                             <compile>
-                                org.apache.maven.plugins:maven-compiler-plugin:compile
+                                org.apache.maven.plugins:maven-compiler-plugin:compile,
+                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
                             </compile>
                             <prepare-package>
                                 org.apache.maven.plugins:maven-jar-plugin:jar
@@ -122,7 +124,8 @@
                                 org.apache.maven.plugins:maven-resources-plugin:resources
                             </process-resources>
                             <compile>
-                                org.apache.maven.plugins:maven-compiler-plugin:compile
+                                org.apache.maven.plugins:maven-compiler-plugin:compile,
+                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
                             </compile>
                             <package>
                                 ${project.groupId}:${project.artifactId}:${project.version}:docker-native

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -18,8 +18,7 @@
                                 org.apache.maven.plugins:maven-resources-plugin:resources
                             </process-resources>
                             <compile>
-                                org.apache.maven.plugins:maven-compiler-plugin:compile,
-                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
+                                org.apache.maven.plugins:maven-compiler-plugin:compile
                             </compile>
                             <process-test-resources>
                                 org.apache.maven.plugins:maven-resources-plugin:testResources
@@ -30,6 +29,9 @@
                             <test>
                                 org.apache.maven.plugins:maven-surefire-plugin:test
                             </test>
+                            <prepare-package>
+                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
+                            </prepare-package>
                             <package>
                                 org.apache.maven.plugins:maven-jar-plugin:jar,
                                 org.apache.maven.plugins:maven-shade-plugin:shade
@@ -62,10 +64,10 @@
                                 org.apache.maven.plugins:maven-resources-plugin:resources
                             </process-resources>
                             <compile>
-                                org.apache.maven.plugins:maven-compiler-plugin:compile,
-                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
+                                org.apache.maven.plugins:maven-compiler-plugin:compile
                             </compile>
                             <prepare-package>
+                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources,
                                 org.apache.maven.plugins:maven-jar-plugin:jar
                             </prepare-package>
                             <package>
@@ -124,9 +126,11 @@
                                 org.apache.maven.plugins:maven-resources-plugin:resources
                             </process-resources>
                             <compile>
-                                org.apache.maven.plugins:maven-compiler-plugin:compile,
-                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
+                                org.apache.maven.plugins:maven-compiler-plugin:compile
                             </compile>
+                            <prepare-package>
+                                ${project.groupId}:${project.artifactId}:${project.version}:graalvm-resources
+                            </prepare-package>
                             <package>
                                 ${project.groupId}:${project.artifactId}:${project.version}:docker-native
                             </package>


### PR DESCRIPTION
This PR adds a new goal that is executed automatically and that creates the GraalVM `resource-config.json` automatically.

This needs to target Micronaut 3.0.x and be merged with the same [PR for Gradle plugin](https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/215)