### PR TITLE
Update zlib to 1.2.13

### DIFF
--- a/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/src/it/dockerfile-docker-native-static/Dockerfile
@@ -10,7 +10,7 @@ ENV TOOLCHAIN_DIR="/musl"
 ENV PATH="$PATH:${TOOLCHAIN_DIR}/bin"
 ENV CC="${TOOLCHAIN_DIR}/bin/gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.13.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${TOOLCHAIN_DIR} && \
     make && make install && \

--- a/src/it/package-docker-native-static/Dockerfile
+++ b/src/it/package-docker-native-static/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir ${RESULT_LIB} && \
 ENV PATH="$PATH:${RESULT_LIB}/bin"
 ENV CC="musl-gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.13.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${RESULT_LIB} && \
     make && make install && \

--- a/src/main/resources/dockerfiles/DockerfileNativeStatic
+++ b/src/main/resources/dockerfiles/DockerfileNativeStatic
@@ -11,7 +11,7 @@ ENV TOOLCHAIN_DIR="/musl"
 ENV PATH="$PATH:${TOOLCHAIN_DIR}/bin"
 ENV CC="${TOOLCHAIN_DIR}/bin/gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.12.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.13.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${TOOLCHAIN_DIR} && \
     make && make install && \


### PR DESCRIPTION
It looks like there was a new release of zlib and they delete old versions when new ones come out. 😔

This PR updates to 1.2.13 (the latest) as otherwise the cURL command pulls a 404 error page and tar fails to gunzip it