### PR TITLE
Fix test resources service not being shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ To debug the plugin, you first need to publish a snapshot to your Maven local:
 $ mvn install
 ```
 
+You can skip execution of integration tests by adding `-Dinvoker.skip=true` to the command line.
+
 Then you need a sample application. The one at `examples/java` is the most up-to-date, but you can in principle generate
 a new one from Micronaut Starter. Then, change its `pom.xml` to set the following property:
 


### PR DESCRIPTION
This commit fixes the fact that the test resources service could be kept alive even when invoking `mn:stop-testresources-service`. This was caused by the presence of a stale keepalive file. The scenario to trigger this was:

1. execute `mvn mn:start-testresources-service`
2. execute `mvn run`
3. when the Micronaut server is running, interrupt with CTRL+C
4. execute `mvn mn:stop-testresources-service`

In that case the server was kept alive because the keepalive file was not deleted.