### PR TITLE
Add Official CRaC JDK support to the Maven Plugin

### DIFF
--- a/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
+++ b/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
@@ -10,11 +10,20 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install latest CRaC OpenJDK
-RUN release="$(curl -sL https://api.github.com/repos/CRaC/openjdk-builds/releases/latest)" \
-    && asset="$(echo $release | sed -e 's/\r//g' | sed -e 's/\x09//g' | tr '\n' ' ' | jq '.assets[] | select(.name | test("openjdk-[0-9]+-crac\\+[0-9]+_linux-x64\\.tar\\.gz"))')" \
-    && id="$(echo $asset | jq .id)" \
-    && name="$(echo $asset | jq -r .name)" \
-    && curl -LJOH 'Accept: application/octet-stream' "https://api.github.com/repos/CRaC/openjdk-builds/releases/assets/$id" >&2 \
+RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
+RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
+    && details=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/$release_id" -H "accept: application/json") \
+    && name=$(echo "$details" | jq -r '.name') \
+    && url=$(echo "$details" | jq -r '.download_url') \
+    && hash=$(echo "$details" | jq -r '.sha256_hash') \
+    && echo "Downloading $name from $url" \
+    && curl -LJOH 'Accept: application/octet-stream' "$url" >&2 \
+    && file_sha=$(sha256sum -b "$name" | cut -d' ' -f 1) \
+    && if [ "$file_sha" != "$hash" ]; then \
+           echo "SHA256 hash mismatch: $file_sha != $hash" >&2; \
+           exit 1; \
+       fi \
+    && echo "SHA256 hash matches: $file_sha == $hash" >&2 \
     && tar xzf "$name" \
     && mv ${name%%.tar.gz} /azul-crac-jdk \
     && rm "$name"

--- a/src/it/package-docker-crac-aot/selector.groovy
+++ b/src/it/package-docker-crac-aot/selector.groovy
@@ -1,6 +1,0 @@
-return isX86()
-
-static boolean isX86() {
-    String osArch = System.getProperty("os.arch")
-    return "x86_64" == osArch
-}

--- a/src/it/package-docker-crac/selector.groovy
+++ b/src/it/package-docker-crac/selector.groovy
@@ -1,6 +1,0 @@
-return isX86()
-
-static boolean isX86() {
-    String osArch = System.getProperty("os.arch")
-    return "x86_64" == osArch
-}

