### PR TITLE
Merge 3.5.x into 4.0.x

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install latest CRaC OpenJDK
 RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
-RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
+RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
     && if [ "$release_id" = "null" ]; then \
            echo "No CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH found"; \
            exit 1; \

--- a/micronaut-maven-integration-tests/src/it/package-docker-crac/selector.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-crac/selector.groovy
@@ -1,6 +1,0 @@
-return isX86()
-
-static boolean isX86() {
-    String osArch = System.getProperty("os.arch")
-    return osArch in ['amd64', 'x86_64']
-}

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-static/selector.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-static/selector.groovy
@@ -1,6 +1,0 @@
-return isX86()
-
-static boolean isX86() {
-    String osArch = System.getProperty("os.arch")
-    return osArch in ['amd64', 'x86_64']
-}

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install latest CRaC OpenJDK
 RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
-RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
+RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&arch=${CRAC_ARCH}&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
     && if [ "$release_id" = "null" ]; then \
            echo "No CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH found"; \
            exit 1; \


### PR DESCRIPTION
Fixes CRaC for Micronaut 4.1.x when we release and update to 4.0.7 of this plugin

I missed there was a 4.0.x branch when I raised this fix for 3.5.x and merged up into master 😞