### PR TITLE
Fix test resources service keepalive

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -189,10 +189,10 @@ public class RunMojo extends AbstractTestResourcesMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        testResourcesHelper = new TestResourcesHelper(testResourcesEnabled, keepAlive, shared, buildDirectory,
+        testResourcesHelper = new TestResourcesHelper(testResourcesEnabled, shared, buildDirectory,
                                                       explicitPort, clientTimeout, runnableProject, mavenSession,
                                                       dependencyResolutionService, toolchainManager, testResourcesVersion,
-                                                      classpathInference, testResourcesDependencies, sharedServerNamespace);
+                                                      classpathInference, testResourcesDependencies, sharedServerNamespace, debugServer);
         resolveDependencies();
         this.sourceDirectories = compilerService.resolveSourceDirectories();
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/DefaultServerFactory.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/DefaultServerFactory.java
@@ -44,16 +44,22 @@ public class DefaultServerFactory implements ServerFactory {
     private final MavenSession mavenSession;
     private final AtomicBoolean serverStarted;
     private final String testResourcesVersion;
+    private final boolean debugServer;
 
     private Process process;
 
-    public DefaultServerFactory(Log log, ToolchainManager toolchainManager, MavenSession mavenSession,
-                                AtomicBoolean serverStarted, String testResourcesVersion) {
+    public DefaultServerFactory(Log log,
+                                ToolchainManager toolchainManager,
+                                MavenSession mavenSession,
+                                AtomicBoolean serverStarted,
+                                String testResourcesVersion,
+                                boolean debugServer) {
         this.log = log;
         this.toolchainManager = toolchainManager;
         this.mavenSession = mavenSession;
         this.serverStarted = serverStarted;
         this.testResourcesVersion = testResourcesVersion;
+        this.debugServer = debugServer;
     }
 
     @Override
@@ -63,6 +69,9 @@ public class DefaultServerFactory implements ServerFactory {
         List<String> cli = new ArrayList<>();
         cli.add(javaBin);
         cli.addAll(processParameters.getJvmArguments());
+        if (debugServer) {
+            cli.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000");
+        }
         processParameters.getSystemProperties().forEach((key, value) -> cli.add("-D" + key + "=" + value));
         cli.add("-cp");
         cli.add(processParameters.getClasspath().stream().map(File::getAbsolutePath).collect(Collectors.joining(File.pathSeparator)));

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
@@ -54,10 +54,12 @@ public class StartTestResourcesServerMojo extends AbstractTestResourcesMojo {
 
     @Override
     public final void execute() throws MojoExecutionException {
-        TestResourcesHelper helper = new TestResourcesHelper(testResourcesEnabled, keepAlive, shared, buildDirectory,
-                explicitPort, clientTimeout, mavenProject, mavenSession,
-                dependencyResolutionService, toolchainManager, testResourcesVersion,
-                classpathInference, testResourcesDependencies, sharedServerNamespace);
+        TestResourcesHelper helper = new TestResourcesHelper(
+            testResourcesEnabled, shared, buildDirectory,
+            explicitPort, clientTimeout, mavenProject, mavenSession,
+            dependencyResolutionService, toolchainManager, testResourcesVersion,
+            classpathInference, testResourcesDependencies, sharedServerNamespace,
+            debugServer);
         helper.start();
 
     }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StopTestResourcesServerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StopTestResourcesServerMojo.java
@@ -53,10 +53,11 @@ public class StopTestResourcesServerMojo extends AbstractTestResourcesMojo {
 
     @Override
     public final void execute() throws MojoExecutionException {
-        TestResourcesHelper helper = new TestResourcesHelper(testResourcesEnabled, keepAlive, shared, buildDirectory,
+        TestResourcesHelper helper = new TestResourcesHelper(testResourcesEnabled, shared, buildDirectory,
                 explicitPort, clientTimeout, mavenProject, mavenSession,
                 dependencyResolutionService, toolchainManager, testResourcesVersion,
-                classpathInference, testResourcesDependencies, sharedServerNamespace);
+                classpathInference, testResourcesDependencies, sharedServerNamespace,
+                debugServer);
         helper.stop();
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesConfiguration.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesConfiguration.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import static io.micronaut.maven.testresources.StopTestResourcesServerMojo.MICRONAUT_TEST_RESOURCES_KEEPALIVE;
-
 /**
  * Base configuration class for Test Resources.
  *
@@ -52,12 +50,6 @@ public class TestResourcesConfiguration {
     protected boolean shared;
 
     /**
-     * Whether the test resources service should be kept alive after the build.
-     */
-    @Parameter(property = MICRONAUT_TEST_RESOURCES_KEEPALIVE, defaultValue = DISABLED)
-    protected boolean keepAlive;
-
-    /**
      * Allows configuring a namespace for the shared test resources server. This can be used in case it makes sense to
      * have different instances of shared services, for example when independent builds sets share different services.
      *
@@ -65,6 +57,15 @@ public class TestResourcesConfiguration {
      */
     @Parameter(property = CONFIG_PROPERTY_PREFIX + "namespace")
     protected String sharedServerNamespace;
+
+    /**
+     * Allows starting the test resources server in debug mode. The server will be started with the ability
+     * to attach a remote debugger on port 8000.
+     *
+     * @since 4.1.1
+     */
+    @Parameter(property = CONFIG_PROPERTY_PREFIX + "debug-server", defaultValue = DISABLED)
+    protected boolean debugServer;
 
     /**
      * @return Whether to enable or disable Micronaut test resources support.
@@ -78,13 +79,6 @@ public class TestResourcesConfiguration {
      */
     public boolean isShared() {
         return shared;
-    }
-
-    /**
-     * @return Whether the test resources service should be kept alive after the build.
-     */
-    public boolean isKeepAlive() {
-        return keepAlive;
     }
 
     /**

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
@@ -102,11 +102,10 @@ public class TestResourcesLifecycleExtension extends AbstractMavenLifecycleParti
                     ExpressionEvaluator evaluator = perProjectEvaluator.computeIfAbsent(currentProject, p -> initEvaluator(p, session));
                     TestResourcesConfiguration configuration = perProjectConfiguration.computeIfAbsent(currentProject, mavenProject -> initConfiguration(plugin));
                     boolean enabled = isEnabled(evaluator, configuration);
-                    boolean keepAlive = isKeepAlive(evaluator, configuration);
                     boolean shared = isShared(evaluator, configuration);
                     File buildDirectory = new File(build.getDirectory());
 
-                    TestResourcesHelper helper = new TestResourcesHelper(enabled, keepAlive, shared, buildDirectory);
+                    TestResourcesHelper helper = new TestResourcesHelper(session, enabled, shared, buildDirectory);
                     if (shared) {
                         String sharedServerNamespace = findSharedServerNamespace(evaluator, configuration);
                         helper.setSharedServerNamespace(sharedServerNamespace);
@@ -141,16 +140,6 @@ public class TestResourcesLifecycleExtension extends AbstractMavenLifecycleParti
             return result;
         } else if (configuration != null) {
             return configuration.isShared();
-        }
-        return false;
-    }
-
-    private boolean isKeepAlive(ExpressionEvaluator evaluator, TestResourcesConfiguration configuration) {
-        Boolean result = evaluateBooleanProperty(evaluator, MICRONAUT_TEST_RESOURCES_KEEPALIVE);
-        if (result != null) {
-            return result;
-        } else if (configuration != null) {
-            return configuration.isKeepAlive();
         }
         return false;
     }


### PR DESCRIPTION
This commit fixes the logic for shutting down the test resources service. Before, the "keepAlive" flag was exposed to the user. If it was set to true, then invoking `stop-testresources-service` would always keep the service alive. Now, the flag is purely internal and used to keep track of whether the service was _already_ alive before starting the build or not.

The keepalive file is now kept under the temporary directory: this prevents the file from being accidentally deleted by another process, or even conflicts with different namespaces for shared services.

If the service was alive before running the build, it will be kept alive unless `stop-testresources-service` is called. If it wasn't alive, then it will be shutdown at the end of the build.

The logic is now similar to what the Gradle plugin is doing.

In addition, this commit adds support for the `debug-server` property which allows running the test resources service in debug mode.

The fix will only be complete once https://github.com/micronaut-projects/micronaut-test-resources/pull/464 is merged.