### PR TITLE
Add docker-crac to the list of package types

### DIFF
--- a/src/site/asciidoc/examples/package.adoc
+++ b/src/site/asciidoc/examples/package.adoc
@@ -6,6 +6,7 @@ This plugin supports different `<packaging>` types:
 * `native-image`: generates a GraalVM native image.
 * `docker`: builds a Docker image with the application artifacts (compiled classes, resources, dependencies, etc).
 * `docker-native`: builds a Docker image with a GraalVM native image inside.
+* `docker-crac`: builds a Docker image containing a CRaC checkpointed application.
 
 To package an application, `mvn package` is the one-stop shop to produce the desired artifact. By default, applications
 generated from https://micronaut.io/launch/[Micronaut Launch] have the packaging defined like


### PR DESCRIPTION
I also pushed 3.5.x as it was missing from the branches

Closes #607 