### PR TITLE
Upgrade to Test Resources M10

### DIFF
--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -78,7 +78,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <streamLogs>true</streamLogs>
+                    <streamLogsOnFailures>false</streamLogsOnFailures>
                     <failIfNoProjects>true</failIfNoProjects>
                     <cloneProjectsTo>../target/it</cloneProjectsTo>
                     <pomIncludes>

--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -78,7 +78,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <streamLogsOnFailures>false</streamLogsOnFailures>
+                    <streamLogsOnFailures>true</streamLogsOnFailures>
                     <failIfNoProjects>true</failIfNoProjects>
                     <cloneProjectsTo>../target/it</cloneProjectsTo>
                     <pomIncludes>

--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -19,7 +19,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
-        <it.micronaut.version>4.0.0-M3</it.micronaut.version>
+        <it.micronaut.version>4.0.0-M4</it.micronaut.version>
 
         <!-- Enable recording of coverage during execution of maven-invoker-plugin -->
         <jacoco.propertyName>invoker.mavenOpts</jacoco.propertyName>

--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -19,7 +19,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
-        <it.micronaut.version>4.0.0-M2</it.micronaut.version>
+        <it.micronaut.version>4.0.0-M3</it.micronaut.version>
 
         <!-- Enable recording of coverage during execution of maven-invoker-plugin -->
         <jacoco.propertyName>invoker.mavenOpts</jacoco.propertyName>

--- a/micronaut-maven-integration-tests/src/it/run-aot/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/run-aot/pom.xml
@@ -27,18 +27,14 @@
     <dependencies>
         <dependency>
             <groupId>io.micronaut</groupId>
-            <artifactId>micronaut-inject</artifactId>
+            <artifactId>micronaut-runtime</artifactId>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut.validation</groupId>
-            <artifactId>micronaut-validation</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut</groupId>
-            <artifactId>micronaut-http-client</artifactId>
-            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micronaut</groupId>
+                    <artifactId>micronaut-jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>
@@ -48,11 +44,6 @@
         <dependency>
             <groupId>io.micronaut.picocli</groupId>
             <artifactId>micronaut-picocli</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-dependency/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-dependency/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/micronaut-maven-integration-tests/src/it/test-resources-failing-test/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-failing-test/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/micronaut-maven-integration-tests/src/it/test-resources-shared-namespace/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-shared-namespace/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/micronaut-maven-integration-tests/src/it/test-resources-shared/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-shared/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/micronaut-maven-integration-tests/src/it/test-resources-start-stop/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-start-stop/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/micronaut-maven-integration-tests/src/it/test-resources/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>micronaut-data-jdbc</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/micronaut-maven-plugin/pom.xml
