### PR TITLE
Upgrade Zlib to 1.3

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
@@ -9,7 +9,7 @@ ENV TOOLCHAIN_DIR="/musl"
 ENV PATH="$PATH:${TOOLCHAIN_DIR}/bin"
 ENV CC="${TOOLCHAIN_DIR}/bin/gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.13.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/current/zlib-1.3.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${TOOLCHAIN_DIR} && \
     make && make install && \

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-static/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir ${RESULT_LIB} && \
 ENV PATH="$PATH:${RESULT_LIB}/bin"
 ENV CC="musl-gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.13.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/current/zlib-1.3.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${RESULT_LIB} && \
     make && make install && \

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeStatic
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeStatic
@@ -10,7 +10,7 @@ ENV TOOLCHAIN_DIR="/musl"
 ENV PATH="$PATH:${TOOLCHAIN_DIR}/bin"
 ENV CC="${TOOLCHAIN_DIR}/bin/gcc"
 
-RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.13.tar.gz && \
+RUN curl -L -o zlib.tar.gz https://zlib.net/current/zlib-1.3.tar.gz && \
     mkdir zlib && tar -xzf zlib.tar.gz -C zlib --strip-components 1 && cd zlib && \
     ./configure --static --prefix=${TOOLCHAIN_DIR} && \
     make && make install && \


### PR DESCRIPTION
Zlib removed the 1.2.13 distribution when they released 1.3 on 18 August 2023.

Although 1.2.13 [appears to be available from GitHub](https://github.com/madler/zlib/releases/tag/v1.2.13), this PR attempts to upgrade to 1.3