### PR TITLE
Allow setting a network for the crac checkpoint

### DIFF
--- a/src/main/java/io/micronaut/build/DockerCracMojo.java
+++ b/src/main/java/io/micronaut/build/DockerCracMojo.java
@@ -75,6 +75,7 @@ public class DockerCracMojo extends AbstractDockerMojo {
     public static final String DEFAULT_READINESS_COMMAND = "curl --output /dev/null --silent --head http://localhost:8080";
     public static final String CRAC_READINESS_PROPERTY = "crac.readiness";
     public static final String DEFAULT_CRAC_CHECKPOINT_TIMEOUT = "60";
+    public static final String CRAC_CHECKPOINT_NETWORK_PROPERTY = "crac.checkpoint.network";
     public static final String CRAC_CHECKPOINT_TIMEOUT_PROPERTY = "crac.checkpoint.timeout";
     public static final String DEFAULT_BASE_IMAGE = "ubuntu:22.04";
 
@@ -90,6 +91,9 @@ public class DockerCracMojo extends AbstractDockerMojo {
 
     @Parameter(property = DockerCracMojo.CRAC_CHECKPOINT_TIMEOUT_PROPERTY, defaultValue = DockerCracMojo.DEFAULT_CRAC_CHECKPOINT_TIMEOUT)
     private Integer checkpointTimeoutSeconds;
+
+    @Parameter(property = DockerCracMojo.CRAC_CHECKPOINT_NETWORK_PROPERTY)
+    private String checkpointNetworkName;
 
     @SuppressWarnings("CdiInjectionPointsInspection")
     @Inject
@@ -141,6 +145,7 @@ public class DockerCracMojo extends AbstractDockerMojo {
         dockerService.runPrivilegedImageAndWait(
                 checkpointImage,
                 checkpointTimeoutSeconds,
+                checkpointNetworkName,
                 new File(mavenProject.getBuild().getDirectory(), "cr").getAbsolutePath() + ":/home/app/cr"
         );
         buildFinalDockerfile(checkpointImage);

--- a/src/main/java/io/micronaut/build/services/DockerService.java
+++ b/src/main/java/io/micronaut/build/services/DockerService.java
@@ -121,13 +121,16 @@ public class DockerService {
      * @param timeoutSeconds the timeout in seconds for the container to finish execution
      * @param binds the bind mounts to use
      */
-    public void runPrivilegedImageAndWait(String imageId, Integer timeoutSeconds, String... binds) throws IOException {
+    public void runPrivilegedImageAndWait(String imageId, Integer timeoutSeconds, String checkpointNetworkName, String... binds) throws IOException {
         try (CreateContainerCmd create = dockerClient.createContainerCmd(imageId)) {
             HostConfig hostConfig = create.getHostConfig();
             if (hostConfig == null) {
                 throw new DockerClientException("When setting binds and privileged, hostConfig was null.  Please check your docker installation and try again");
             }
-            create.withHostConfig(hostConfig.withPrivileged(true));
+            hostConfig.withPrivileged(true);
+            if (checkpointNetworkName != null) {
+                hostConfig.withNetworkMode(checkpointNetworkName);
+            }
             for (String bind : binds) {
                 hostConfig.withBinds(Bind.parse(bind));
             }


### PR DESCRIPTION
If using mysql in a container, we need to be able to specify the network it is running on.