### PR TITLE
Fix #272 - GraalVM image names are invalid

### DIFF
--- a/src/it/dockerfile-docker-native-distroless/Dockerfile
+++ b/src/it/dockerfile-docker-native-distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:java11-21.3.0 AS builder
+FROM ghcr.io/graalvm/native-image:ol8-java11-21.3.1 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/src/it/dockerfile-docker-native-distroless/pom.xml
+++ b/src/it/dockerfile-docker-native-distroless/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-lambda/Dockerfile
+++ b/src/it/dockerfile-docker-native-lambda/Dockerfile
@@ -1,9 +1,9 @@
 FROM amazonlinux:2 AS graalvm
 ENV LANG=en_US.UTF-8
 RUN yum update -y && yum install -y gcc gcc-c++ zlib-devel zip tar gzip && yum clean all
-RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-linux-amd64-21.3.0.tar.gz -o /tmp/graalvm.tar.gz \
+RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.1/graalvm-ce-java11-linux-amd64-21.3.1.tar.gz -o /tmp/graalvm.tar.gz \
     && tar -zxf /tmp/graalvm.tar.gz -C /tmp \
-    && mv /tmp/graalvm-ce-java11-21.3.0 /usr/lib/graalvm \
+    && mv /tmp/graalvm-ce-java11-21.3.1 /usr/lib/graalvm \
     && rm -rf /tmp/*
 RUN /usr/lib/graalvm/bin/gu install native-image
 ENV PATH=/usr/lib/graalvm/bin:${PATH}

--- a/src/it/dockerfile-docker-native-lambda/pom.xml
+++ b/src/it/dockerfile-docker-native-lambda/pom.xml
@@ -19,7 +19,7 @@
     <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
     <exec.mainClass>io.micronaut.function.aws.runtime.MicronautLambdaRuntime</exec.mainClass>
     <micronaut.runtime>lambda</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:java11-21.3.0 AS builder
+FROM ghcr.io/graalvm/native-image:ol8-java11-21.3.1 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/src/it/dockerfile-docker-native-netty/pom.xml
+++ b/src/it/dockerfile-docker-native-netty/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-oracle-function/Dockerfile
+++ b/src/it/dockerfile-docker-native-oracle-function/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:java11-21.3.0 AS builder
+FROM ghcr.io/graalvm/native-image:ol8-java11-21.3.1 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/src/it/dockerfile-docker-native-oracle-function/pom.xml
+++ b/src/it/dockerfile-docker-native-oracle-function/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/src/it/dockerfile-docker-native-static/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/graalvm-ce:java11-21.3.0 AS builder
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.3.1 AS builder
 RUN gu install native-image
 
 RUN curl -L -o musl.tar.gz https://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz && \

--- a/src/it/dockerfile-docker-native-static/pom.xml
+++ b/src/it/dockerfile-docker-native-static/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/package-docker-native-distroless/pom.xml
+++ b/src/it/package-docker-native-distroless/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/package-docker-native-static/Dockerfile
+++ b/src/it/package-docker-native-static/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/graalvm-ce:java11-21.3.0 AS builder
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.3.1 AS builder
 RUN gu install native-image
 WORKDIR /home/app
 

--- a/src/it/package-docker-native-static/pom.xml
+++ b/src/it/package-docker-native-static/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/package-docker-native/pom.xml
+++ b/src/it/package-docker-native/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/it/package-native-image/pom.xml
+++ b/src/it/package-native-image/pom.xml
@@ -20,7 +20,7 @@
     <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
     <packaging>jar</packaging>
     <micronaut.runtime>netty</micronaut.runtime>
-    <graal.version>21.3.0</graal.version>
+    <graal.version>21.3.1</graal.version>
   </properties>
 
   <repositories>

--- a/src/main/java/io/micronaut/build/AbstractDockerMojo.java
+++ b/src/main/java/io/micronaut/build/AbstractDockerMojo.java
@@ -111,9 +111,9 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     protected String getFrom() {
         if (staticNativeImage) {
             // For building a static native image we need a base image with tools (cc, make,...) already installed
-            return jibConfigurationService.getFromImage().orElse("ghcr.io/graalvm/graalvm-ce:" + graalVmJvmVersion() + "-" + graalVmVersion());
+            return jibConfigurationService.getFromImage().orElse("ghcr.io/graalvm/graalvm-ce:ol8-" + graalVmJvmVersion() + "-" + graalVmVersion());
         } else {
-            return jibConfigurationService.getFromImage().orElse("ghcr.io/graalvm/native-image:" + graalVmJvmVersion() + "-" + graalVmVersion());
+            return jibConfigurationService.getFromImage().orElse("ghcr.io/graalvm/native-image:ol8-" + graalVmJvmVersion() + "-" + graalVmVersion());
         }
     }
 


### PR DESCRIPTION
Fixes #272 as currently native images fail to build as the default base images do not exist.