### PR TITLE
Honor from.image if defined in jib-maven-plugin configuration #178

### DIFF
--- a/src/main/java/io/micronaut/build/DockerMojo.java
+++ b/src/main/java/io/micronaut/build/DockerMojo.java
@@ -60,7 +60,7 @@ public class DockerMojo extends AbstractDockerMojo {
             } catch (IOException e) {
                 throw new MojoExecutionException(e.getMessage(), e);
             }
-        } else {
+        } else if(!jibConfigurationService.getFromImage().isPresent()) {
             mavenProject.getProperties().setProperty(PropertyNames.FROM_IMAGE, JibMicronautExtension.DEFAULT_BASE_IMAGE);
         }
     }


### PR DESCRIPTION
Currently, system property `jib.from.image` is always set to the value of `JibMicronautExtension.DEFAULT_BASE_IMAGE`.

The jib-maven-plugin will always pick this image regardless of what `<from><image>` plugin configuration is set to.

This fix changes the default behavior to only set `jib.from.image` to default image if `<from><image>` is not set in the jib-maven-plugin configuration.

See also: https://github.com/micronaut-projects/micronaut-maven-plugin/issues/178