### PR TITLE
Add Test Resources client dependency automatically

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -75,11 +75,6 @@
       <artifactId>micronaut-test-junit5</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.micronaut.testresources</groupId>
-      <artifactId>micronaut-test-resources-client</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- For aws-custom-runtime -->
     <dependency>

--- a/src/it/test-resources-custom-dependency/pom.xml
+++ b/src/it/test-resources-custom-dependency/pom.xml
@@ -19,9 +19,7 @@
         <micronaut.runtime>netty</micronaut.runtime>
         <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
         <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
-        <micronaut.test.resources.version>@micronaut.test.resources.version@</micronaut.test.resources.version>
         <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
-<!--        <micronaut.test-resources.shared>true</micronaut.test-resources.shared>-->
     </properties>
     <repositories>
         <repository>
@@ -104,12 +102,6 @@
             <groupId>io.micronaut.data</groupId>
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut.testresources</groupId>
-            <artifactId>micronaut-test-resources-client</artifactId>
-            <version>${micronaut.test.resources.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/it/test-resources-disabled/invoker.properties
+++ b/src/it/test-resources-disabled/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -ntp -e dependency:tree

--- a/src/it/test-resources-disabled/pom.xml
+++ b/src/it/test-resources-disabled/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.micronaut.build.examples</groupId>
-    <artifactId>test-resources</artifactId>
+    <artifactId>test-resources-disabled</artifactId>
     <version>0.1</version>
     <packaging>${packaging}</packaging>
     <parent>
@@ -19,7 +19,7 @@
         <micronaut.runtime>netty</micronaut.runtime>
         <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
         <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
-        <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
+        <micronaut.test.resources.enabled>false</micronaut.test.resources.enabled>
     </properties>
     <repositories>
         <repository>
@@ -145,7 +145,7 @@
                     </annotationProcessorPaths>
                     <compilerArgs>
                         <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
-                        <arg>-Amicronaut.processing.module=test-resources</arg>
+                        <arg>-Amicronaut.processing.module=test-resources-disabled</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/src/it/test-resources-disabled/src/main/java/io/micronaut/build/examples/Application.java
+++ b/src/it/test-resources-disabled/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,11 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+
+}

--- a/src/it/test-resources-disabled/src/main/resources/application.yml
+++ b/src/it/test-resources-disabled/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+micronaut:
+  application:
+    name: test-resources-disabled
+netty:
+  default:
+    allocator:
+      max-order: 3
+datasources:
+  default:
+    schema-generate: CREATE
+    dialect: MYSQL
+#  users:
+#    driverClassName: org.postgresql.Driver
+#    schema-generate: CREATE_DROP
+#    dialect: POSTGRES

--- a/src/it/test-resources-disabled/src/main/resources/logback.xml
+++ b/src/it/test-resources-disabled/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/it/test-resources-disabled/verify.groovy
+++ b/src/it/test-resources-disabled/verify.groovy
@@ -1,0 +1,4 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD SUCCESS")
+assert !log.text.contains("test-resources-client")

--- a/src/it/test-resources-failing-test/pom.xml
+++ b/src/it/test-resources-failing-test/pom.xml
@@ -19,9 +19,7 @@
         <micronaut.runtime>netty</micronaut.runtime>
         <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
         <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
-        <micronaut.test.resources.version>@micronaut.test.resources.version@</micronaut.test.resources.version>
         <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
-<!--        <micronaut.test-resources.shared>true</micronaut.test-resources.shared>-->
     </properties>
     <repositories>
         <repository>
