### PR TITLE
Fix CRaC JDK download in docker container

### DIFF
--- a/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
+++ b/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install latest CRaC OpenJDK
 RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
-RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
+RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
     && if [ "$release_id" = "null" ]; then \
            echo "No CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH found"; \
            exit 1; \

--- a/src/main/resources/dockerfiles/DockerfileCracCheckpoint
+++ b/src/main/resources/dockerfiles/DockerfileCracCheckpoint
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install latest CRaC OpenJDK
 RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
-RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
+RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
     && if [ "$release_id" = "null" ]; then \
            echo "No CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH found"; \
            exit 1; \


### PR DESCRIPTION
Azul added a JRE to their CRaC java deliverables.

The query wasn't specific enough to say we want a JDK, so we end up pulling the JRE if it comes back first in the response.

This change adds java_package_type=jdk to the request URL so we just get the JDK.

#### Done on the 3.5.x branch for Micronaut 3.x