--- a/src/main/java/io/micronaut/build/DockerCracMojo.java
+++ b/src/main/java/io/micronaut/build/DockerCracMojo.java
@@ -77,7 +77,16 @@ public class DockerCracMojo extends AbstractDockerMojo {
     public static final String DEFAULT_CRAC_CHECKPOINT_TIMEOUT = "60";
     public static final String CRAC_CHECKPOINT_NETWORK_PROPERTY = "crac.checkpoint.network";
     public static final String CRAC_CHECKPOINT_TIMEOUT_PROPERTY = "crac.checkpoint.timeout";
+
+    public static final String CRAC_JAVA_VERSION = "crac.java.version";
+    public static final String DEFAULT_CRAC_JAVA_VERSION = "17";
+
+    public static final String CRAC_ARCHITECTURE = "crac.arch";
+
     public static final String DEFAULT_BASE_IMAGE = "ubuntu:22.04";
+
+    public static final String ARM_ARCH = "aarch64";
+    public static final String X86_64_ARCH = "amd64";
 
     private static final EnumSet<PosixFilePermission> POSIX_FILE_PERMISSIONS = EnumSet.of(
             PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
@@ -94,6 +103,12 @@ public class DockerCracMojo extends AbstractDockerMojo {
 
     @Parameter(property = DockerCracMojo.CRAC_CHECKPOINT_NETWORK_PROPERTY)
     private String checkpointNetworkName;
+
+    @Parameter(property = DockerCracMojo.CRAC_JAVA_VERSION, defaultValue = DockerCracMojo.DEFAULT_CRAC_JAVA_VERSION)
+    private String cracJavaVersion;
+
+    @Parameter(property = DockerCracMojo.CRAC_ARCHITECTURE)
+    private String cracArchitecture;
 
     @SuppressWarnings("CdiInjectionPointsInspection")
     @Inject
@@ -154,14 +169,31 @@ public class DockerCracMojo extends AbstractDockerMojo {
         buildFinalDockerfile(checkpointImage);
     }
 
+    private String limitArchitecture(String architecture) {
+        if (architecture == null) {
+            return null;
+        }
+        if (ARM_ARCH.equals(architecture)) {
+            return architecture;
+        }
+        return X86_64_ARCH;
+    }
+
     private String buildCheckpointDockerfile() throws IOException, MavenFilteringException {
         String name = mavenProject.getArtifactId() + "-crac-checkpoint";
         Set<String> checkpointTags = Collections.singleton(name);
         copyScripts(CHECKPOINT_SCRIPT_NAME, WARMUP_SCRIPT_NAME, RUN_SCRIPT_NAME);
         File dockerfile = dockerService.loadDockerfileAsResource(DockerfileMojo.DOCKERFILE_CRAC_CHECKPOINT);
+
+        String systemArchitecture = limitArchitecture(System.getProperty("os.arch"));
+        String filteredCracArchitecture = limitArchitecture(cracArchitecture);
+        String finalArchitecture = filteredCracArchitecture == null ? systemArchitecture : filteredCracArchitecture;
+
         BuildImageCmd buildImageCmd = dockerService.buildImageCmd()
                 .withDockerfile(dockerfile)
                 .withBuildArg("BASE_IMAGE", getFromImage().orElse(DEFAULT_BASE_IMAGE))
+                .withBuildArg("CRAC_ARCH", finalArchitecture)
+                .withBuildArg("CRAC_JDK_VERSION", cracJavaVersion)
                 .withTags(checkpointTags);
         dockerService.buildImage(buildImageCmd);
         return name;

--- a/src/main/resources/dockerfiles/DockerfileCracCheckpoint
+++ b/src/main/resources/dockerfiles/DockerfileCracCheckpoint
@@ -1,6 +1,9 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG CRAC_ARCH
+ARG CRAC_JDK_VERSION
+
 WORKDIR /home/app
 
 # Add required libraries
@@ -11,11 +14,24 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install latest CRaC OpenJDK
-RUN release="$(curl -sL https://api.github.com/repos/CRaC/openjdk-builds/releases/latest)" \
-    && asset="$(echo $release | sed -e 's/\r//g' | sed -e 's/\x09//g' | tr '\n' ' ' | jq '.assets[] | select(.name | test("openjdk-[0-9]+-crac\\+[0-9]+_linux-x64\\.tar\\.gz"))')" \
-    && id="$(echo $asset | jq .id)" \
-    && name="$(echo $asset | jq -r .name)" \
-    && curl -LJOH 'Accept: application/octet-stream' "https://api.github.com/repos/CRaC/openjdk-builds/releases/assets/$id" >&2 \
+RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
+RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
+    && if [ "$release_id" ]; then \
+           echo "No CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH found"; \
+           exit 1; \
+       fi \
+    && details=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/$release_id" -H "accept: application/json") \
+    && name=$(echo "$details" | jq -r '.name') \
+    && url=$(echo "$details" | jq -r '.download_url') \
+    && hash=$(echo "$details" | jq -r '.sha256_hash') \
+    && echo "Downloading $name from $url" \
+    && curl -LJOH 'Accept: application/octet-stream' "$url" >&2 \
+    && file_sha=$(sha256sum -b "$name" | cut -d' ' -f 1) \
+    && if [ "$file_sha" != "$hash" ]; then \
+           echo "SHA256 hash mismatch: $file_sha != $hash"; \
+           exit 1; \
+       fi \
+    && echo "SHA256 hash matches: $file_sha == $hash" >&2 \
     && tar xzf "$name" \
     && mv ${name%%.tar.gz} /azul-crac-jdk \
     && rm "$name"

--- a/src/site/asciidoc/examples/package.adoc
+++ b/src/site/asciidoc/examples/package.adoc
@@ -306,7 +306,6 @@ This is by default done by executing the command `curl --output /dev/null --sile
 </properties>
 ----
 
-
 ==== Customizing warmup
 
 The default warmup script simply makes a request to port 8080 of the application.
@@ -322,3 +321,19 @@ for run in {1..10}; do
   curl --output /dev/null --silent http://localhost:8080
 done
 ----
+
+==== Customizing the JDK
+
+By default, the CRaC JDK used to build the image will be for the current system architecture and Java 17.
+These can be overridden by passing properties to the build:
+
+[source,xml]
+.Example checking https
+----
+<properties>
+    <crac.java.version>21</crac.java.version>
+    <crac.arch>amd64</crac.arch>
+</properties>
+----
+
+NOTE: Currently only Java 17, and `amd64` and `aarch64` architectures are supported.


### PR DESCRIPTION
Azul has officially released their CRaC JDK.

This PR switches to find and download the official JDK when building with dockerBuildCrac.

They have also silently released the ARM version of the CRaC enabled JDK.

This PR also adds support for this, using the current system architecture as the default.

New configuration has been added to allow changing from the defaults.