@@ -104,12 +102,6 @@
             <groupId>io.micronaut.data</groupId>
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut.testresources</groupId>
-            <artifactId>micronaut-test-resources-client</artifactId>
-            <version>${micronaut.test.resources.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/io/micronaut/build/services/DependencyResolutionService.java
+++ b/src/main/java/io/micronaut/build/services/DependencyResolutionService.java
@@ -50,9 +50,9 @@ import java.util.stream.Stream;
 public class DependencyResolutionService {
 
     public static final String TEST_RESOURCES_GROUP = "io.micronaut.testresources";
+    public static final String TEST_RESOURCES_ARTIFACT_ID_PREFIX = "micronaut-test-resources-";
 
     private static final String JAR_EXTENSION = "jar";
-    private static final String TEST_RESOURCES_ARTIFACT_ID_PREFIX = "micronaut-test-resources-";
 
     private final MavenSession mavenSession;
 

--- a/src/main/java/io/micronaut/build/testresources/AbstractTestResourcesMojo.java
+++ b/src/main/java/io/micronaut/build/testresources/AbstractTestResourcesMojo.java
@@ -34,7 +34,7 @@ public abstract class AbstractTestResourcesMojo extends AbstractMojo {
     /**
      * Whether to enable or disable Micronaut test resources support.
      */
-    @Parameter(property =  CONFIG_PROPERTY_PREFIX + "enabled", defaultValue = "false")
+    @Parameter(property =  CONFIG_PROPERTY_PREFIX + "enabled", defaultValue = DISABLED)
     protected boolean testResourcesEnabled;
 
     /**

--- a/src/main/java/io/micronaut/build/testresources/StopTestResourcesHelper.java
+++ b/src/main/java/io/micronaut/build/testresources/StopTestResourcesHelper.java
@@ -69,11 +69,9 @@ public class StopTestResourcesHelper {
         }
         try {
             Optional<ServerSettings> optionalServerSettings = ServerUtils.readServerSettings(getServerSettingsDirectory());
-            if (optionalServerSettings.isPresent()) {
-                if (ServerUtils.isServerStarted(optionalServerSettings.get().getPort())) {
-                    log.info("Shutting down Micronaut Test Resources service");
-                    doStop();
-                }
+            if (optionalServerSettings.isPresent() && ServerUtils.isServerStarted(optionalServerSettings.get().getPort())) {
+                log.info("Shutting down Micronaut Test Resources service");
+                doStop();
             }
         } catch (Exception e) {
             throw new MojoExecutionException("Unable to stop test resources server", e);

--- a/src/main/java/io/micronaut/build/testresources/StopTestResourcesServerMojo.java
+++ b/src/main/java/io/micronaut/build/testresources/StopTestResourcesServerMojo.java
@@ -30,8 +30,8 @@ public class StopTestResourcesServerMojo extends AbstractTestResourcesMojo {
 
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
-        StopTestResourcesHelper service = new StopTestResourcesHelper(testResourcesEnabled, keepAlive, shared, getLog(), buildDirectory);
-        service.stopTestResources();
+        StopTestResourcesHelper helper = new StopTestResourcesHelper(testResourcesEnabled, keepAlive, shared, getLog(), buildDirectory);
+        helper.stopTestResources();
     }
 
 }

--- a/src/main/java/io/micronaut/build/testresources/TestResourcesLifecycleExtension.java
+++ b/src/main/java/io/micronaut/build/testresources/TestResourcesLifecycleExtension.java
@@ -15,23 +15,30 @@
  */
 package io.micronaut.build.testresources;
 
-import io.micronaut.build.RunMojo;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.monitor.logging.DefaultLog;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.util.artifact.JavaScopes;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
 import java.util.function.Consumer;
 
+import static io.micronaut.build.RunMojo.THIS_PLUGIN;
+import static io.micronaut.build.services.DependencyResolutionService.TEST_RESOURCES_ARTIFACT_ID_PREFIX;
+import static io.micronaut.build.services.DependencyResolutionService.TEST_RESOURCES_GROUP;
 import static io.micronaut.build.testresources.AbstractTestResourcesMojo.CONFIG_PROPERTY_PREFIX;
 import static io.micronaut.build.testresources.StopTestResourcesServerMojo.MICRONAUT_TEST_RESOURCES_KEEPALIVE;
 
@@ -44,89 +51,98 @@ public class TestResourcesLifecycleExtension extends AbstractMavenLifecycleParti
     private static final String EXPLICIT_START_SERVICE_GOAL_NAME = "mn:" + StartTestResourcesServerMojo.NAME;
     private static final String EXPLICIT_STOP_SERVICE_GOAL_NAME = "mn:" + StopTestResourcesServerMojo.NAME;
 
+    private ExpressionEvaluator evaluator;
+
     @Override
     public void afterProjectsRead(MavenSession session) {
-        List<String> goals = session.getGoals();
-        if (goals.stream().anyMatch(EXPLICIT_START_SERVICE_GOAL_NAME::equals)) {
-            // we need to keep the server alive at the end of the build
-            session.getAllProjects().forEach(p -> {
-                Build build = p.getBuild();
-                withPlugin(build, "micronaut-maven-plugin", plugin -> {
-                    Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
-                    boolean enabled = isEnabled(configuration, p);
-                    if (enabled) {
-                        if (configuration == null) {
-                            configuration = new Xpp3Dom("configuration");
-                            plugin.setConfiguration(configuration);
-                        }
+        session.getAllProjects().forEach(p -> {
+            Build build = p.getBuild();
+            withPlugin(build, THIS_PLUGIN, plugin -> {
+                this.evaluator = getEvaluator(session, plugin);
+                Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+                boolean enabled = isEnabled();
+                if (enabled) {
+                    if (configuration == null) {
+                        configuration = new Xpp3Dom("configuration");
+                        plugin.setConfiguration(configuration);
+                    }
+                    List<String> goals = session.getGoals();
+                    if (goals.stream().anyMatch(EXPLICIT_START_SERVICE_GOAL_NAME::equals)) {
+                        // we need to keep the server alive at the end of the build
+
                         Xpp3Dom flag = new Xpp3Dom(MICRONAUT_TEST_RESOURCES_KEEPALIVE);
                         configuration.addChild(flag);
                         flag.setValue("true");
                     }
-                });
+                    Dependency clientDependency = new Dependency();
+                    clientDependency.setGroupId(TEST_RESOURCES_GROUP);
+                    clientDependency.setArtifactId(TEST_RESOURCES_ARTIFACT_ID_PREFIX + "client");
+                    clientDependency.setVersion(String.valueOf(p.getProperties().get(CONFIG_PROPERTY_PREFIX + "version")));
+                    clientDependency.setScope(JavaScopes.TEST);
+                    p.getDependencies().add(clientDependency);
+                }
             });
-        }
+        });
     }
 
     @Override
     public void afterSessionEnd(MavenSession session) throws MavenExecutionException {
         if (session.getGoals().stream().noneMatch(s -> s.equals(EXPLICIT_START_SERVICE_GOAL_NAME) || s.equals(EXPLICIT_STOP_SERVICE_GOAL_NAME))) {
             MavenProject project = session.getAllProjects().stream()
-                    .filter(p -> p.getPlugin(RunMojo.THIS_PLUGIN) != null)
+                    .filter(p -> p.getPlugin(THIS_PLUGIN) != null)
                     .findFirst()
-                    .orElseThrow(() -> new MavenExecutionException("Could not find plugin" + RunMojo.THIS_PLUGIN, (Throwable) null));
+                    .orElseThrow(() -> new MavenExecutionException("Could not find plugin" + THIS_PLUGIN, (Throwable) null));
 
-            Xpp3Dom configuration = (Xpp3Dom) project.getPlugin(RunMojo.THIS_PLUGIN).getConfiguration();
-
-            boolean enabled = isEnabled(configuration, project);
-            boolean keepAlive = isKeepAlive(configuration, project);
-            boolean shared = isShared(configuration, project);
+            boolean enabled = isEnabled();
+            boolean keepAlive = isKeepAlive();
+            boolean shared = isShared();
             Log log = new DefaultLog(new ConsoleLogger());
             File buildDirectory = new File(project.getBuild().getDirectory());
 
-            StopTestResourcesHelper service = new StopTestResourcesHelper(enabled, keepAlive, shared, log, buildDirectory);
+            StopTestResourcesHelper helper = new StopTestResourcesHelper(enabled, keepAlive, shared, log, buildDirectory);
             try {
-                service.stopTestResources();
+                helper.stopTestResources();
             } catch (Exception e) {
                 //no op
             }
         }
     }
 
-    private boolean isShared(Xpp3Dom configuration, MavenProject project) {
-        return evaluateBooleanProperty(project.getProperties(), configuration, CONFIG_PROPERTY_PREFIX + "shared", "shared");
+    private boolean isShared() {
+        return evaluateBooleanProperty(CONFIG_PROPERTY_PREFIX + "shared");
     }
 
-    private boolean isKeepAlive(Xpp3Dom configuration, MavenProject project) {
-        return evaluateBooleanProperty(project.getProperties(), configuration, MICRONAUT_TEST_RESOURCES_KEEPALIVE, "keepAlive");
+    private boolean isKeepAlive() {
+        return evaluateBooleanProperty(MICRONAUT_TEST_RESOURCES_KEEPALIVE);
     }
 
-    private boolean isEnabled(Xpp3Dom configuration, MavenProject project) {
-        return evaluateBooleanProperty(project.getProperties(), configuration, CONFIG_PROPERTY_PREFIX + "enabled", "testResourcesEnabled");
+    private boolean isEnabled() {
+        return evaluateBooleanProperty(CONFIG_PROPERTY_PREFIX + "enabled");
     }
 
-    private boolean evaluateBooleanProperty(Properties properties, Xpp3Dom configuration, String property, String xmlTag) {
-        boolean systemPropertyEnabled = Boolean.getBoolean(property);
-        if (systemPropertyEnabled) {
-            return true;
-        } else {
-            boolean projectPropertyEnabled = Boolean.parseBoolean(properties.getProperty(property, "false"));
-            if (projectPropertyEnabled) {
-                return true;
-            } else if (configuration != null) {
-                Xpp3Dom testResourcesEnabled = configuration.getChild(xmlTag);
-                if (testResourcesEnabled != null && testResourcesEnabled.getValue() != null) {
-                    return Boolean.parseBoolean(testResourcesEnabled.getValue());
-                }
+    private boolean evaluateBooleanProperty(String property) {
+        try {
+            Object result = evaluator.evaluate("${" + property + "}");
+            if (result instanceof Boolean) {
+                return (Boolean) result;
+            } else if (result instanceof String && (result.equals(Boolean.TRUE.toString()) || result.equals(Boolean.FALSE.toString()))) {
+                return Boolean.parseBoolean((String) result);
             }
+        } catch (ExpressionEvaluationException e) {
+            return false;
         }
         return false;
     }
 
-    private static void withPlugin(Build build, String artifactId, Consumer<? super Plugin> consumer) {
+    private ExpressionEvaluator getEvaluator(MavenSession session, Plugin thisPlugin) {
+        MojoExecution execution = new MojoExecution(thisPlugin, null, null);
+        return new PluginParameterExpressionEvaluator(session, execution);
+    }
+
+    private static void withPlugin(Build build, String groupIdArtifactId, Consumer<? super Plugin> consumer) {
         build.getPlugins()
                 .stream()
-                .filter(p -> artifactId.equals(p.getArtifactId()))
+                .filter(p -> groupIdArtifactId.equals(p.getGroupId() + ":" + p.getArtifactId()))
                 .findFirst()
                 .ifPresent(consumer);
     }

--- a/src/site/asciidoc/examples/test-resources.adoc
+++ b/src/site/asciidoc/examples/test-resources.adoc
@@ -11,24 +11,8 @@ configuration property. For example, if the kafka.bootstrap-servers property isn
 resources service for the value of this property. This will trigger the creation of a Kafka test container, and the
 service will answer with the URI to the bootstrap server.
 
-You can enable test resources support by adding the following elements to your `pom.xml`:
-
-.Maven
-[source,xml]
-----
-<project>
-    <properties>
-        <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>io.micronaut.testresources</groupId>
-            <artifactId>micronaut-test-resources-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-</project>
-----
+You can enable test resources support simply by setting the property `micronaut.test.resources.enabled` (either in your
+POM or via the command-line).
 
 This will be sufficient for most use cases, and Micronaut will automatically start containers, for example, when a
 particular property is not present in your configuration and that you run tests (`mvn test`) or the application in


### PR DESCRIPTION
This adds `io.micronaut.testresources:micronaut-test-resources-client`
as a `test` dependency if Test Resources is enabled.

It also uses a proper expression evaluation mechanism.