### PR TITLE
Replace openjdk with eclipse-temurin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
       "enabled": false
     },{
       "matchPaths": ["src/main/resources/dockerfiles/Dockerfile*"],
-      "matchPackageNames": ["openjdk", "amazonlinux"],
+      "matchPackageNames": ["eclipse-temurin", "amazonlinux"],
       "enabled": false
     }
   ]

--- a/examples/java/Dockerfile.example
+++ b/examples/java/Dockerfile.example
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-alpine
 WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/* /home/app/libs/

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-lambda/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-alpine
 WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/* /home/app/libs/

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-netty/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-netty/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-alpine
 WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/* /home/app/libs/

--- a/micronaut-maven-jib-integration/src/main/java/io/micronaut/maven/jib/JibMicronautExtension.java
+++ b/micronaut-maven-jib-integration/src/main/java/io/micronaut/maven/jib/JibMicronautExtension.java
@@ -35,7 +35,7 @@ import java.util.*;
  */
 public class JibMicronautExtension implements JibMavenPluginExtension<Void> {
 
-    public static final String DEFAULT_BASE_IMAGE = "openjdk:17-alpine";
+    public static final String DEFAULT_BASE_IMAGE = "eclipse-temurin:17-alpine";
     private static final String LATEST_TAG = "latest";
 
     @Override

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/Dockerfile
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-alpine
 WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/* /home/app/libs/


### PR DESCRIPTION
The `openjdk` project has been deprecated and only publishes early access
builds[1]. As a result the `openjdk:17-alpine` on Dockerhub has not been
updated in the last year and a half.

Replacing the image with `eclipse-temurin` should resolve these issues. The
choice for `eclipse-temurin` is somewhat arbitrary. But as an opensource
project its good enough.

 1. https://hub.docker.com/_/openjdk

Fixes: #628