+++ b/micronaut-maven-plugin/pom.xml
@@ -108,7 +108,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,7 +117,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Micronaut AOT -->
+        <!-- Micronaut -->
         <dependency>
             <groupId>io.micronaut.aot</groupId>
             <artifactId>micronaut-aot-std-optimizers</artifactId>

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/DefaultServerFactory.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/DefaultServerFactory.java
@@ -43,19 +43,22 @@ public class DefaultServerFactory implements ServerFactory {
     private final ToolchainManager toolchainManager;
     private final MavenSession mavenSession;
     private final AtomicBoolean serverStarted;
+    private final String testResourcesVersion;
 
     private Process process;
 
-    public DefaultServerFactory(Log log, ToolchainManager toolchainManager, MavenSession mavenSession, AtomicBoolean serverStarted) {
+    public DefaultServerFactory(Log log, ToolchainManager toolchainManager, MavenSession mavenSession,
+                                AtomicBoolean serverStarted, String testResourcesVersion) {
         this.log = log;
         this.toolchainManager = toolchainManager;
         this.mavenSession = mavenSession;
         this.serverStarted = serverStarted;
+        this.testResourcesVersion = testResourcesVersion;
     }
 
     @Override
     public void startServer(ServerUtils.ProcessParameters processParameters) {
-        log.info("Starting Micronaut Test Resources service");
+        log.info("Starting Micronaut Test Resources service, version " + testResourcesVersion);
         String javaBin = findJavaExecutable(toolchainManager, mavenSession);
         List<String> cli = new ArrayList<>();
         cli.add(javaBin);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/DefaultServerFactory.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/DefaultServerFactory.java
@@ -68,11 +68,15 @@ public class DefaultServerFactory implements ServerFactory {
         ProcessBuilder builder = new ProcessBuilder(cli);
         try {
             process = builder.inheritIO().start();
-            if (process.isAlive()) {
-                serverStarted.set(true);
-            }
         } catch (Exception e) {
             serverStarted.set(false);
+            process.destroyForcibly();
+        } finally {
+            if (process.isAlive()) {
+                serverStarted.set(true);
+            } else {
+                process.destroyForcibly();
+            }
         }
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -134,7 +134,7 @@ public class TestResourcesHelper {
         Path buildDir = buildDirectory.toPath();
         Path serverSettingsDirectory = getServerSettingsDirectory();
         AtomicBoolean serverStarted = new AtomicBoolean(false);
-        ServerFactory serverFactory = new DefaultServerFactory(log, toolchainManager, mavenSession, serverStarted);
+        ServerFactory serverFactory = new DefaultServerFactory(log, toolchainManager, mavenSession, serverStarted, testResourcesVersion);
         Optional<ServerSettings> serverSettings = startOrConnectToExistingServer(accessToken, buildDir, serverSettingsDirectory, serverFactory);
         if (serverSettings.isPresent()) {
             setSystemProperties(serverSettings.get());

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
@@ -21,7 +21,6 @@ import io.micronaut.maven.RunMojo;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
@@ -32,7 +31,6 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomWriter;
-import org.eclipse.aether.util.artifact.JavaScopes;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
 
 import javax.inject.Inject;
@@ -45,8 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import static io.micronaut.maven.RunMojo.THIS_PLUGIN;
-import static io.micronaut.maven.services.DependencyResolutionService.TEST_RESOURCES_ARTIFACT_ID_PREFIX;
-import static io.micronaut.maven.services.DependencyResolutionService.TEST_RESOURCES_GROUP;
 import static io.micronaut.maven.testresources.AbstractTestResourcesMojo.CONFIG_PROPERTY_PREFIX;
 import static io.micronaut.maven.testresources.StopTestResourcesServerMojo.MICRONAUT_TEST_RESOURCES_KEEPALIVE;
 
@@ -92,12 +88,6 @@ public class TestResourcesLifecycleExtension extends AbstractMavenLifecycleParti
                         pluginConfiguration.addChild(flag);
                         flag.setValue("true");
                     }
-                    Dependency clientDependency = new Dependency();
-                    clientDependency.setGroupId(TEST_RESOURCES_GROUP);
-                    clientDependency.setArtifactId(TEST_RESOURCES_ARTIFACT_ID_PREFIX + "client");
-                    clientDependency.setVersion(String.valueOf(currentProject.getProperties().get(CONFIG_PROPERTY_PREFIX + "version")));
-                    clientDependency.setScope(JavaScopes.TEST);
-                    currentProject.getDependencies().add(clientDependency);
                 }
             });
         });

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.version>3.9.2</maven.version>
-        <micronaut.version>4.0.0-M3</micronaut.version>
+        <micronaut.version>4.0.0-M4</micronaut.version>
         <native-maven-plugin.version>0.9.22</native-maven-plugin.version>
         <micronaut.aot.version>2.0.0-M3</micronaut.aot.version>
         <micronaut.test.resources.version>2.0.0-M10</micronaut.test.resources.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <micronaut.version>4.0.0-M3</micronaut.version>
         <native-maven-plugin.version>0.9.22</native-maven-plugin.version>
         <micronaut.aot.version>2.0.0-M3</micronaut.aot.version>
-        <micronaut.test.resources.version>2.0.0-M7</micronaut.test.resources.version>
+        <micronaut.test.resources.version>2.0.0-M10</micronaut.test.resources.version>
 
         <maven.resources-plugin.version>3.3.1</maven.resources-plugin.version>
         <maven.archiver-plugin.version>3.6.0</maven.archiver-plugin.version>
@@ -86,6 +86,8 @@
         <site.description>${project.description}</site.description>
         <site.version>${project.version}</site.version>
 
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.outputTimestamp>2023-05-18T10:01:11Z</project.build.outputTimestamp>
 
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -94,6 +96,10 @@
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/micronaut-maven-integration-tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <jacoco.version>0.8.10</jacoco.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
+        <directory-watcher.version>0.18.0</directory-watcher.version>
+        <testcontainers.version>1.18.3</testcontainers.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
+        <jackson.version>2.15.2</jackson.version>
     </properties>
 
     <repositories>
@@ -122,20 +128,45 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Maven -->
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>${maven.version}</version>
             </dependency>
-
-            <!-- Micronaut -->
             <dependency>
-                <groupId>io.micronaut.platform</groupId>
-                <artifactId>micronaut-platform</artifactId>
+                <groupId>io.methvin</groupId>
+                <artifactId>directory-watcher</artifactId>
+                <version>${directory-watcher.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micronaut</groupId>
+                <artifactId>micronaut-inject</artifactId>
                 <version>${micronaut.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR upgrades the Test Resources support to use M10, which no longer supports reading properties from classpath, but instead, will read from system properties or a couple of default file system locations.

It also stops adding the client dependency under the covers (which was a hack), so it needs a counterpart PR in Starter.