### PR TITLE
StringUtils.isNotEmpty -> StringUtils.isEmpty

### DIFF
--- a/micronaut-maven-jib-integration/src/main/java/io/micronaut/maven/jib/JibMicronautExtension.java
+++ b/micronaut-maven-jib-integration/src/main/java/io/micronaut/maven/jib/JibMicronautExtension.java
@@ -52,7 +52,7 @@ public class JibMicronautExtension implements JibMavenPluginExtension<Void> {
 
         JibConfigurationService jibConfigurationService = new JibConfigurationService(mavenData.getMavenProject());
 
-        if (StringUtils.isNotEmpty(buildPlan.getBaseImage())) {
+        if (StringUtils.isEmpty(buildPlan.getBaseImage())) {
             builder.setBaseImage(DEFAULT_BASE_IMAGE);
         }
 


### PR DESCRIPTION
Logical error on line 55 in JibMicronautExtension#ContainerBuildPlan

```
if (StringUtils.isNotEmpty(buildPlan.getBaseImage())) {
    builder.setBaseImage(DEFAULT_BASE_IMAGE);
}
```
Changed to
```
if (StringUtils.isEmpty(buildPlan.getBaseImage())) {
    builder.setBaseImage(DEFAULT_BASE_IMAGE);
}
```

