### PR TITLE
Fix AOT execution

### DIFF
--- a/src/main/java/io/micronaut/build/RunMojo.java
+++ b/src/main/java/io/micronaut/build/RunMojo.java
@@ -164,9 +164,6 @@ public class RunMojo extends AbstractMojo {
     @SuppressWarnings("unchecked")
     public void execute() throws MojoExecutionException {
         this.sourceDirectories = compilerService.resolveSourceDirectories();
-        if (compilerService.needsCompilation()) {
-            compilerService.compileProject(true);
-        }
 
         try {
             runApplication();

--- a/src/main/java/io/micronaut/build/aot/AbstractMicronautAotMojo.java
+++ b/src/main/java/io/micronaut/build/aot/AbstractMicronautAotMojo.java
@@ -17,6 +17,7 @@ package io.micronaut.build.aot;
 
 import io.micronaut.build.Packaging;
 import io.micronaut.build.services.CompilerService;
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -27,6 +28,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 
 import java.io.File;
+import java.io.IOException;
 
 public abstract class AbstractMicronautAotMojo extends AbstractMojo {
 
@@ -83,12 +85,21 @@ public abstract class AbstractMicronautAotMojo extends AbstractMojo {
         validateRuntime();
         getLog().info("Running Micronaut AOT " + micronautAotVersion + " " + getName());
         try {
-            getBaseOutputDirectory().mkdirs();
+            File baseOutputDirectory = getBaseOutputDirectory();
+            clean(baseOutputDirectory);
             doExecute();
-            onSuccess(getBaseOutputDirectory());
-        } catch (DependencyResolutionException e) {
+            onSuccess(baseOutputDirectory);
+        } catch (DependencyResolutionException | IOException e) {
             throw new MojoExecutionException("Unable to generate AOT optimizations", e);
         }
+    }
+
+    private void clean(File baseOutputDirectory) throws IOException {
+        if (baseOutputDirectory.exists()) {
+            getLog().debug("Deleting " + baseOutputDirectory.getAbsolutePath());
+            FileUtils.deleteDirectory(baseOutputDirectory);
+        }
+        baseOutputDirectory.mkdirs();
     }
 
     private void validateRuntime() {


### PR DESCRIPTION
This PR:
* Cleans the AOT output directory before running AOT.
* Removes the initial compilation in `mn:run`. It is no longer needed because since version 3.2.0, the run mojo forks the `process-classes` phase, which includes `compile`.