### PR TITLE
Maven plugin parent pom to use micronaut version latest 4.0.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.version>3.9.1</maven.version>
-        <micronaut.version>4.0.0-SNAPSHOT</micronaut.version>
+        <micronaut.version>4.0.0-M1</micronaut.version>
         <native-maven-plugin.version>0.9.21</native-maven-plugin.version>
         <micronaut.aot.version>2.0.0-M1</micronaut.aot.version>
         <micronaut.test.resources.version>2.0.0-M1</micronaut.test.resources.version>


### PR DESCRIPTION
The project cannot be built because the pom has micronaut version as 4.0.0-SNAPSHOT. This PR will move it to correct latest micronaut 4.0.0-M1 version.