### PR TITLE
Update zlib to 1.2.12

### DIFF
--- a/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/src/it/dockerfile-docker-native-static/Dockerfile
@@ -9,7 +9,7 @@ ENV TOOLCHAIN_DIR="/musl"
 ENV PATH="$PATH:${TOOLCHAIN_DIR}/bin"
 ENV CC="${TOOLCHAIN_DIR}/bin/gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${TOOLCHAIN_DIR} && \
     make && make install && \

--- a/src/it/package-docker-native-static/Dockerfile
+++ b/src/it/package-docker-native-static/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir ${RESULT_LIB} && \
 ENV PATH="$PATH:${RESULT_LIB}/bin"
 ENV CC="musl-gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${RESULT_LIB} && \
     make && make install && \

--- a/src/main/resources/dockerfiles/DockerfileNativeStatic
+++ b/src/main/resources/dockerfiles/DockerfileNativeStatic
@@ -10,7 +10,7 @@ ENV TOOLCHAIN_DIR="/musl"
 ENV PATH="$PATH:${TOOLCHAIN_DIR}/bin"
 ENV CC="${TOOLCHAIN_DIR}/bin/gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${TOOLCHAIN_DIR} && \
     make && make install && \


### PR DESCRIPTION
Version 1.2.11 has been removed, and according to https://zlib.net:

> Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12.