### PR TITLE
Clean target/classes before running AOT

### DIFF
--- a/src/main/java/io/micronaut/build/aot/AbstractMicronautAotMojo.java
+++ b/src/main/java/io/micronaut/build/aot/AbstractMicronautAotMojo.java
@@ -61,6 +61,12 @@ public abstract class AbstractMicronautAotMojo extends AbstractMojo {
     @Parameter(property = "micronaut.aot.enabled", defaultValue = "false")
     protected boolean enabled;
 
+    /**
+     * Directory where compiled application classes are.
+     */
+    @Parameter(defaultValue = "${project.build.outputDirectory}", required = true)
+    protected File outputDirectory;
+
     public AbstractMicronautAotMojo(CompilerService compilerService, MavenProject mavenProject, MavenSession mavenSession, RepositorySystem repositorySystem) {
         this.compilerService = compilerService;
         this.mavenProject = mavenProject;
@@ -89,6 +95,7 @@ public abstract class AbstractMicronautAotMojo extends AbstractMojo {
         try {
             File baseOutputDirectory = getBaseOutputDirectory();
             clean(baseOutputDirectory);
+            clean(outputDirectory);
             doExecute();
             onSuccess(baseOutputDirectory);
         } catch (DependencyResolutionException | IOException e) {

--- a/src/main/java/io/micronaut/build/aot/AotAnalysisMojo.java
+++ b/src/main/java/io/micronaut/build/aot/AotAnalysisMojo.java
@@ -65,12 +65,6 @@ public class AotAnalysisMojo extends AbstractMicronautAotCliMojo {
     private File baseDirectory;
 
     /**
-     * Directory where compiled application classes are.
-     */
-    @Parameter(defaultValue = "${project.build.outputDirectory}", required = true)
-    private File outputDirectory;
-
-    /**
      * Micronaut AOT configuration file. Run the <a href="aot-sample-config-mojo.html"><code>aot-sample-config</code> goal</a> to
      * see all the possible options.
      */


### PR DESCRIPTION
Since it can contain an AOT-generated class for a different runtime than the current execution.

Fixes #329.