### PR TITLE
Fix CRaC for ubuntu 22.04

### DIFF
--- a/src/main/java/io/micronaut/build/DockerCracMojo.java
+++ b/src/main/java/io/micronaut/build/DockerCracMojo.java
@@ -76,7 +76,7 @@ public class DockerCracMojo extends AbstractDockerMojo {
     public static final String CRAC_READINESS_PROPERTY = "crac.readiness";
     public static final String DEFAULT_CRAC_CHECKPOINT_TIMEOUT = "60";
     public static final String CRAC_CHECKPOINT_TIMEOUT_PROPERTY = "crac.checkpoint.timeout";
-    public static final String DEFAULT_BASE_IMAGE = "ubuntu:20.04";
+    public static final String DEFAULT_BASE_IMAGE = "ubuntu:22.04";
 
     private static final EnumSet<PosixFilePermission> POSIX_FILE_PERMISSIONS = EnumSet.of(
             PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,

--- a/src/main/resources/cracScripts/checkpoint.sh
+++ b/src/main/resources/cracScripts/checkpoint.sh
@@ -7,6 +7,10 @@ echo 599 > /proc/sys/kernel/ns_last_pid
 trap 'echo "Killing $PROCESS" && kill -0 $PROCESS 2>/dev/null && kill $PROCESS' EXIT
 
 echo "Starting application"
+
+# Fix for WSL and OS X Docker Kernels
+GLIBC_TUNABLES=glibc.pthread.rseq=0
+
 # Run the app in the background
 /azul-crac-jdk/bin/java \
   -XX:CRaCCheckpointTo=cr \


### PR DESCRIPTION
Previously, the CRaC JDK fils if using Ubuntu 22.04

After checking with the Azul team, this issue only affects Mac and WSL docker clients where the kernel has not yet been updated to support it.

This fix sets and environment variable that has no effect for previous versions, but fixes the kernel settings for 22.04.

I have made the default 22.04