### PR TITLE
Allow setting OracleLinux version for native base image

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:ol8-java17-22.3.0 AS builder
+FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.0 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes
@@ -7,7 +7,8 @@ COPY *.args /home/app/graalvm-native-image.args
 ENV USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/*:/home/app/classes/"
 
-FROM gcr.io/distroless/cc-debian10
+FROM frolvlad/alpine-glibc:alpine-3.12
+RUN apk update && apk add libstdc++
 COPY --from=builder /home/app/application /app/application
 
 EXPOSE 8080

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native
+invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native -Dmicronaut.native-image.ol.version=ol7
 invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/pom.xml
@@ -1,0 +1,121 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>dockerfile-docker-native-netty</artifactId>
+  <version>0.1</version>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.platform</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>@it.micronaut.version@</version>
+  </parent>
+
+  <properties>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+    <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
+    <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+    <packaging>jar</packaging>
+    <micronaut.runtime>netty</micronaut.runtime>
+    <graal.oracle.linux.version>ol7</graal.oracle.linux.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-runtime</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <version>${micronaut-maven-plugin.version}</version>
+        <configuration>
+          <nativeImageBuildArgs>-Ob</nativeImageBuildArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-graal</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=${project.artifactId}</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>alvarosanchez/demo:${project.version}</image>
+          </to>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.micronaut.build.examples</groupId>
-  <artifactId>dockerfile-docker-native-netty</artifactId>
+  <artifactId>dockerfile-docker-native-netty-custom-ol</artifactId>
   <version>0.1</version>
   <packaging>${packaging}</packaging>
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,13 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+import io.micronaut.build.examples.greeter.Greeter;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Greeter greeter = new Greeter();
+        System.out.println(greeter.greet("world!"));
+        Micronaut.run(Application.class);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/java/io/micronaut/build/examples/greeter/Greeter.java
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/java/io/micronaut/build/examples/greeter/Greeter.java
@@ -1,0 +1,8 @@
+package io.micronaut.build.examples.greeter;
+
+public class Greeter {
+
+    public String greet(String name) {
+        return "HELLO " + name;
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: dockerfile-docker-native-netty

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 micronaut:
   application:
-    name: dockerfile-docker-native-netty
+    name: dockerfile-docker-native-netty-custom-ol

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/test/java/io/micronaut/build/examples/ApplicationTest.java
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/src/test/java/io/micronaut/build/examples/ApplicationTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+@MicronautTest
+public class ApplicationTest {
+
+    @Inject
+    EmbeddedApplication application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/verify.groovy
@@ -1,0 +1,4 @@
+File dockerfile = new File("$basedir/target", "Dockerfile")
+File expectedDockerfile = new File(basedir, "Dockerfile")
+
+assert dockerfile.text == expectedDockerfile.text

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.0 AS builder
+FROM ghcr.io/graalvm/native-image:ol8-java17-22.3.0 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.0 AS builder
+FROM ghcr.io/graalvm/native-image:ol8-java17-22.3.0 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-22.3.0 AS builder
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java17-22.3.0 AS builder
 RUN gu install native-image
 
 WORKDIR /

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-static/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-22.3.0 AS builder
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java17-22.3.0 AS builder
 RUN gu install native-image
 WORKDIR /home/app
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -137,6 +137,9 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         return mavenProject.getProperties().getProperty("graal.version");
     }
 
+    /**
+     * @return the oracle Linux version to use for the GraalVM base image. Defaults to {@value #ORACLE_LINUX_VERSION}
+     */
     protected String oracleLinuxVersion() {
         String version = mavenProject.getProperties().getProperty("graal.oracle.linux.version");
         return version == null ? ORACLE_LINUX_VERSION : version;

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -52,7 +52,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "amd64";
     public static final String JAVA_17 = "java17";
-    public static final String ORACLE_LINUX_VERSION = "ol8";
+    public static final String DEFAULT_ORACLE_LINUX_VERSION = "ol8";
 
     protected final MavenProject mavenProject;
     protected final JibConfigurationService jibConfigurationService;
@@ -105,6 +105,12 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     protected String baseImageRun;
 
     /**
+     * The version of Oracle Linux to use as a native-compile base when building a native image inside a Docker container.
+     */
+    @Parameter(property = "micronaut.native-image.ol.version", defaultValue = DEFAULT_ORACLE_LINUX_VERSION)
+    protected String oracleLinuxVersion;
+
+    /**
      * Networking mode for the RUN instructions during build.
      *
      * @since 4.0.0
@@ -138,14 +144,6 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     }
 
     /**
-     * @return the oracle Linux version to use for the GraalVM base image. Defaults to {@value #ORACLE_LINUX_VERSION}
-     */
-    protected String oracleLinuxVersion() {
-        String version = mavenProject.getProperties().getProperty("graal.oracle.linux.version");
-        return version == null ? ORACLE_LINUX_VERSION : version;
-    }
-
-    /**
      * @return the JVM version to use for GraalVM.
      */
     protected String graalVmJvmVersion() {
@@ -170,9 +168,9 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     protected String getFrom() {
         if (Boolean.TRUE.equals(staticNativeImage)) {
             // For building a static native image we need a base image with tools (cc, make,...) already installed
-            return getFromImage().orElse("ghcr.io/graalvm/graalvm-ce:" + oracleLinuxVersion() + "-" + graalVmJvmVersion() + "-" + graalVmVersion());
+            return getFromImage().orElse("ghcr.io/graalvm/graalvm-ce:" + oracleLinuxVersion + "-" + graalVmJvmVersion() + "-" + graalVmVersion());
         } else {
-            return getFromImage().orElse("ghcr.io/graalvm/native-image:" + oracleLinuxVersion() + "-" + graalVmJvmVersion() + "-" + graalVmVersion());
+            return getFromImage().orElse("ghcr.io/graalvm/native-image:" + oracleLinuxVersion + "-" + graalVmJvmVersion() + "-" + graalVmVersion());
         }
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -52,6 +52,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "amd64";
     public static final String JAVA_17 = "java17";
+    public static final String ORACLE_LINUX_VERSION = "ol8";
 
     protected final MavenProject mavenProject;
     protected final JibConfigurationService jibConfigurationService;
@@ -136,6 +137,11 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         return mavenProject.getProperties().getProperty("graal.version");
     }
 
+    protected String oracleLinuxVersion() {
+        String version = mavenProject.getProperties().getProperty("graal.oracle.linux.version");
+        return version == null ? ORACLE_LINUX_VERSION : version;
+    }
+
     /**
      * @return the JVM version to use for GraalVM.
      */
@@ -161,9 +167,9 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     protected String getFrom() {
         if (Boolean.TRUE.equals(staticNativeImage)) {
             // For building a static native image we need a base image with tools (cc, make,...) already installed
-            return getFromImage().orElse("ghcr.io/graalvm/graalvm-ce:ol7-" + graalVmJvmVersion() + "-" + graalVmVersion());
+            return getFromImage().orElse("ghcr.io/graalvm/graalvm-ce:" + oracleLinuxVersion() + "-" + graalVmJvmVersion() + "-" + graalVmVersion());
         } else {
-            return getFromImage().orElse("ghcr.io/graalvm/native-image:ol7-" + graalVmJvmVersion() + "-" + graalVmVersion());
+            return getFromImage().orElse("ghcr.io/graalvm/native-image:" + oracleLinuxVersion() + "-" + graalVmJvmVersion() + "-" + graalVmVersion());
         }
     }
 


### PR DESCRIPTION
Defaults to ol8, but can be configured via graal.oracle.linux.version

This is to align it with https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/714