### PR TITLE
Fix file watching

### DIFF
--- a/micronaut-maven-plugin/pom.xml
+++ b/micronaut-maven-plugin/pom.xml
@@ -116,6 +116,12 @@
             <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Micronaut -->
         <dependency>

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -51,7 +51,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -84,6 +83,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
     public static final String RESOURCES_DIR = "src/main/resources";
     public static final String THIS_PLUGIN = "io.micronaut.maven:micronaut-maven-plugin";
 
+    private static final List<String> RELEVANT_SRC_DIRS = List.of("resources", "java", "kotlin", "groovy");
     private static final int LAST_COMPILATION_THRESHOLD = 500;
     private static final List<String> DEFAULT_EXCLUDES;
 
@@ -138,7 +138,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
     private String debugHost;
 
     /**
-     * List of inclusion/exclusion paths that should not trigger an application restart. 
+     * List of inclusion/exclusion paths that should not trigger an application restart.
      * For example, you can exclude a particular directory from being watched by adding the following
      * configuration:
      * <pre>
@@ -199,7 +199,6 @@ public class RunMojo extends AbstractTestResourcesMojo {
     private String classpath;
     private int classpathHash;
     private long lastCompilation;
-    private List<Path> sourceDirectories;
     private TestResourcesHelper testResourcesHelper;
 
     @SuppressWarnings("CdiInjectionPointsInspection")
@@ -239,8 +238,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
             testResourcesDependencies,
             sharedServerNamespace,
             debugServer);
-        resolveDependencies();
-        this.sourceDirectories = compilerService.resolveSourceDirectories();
+        initialize();
 
         try {
             maybeStartTestResourcesServer();
@@ -250,42 +248,36 @@ public class RunMojo extends AbstractTestResourcesMojo {
 
             if (process != null && process.isAlive()) {
                 if (watchForChanges) {
-                    List<Path> pathsToWatch = new ArrayList<>(sourceDirectories);
-                    for (MavenProject project : mavenSession.getProjects()) {
-                        Path baseDir = project.getBasedir().toPath();
-                        pathsToWatch.add(baseDir);
-                        if (Files.exists(baseDir.resolve(RESOURCES_DIR))) {
-                            pathsToWatch.add(baseDir.resolve(RESOURCES_DIR));
-                        }
-                    }
-                    if (watches != null && !watches.isEmpty()) {
-                        for (FileSet fs : watches) {
-                            File directory = new File(fs.getDirectory()).getAbsoluteFile();
-                            if (directory.exists()) {
-                                pathsToWatch.add(directory.toPath());
-                                //If neither includes nor excludes, add a default include
-                                if ((fs.getIncludes() == null || fs.getIncludes().isEmpty()) && (fs.getExcludes() == null || fs.getExcludes().isEmpty())) {
-                                    fs.addInclude("**/*");
-                                }
-                            } else {
-                                if (getLog().isWarnEnabled()) {
-                                    getLog().warn("The specified directory to watch doesn't exist: " + directory.getPath());
-                                }
-                            }
+                    List<Path> pathsToWatch = new ArrayList<>();
+                    for (FileSet fs : watches) {
+                        var directory = runnableProject.getBasedir().toPath().resolve(fs.getDirectory()).toAbsolutePath();
+                        pathsToWatch.add(directory);
+                        //If neither includes nor excludes, add a default include
+                        if ((fs.getIncludes() == null || fs.getIncludes().isEmpty()) && (fs.getExcludes() == null || fs.getExcludes().isEmpty())) {
+                            fs.addInclude("**/*");
                         }
                     }
 
                     this.directoryWatcher = DirectoryWatcher
-                            .builder()
-                            .paths(pathsToWatch)
-                            .listener(this::handleEvent)
-                            .build();
+                        .builder()
+                        .paths(pathsToWatch)
+                        .listener(this::handleEvent)
+                        .build();
 
-                    Path projectRootDirectory = mavenSession.getTopLevelProject().getBasedir().toPath();
+                    // We use the working directory as the root path, because
+                    // the top-level project information may not be what we
+                    // expect, in particular if we run from a submodule, or
+                    // that we run from root but with the "-pl" option.
+                    // We can safely do this because it's only used to display
+                    // information about paths being watched to the user, the
+                    // actual paths are unchanged.
+                    Path root = Path.of(".").toAbsolutePath();
                     List<Path> pathList = pathsToWatch.stream()
-                            .map(other -> projectRootDirectory.getParent().relativize(other))
-                            .sorted()
-                            .toList();
+                        .map(root::relativize)
+                        .filter(s -> !s.toString().isEmpty())
+                        .filter(Files::exists)
+                        .sorted()
+                        .toList();
                     getLog().info("👀 Watching for changes in " + pathList);
                     this.directoryWatcher.watch();
                 } else if (process != null && process.isAlive()) {
@@ -305,15 +297,44 @@ public class RunMojo extends AbstractTestResourcesMojo {
         }
     }
 
-    private void handleEvent(DirectoryChangeEvent event) {
+    protected final void initialize() {
+        resolveDependencies();
+        if (watches == null) {
+            watches = new ArrayList<>();
+        }
+        // watch pom.xml file changes
+        mavenSession.getAllProjects()
+            .stream()
+            .map(MavenProject::getBasedir)
+            .map(File::toPath)
+            .forEach(path -> {
+                var fileSet = new FileSet();
+                fileSet.setDirectory(path.toString());
+                fileSet.addInclude("pom.xml");
+                watches.add(fileSet);
+            });
+        // Add the default watch paths
+        mavenSession.getAllProjects()
+            .stream()
+            .flatMap(p -> {
+                var basedir = p.getBasedir().toPath();
+                return RELEVANT_SRC_DIRS.stream().map(dir -> basedir.resolve("src/main/" + dir));
+            })
+            .forEach(path -> {
+                var fileSet = new FileSet();
+                fileSet.setDirectory(path.toString());
+                fileSet.addInclude("**/*");
+                watches.add(fileSet);
+            });
+    }
+
+    protected final void setWatches(List<FileSet> watches) {
+        this.watches = watches;
+    }
+
+    final void handleEvent(DirectoryChangeEvent event) {
         Path path = event.path();
         Path parent = path.getParent();
-
-        List<Path> projectRoots = mavenSession.getProjects().stream()
-                .map(MavenProject::getBasedir)
-                .map(File::toPath)
-                .toList();
-
         Path projectRootDirectory = mavenSession.getTopLevelProject().getBasedir().toPath();
 
         if (matches(path)) {
@@ -337,71 +358,50 @@ public class RunMojo extends AbstractTestResourcesMojo {
             return false;
         }
 
-        // Start by checking whether it's a change in any source directory
-        Collection<Path> values = this.sourceDirectories;
-        Collection<Path> pathsToCheck = new ArrayList<>(values.size() + 1);
-        pathsToCheck.addAll(values);
-        for (MavenProject project : mavenSession.getProjects()) {
-            Path baseDir = project.getBasedir().toPath();
-            pathsToCheck.add(baseDir);
-            if (Files.exists(baseDir.resolve(RESOURCES_DIR))) {
-                pathsToCheck.add(baseDir.resolve(RESOURCES_DIR));
-            }
-        }
-        boolean matches = pathsToCheck.stream().anyMatch(path.getParent()::startsWith);
         Path projectRootDirectory = mavenSession.getTopLevelProject().getBasedir().toPath();
 
         String relativePath = projectRootDirectory.relativize(path).toString();
 
-        if (getLog().isDebugEnabled()) {
-            String belongs = matches ? "belongs" : "does not belong";
-            getLog().debug("Path [" + relativePath + "] " + belongs + " to a source directory");
-        }
-
-        if (watches != null && !watches.isEmpty()) {
-            // Then process includes
-            if (!matches) {
-                for (FileSet fileSet : watches) {
-                    if (fileSet.getIncludes() != null && !fileSet.getIncludes().isEmpty()) {
-                        File directory = new File(fileSet.getDirectory());
-                        if (directory.exists() && path.getParent().startsWith(directory.getAbsolutePath())) {
-                            for (String includePattern : fileSet.getIncludes()) {
-                                if (AbstractScanner.match(includePattern, path.toString()) || new File(directory, includePattern).toPath().toAbsolutePath().equals(path)) {
-                                    matches = true;
-                                    if (getLog().isDebugEnabled()) {
-                                        getLog().debug("Path [" + relativePath + "] matched the include pattern [" + includePattern + "] of the directory [" + fileSet.getDirectory() + "]");
-                                    }
-                                    break;
-                                }
+        boolean matches = false;
+        for (FileSet fileSet : watches) {
+            if (fileSet.getIncludes() != null && !fileSet.getIncludes().isEmpty()) {
+                File directory = new File(fileSet.getDirectory());
+                if (directory.exists() && path.getParent().startsWith(directory.getAbsolutePath())) {
+                    for (String includePattern : fileSet.getIncludes()) {
+                        if (AbstractScanner.match(includePattern, path.toString()) || new File(directory, includePattern).toPath().toAbsolutePath().equals(path)) {
+                            matches = true;
+                            if (getLog().isDebugEnabled()) {
+                                getLog().debug("Path [" + relativePath + "] matched the include pattern [" + includePattern + "] of the directory [" + fileSet.getDirectory() + "]");
                             }
+                            break;
                         }
-                    }
-                    if (matches) {
-                        break;
                     }
                 }
             }
-
-            // Finally, process excludes only if the path is matching
             if (matches) {
-                for (FileSet fileSet : watches) {
-                    if (fileSet.getExcludes() != null && !fileSet.getExcludes().isEmpty()) {
-                        File directory = new File(fileSet.getDirectory());
-                        if (directory.exists() && path.getParent().startsWith(directory.getAbsolutePath())) {
-                            for (String excludePattern : fileSet.getExcludes()) {
-                                if (AbstractScanner.match(excludePattern, path.toString()) || new File(directory, excludePattern).toPath().toAbsolutePath().equals(path)) {
-                                    matches = false;
-                                    if (getLog().isDebugEnabled()) {
-                                        getLog().debug("Path [" + relativePath + "] matched the exclude pattern [" + excludePattern + "] of the directory [" + fileSet.getDirectory() + "]");
-                                    }
-                                    break;
+                break;
+            }
+        }
+
+        // Finally, process excludes only if the path is matching
+        if (matches) {
+            for (FileSet fileSet : watches) {
+                if (fileSet.getExcludes() != null && !fileSet.getExcludes().isEmpty()) {
+                    File directory = new File(fileSet.getDirectory());
+                    if (directory.exists() && path.getParent().startsWith(directory.getAbsolutePath())) {
+                        for (String excludePattern : fileSet.getExcludes()) {
+                            if (AbstractScanner.match(excludePattern, path.toString()) || new File(directory, excludePattern).toPath().toAbsolutePath().equals(path)) {
+                                matches = false;
+                                if (getLog().isDebugEnabled()) {
+                                    getLog().debug("Path [" + relativePath + "] matched the exclude pattern [" + excludePattern + "] of the directory [" + fileSet.getDirectory() + "]");
                                 }
+                                break;
                             }
                         }
                     }
-                    if (!matches) {
-                        break;
-                    }
+                }
+                if (!matches) {
+                    break;
                 }
             }
         }
@@ -419,8 +419,8 @@ public class RunMojo extends AbstractTestResourcesMojo {
             }
         }
         return (excludeTargetDirectory && path.startsWith(targetDirectory.getAbsolutePath())) ||
-                DEFAULT_EXCLUDES.stream()
-                        .anyMatch(excludePattern -> AbstractScanner.match(excludePattern, path.toString()));
+               DEFAULT_EXCLUDES.stream()
+                   .anyMatch(excludePattern -> AbstractScanner.match(excludePattern, path.toString()));
     }
 
     private boolean hasBeenCompiledRecently() {
@@ -480,7 +480,13 @@ public class RunMojo extends AbstractTestResourcesMojo {
 
     }
 
-    private void runApplication() throws Exception {
+    /**
+     * Runs or restarts the application. Only visible for testing, shouldn't
+     * be called directly.
+     *
+     * @throws Exception if something goes wrong while starting the application
+     */
+    protected void runApplication() throws Exception {
         if (restartLock.getQueueLength() >= 1) {
             // if there's more than one restart request, we'll handle them all at once
             return;

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/FileWatchingTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/FileWatchingTest.java
@@ -1,0 +1,313 @@
+package io.micronaut.maven;
+
+import io.methvin.watcher.DirectoryChangeEvent;
+import io.methvin.watcher.hashing.FileHash;
+import io.micronaut.maven.services.CompilerService;
+import io.micronaut.maven.services.DependencyResolutionService;
+import io.micronaut.maven.services.ExecutorService;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.FileSet;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FileWatchingTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    @DisplayName("should detect changes in a single module project")
+    void testFileWatchesSingleProject() throws IOException {
+        // given:
+        var mojo = createMojoForSingleProject();
+        var javaSources = tempDir.resolve("src/main/java");
+        var javaResources = tempDir.resolve("src/main/resources");
+
+        // when:
+        mojo.withChange(createFile(javaSources.resolve("Dummy.java"), "public class Dummy {}"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(updateFile(javaSources.resolve("Dummy.java"), "public class Dummy { public static void main(String[] args) {} }"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(createFile(javaSources.resolve("file.back~"), "excludes some files by default"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        mojo.withChange(createFile(tempDir.resolve(".ignored/file"), "should not trigger recompilation"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        mojo.withChange(createFile(tempDir.resolve("pom.xml"), "should detect changes to pom.xml"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(createFile(javaResources.resolve("application.yml"), "should detect changes to application configuration"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(createFile(javaResources.resolve("META-INF/version.txt"), "detects changes to resources directory"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.addWatch(new FileSet() {{
+            setDirectory(javaResources.resolve("META-INF").toString());
+            setExcludes(List.of("**/*"));
+        }});
+        mojo.withChange(createFile(javaResources.resolve("META-INF/version.txt"), "changes to META-INF are now explicitly ignored"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        List.of("groovy", "kotlin").forEach(lang -> {
+            mojo.withChange(createFile(tempDir.resolve("src/main/" + lang + "/Dummy." + lang), "public class Dummy { public static void main(String[] args) {} }"));
+            // then:
+            mojo.assertRecompiled();
+        });
+
+        // when:
+        mojo.withChange(createFile(tempDir.resolve("src/main/scala/Dummy.java"), "I'm not a supported language"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        mojo.withChange(createFile(tempDir.resolve("unrelated.file"), "I'm not a source file"));
+        // then:
+        mojo.assertNotRecompiled();
+    }
+
+    @Test
+    @DisplayName("should detect changes in a multi-module project")
+    void testFileWatchesMultiProject() throws IOException {
+        // given:
+        var mojo = createMojoForMultiProject(2, 0);
+        var module0 = tempDir.resolve("module0");
+        var module1 = tempDir.resolve("module1");
+        var javaSources = module0.resolve("src/main/java");
+        var javaResources = module0.resolve("src/main/resources");
+
+        // when:
+        mojo.withChange(createFile(javaSources.resolve("Dummy.java"), "public class Dummy {}"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(updateFile(javaSources.resolve("Dummy.java"), "public class Dummy { public static void main(String[] args) {} }"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(createFile(javaSources.resolve("file.back~"), "excludes some files by default"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        mojo.withChange(createFile(module0.resolve(".ignored/file"), "should not trigger recompilation"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        mojo.withChange(createFile(module0.resolve("pom.xml"), "should detect changes to pom.xml"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(createFile(javaResources.resolve("application.yml"), "should detect changes to application configuration"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(createFile(javaResources.resolve("META-INF/version.txt"), "detects changes to resources directory"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.addWatch(new FileSet() {{
+            setDirectory(javaResources.resolve("META-INF").toString());
+            setExcludes(List.of("**/*"));
+        }});
+        mojo.withChange(createFile(javaResources.resolve("META-INF/version.txt"), "changes to META-INF are now explicitly ignored"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        List.of("groovy", "kotlin").forEach(lang -> {
+            mojo.withChange(createFile(module0.resolve("src/main/" + lang + "/Dummy." + lang), "public class Dummy { public static void main(String[] args) {} }"));
+            // then:
+            mojo.assertRecompiled();
+        });
+
+        // when:
+        mojo.withChange(createFile(module0.resolve("src/main/scala/Dummy.java"), "I'm not a supported language"));
+        // then:
+        mojo.assertNotRecompiled();
+
+        // when:
+        mojo.withChange(createFile(module1.resolve("src/main/java/Dummy.java"), "Detects change in another module"));
+        // then:
+        mojo.assertRecompiled();
+
+        // when:
+        mojo.withChange(createFile(module1.resolve(".toto/ignored"), "Ignores change in another module"));
+        // then:
+        mojo.assertNotRecompiled();
+
+    }
+
+    private MojoUnderTest createMojoForSingleProject() {
+        var project = newProject(tempDir);
+        var compilerService = createCompilerServices();
+        when(compilerService.findRunnableProject()).thenReturn(project);
+        var mavenSession = mock(MavenSession.class);
+        when(mavenSession.getTopLevelProject()).thenReturn(project);
+        when(mavenSession.getProjects()).thenReturn(List.of(project));
+        when(mavenSession.getAllProjects()).thenReturn(List.of(project));
+        return createMojoUnderTest(mavenSession, compilerService);
+    }
+
+    @NotNull
+    private static CompilerService createCompilerServices() {
+        var compilerService = mock(CompilerService.class);
+        when(compilerService.compileProject()).thenReturn(Optional.of(123L));
+        return compilerService;
+    }
+
+    @NotNull
+    private MavenProject newProject(Path baseDir) {
+        var build = mock(Build.class);
+        when(build.getDirectory()).thenReturn("target");
+        var project = mock(MavenProject.class);
+        when(project.getBuild()).thenReturn(build);
+        when(project.getBasedir()).thenReturn(baseDir.toFile());
+        return project;
+    }
+
+    private MojoUnderTest createMojoForMultiProject(int moduleCount, int consideredProject) {
+        var rootProject = newProject(tempDir);
+        var mavenSession = mock(MavenSession.class);
+        when(mavenSession.getTopLevelProject()).thenReturn(rootProject);
+        var modules = IntStream.range(0, moduleCount)
+            .mapToObj(i -> "module" + i)
+            .map(tempDir::resolve)
+            .map(this::newProject)
+            .toList();
+        var compilerService = createCompilerServices();
+        when(compilerService.findRunnableProject()).thenReturn(modules.get(consideredProject));
+        when(mavenSession.getProjects()).thenReturn(modules);
+        when(mavenSession.getAllProjects()).thenReturn(
+            Stream.concat(Stream.of(rootProject), modules.stream()).toList()
+        );
+        return createMojoUnderTest(mavenSession, compilerService);
+    }
+
+    private static MojoUnderTest createMojoUnderTest(MavenSession mavenSession, CompilerService compilerService) {
+        var recompilationCount = new AtomicInteger();
+        var mojo = new RunMojo(
+            mavenSession,
+            mock(BuildPluginManager.class),
+            mock(ProjectBuilder.class),
+            mock(ToolchainManager.class),
+            compilerService,
+            mock(ExecutorService.class),
+            mock(DependencyResolutionService.class)
+        ) {
+            @Override
+            protected void runApplication() throws Exception {
+                recompilationCount.incrementAndGet();
+            }
+        };
+        var watches = new ArrayList<FileSet>();
+        mojo.setWatches(watches);
+        mojo.initialize();
+        return new MojoUnderTest(mojo, recompilationCount, watches);
+    }
+
+    private static DirectoryChangeEvent createFile(Path file, String content) {
+        try {
+            Files.createDirectories(file.getParent());
+            Files.writeString(file, content);
+            return new DirectoryChangeEvent(
+                DirectoryChangeEvent.EventType.CREATE,
+                true,
+                file,
+                mock(FileHash.class),
+                0,
+                null
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static DirectoryChangeEvent updateFile(Path file, String content) throws IOException {
+        Files.writeString(file, content);
+        return new DirectoryChangeEvent(
+            DirectoryChangeEvent.EventType.MODIFY,
+            true,
+            file,
+            mock(FileHash.class),
+            0,
+            null
+        );
+    }
+
+    private static class MojoUnderTest {
+        private final RunMojo mojo;
+        private final AtomicInteger recompilationCount;
+        private final List<FileSet> watches;
+        private int lastRecompilationCount;
+
+        private MojoUnderTest(RunMojo mojo, AtomicInteger recompilationCount, List<FileSet> watches) {
+            this.mojo = mojo;
+            this.recompilationCount = recompilationCount;
+            this.watches = watches;
+        }
+
+        public void withChange(DirectoryChangeEvent event) {
+            mojo.handleEvent(event);
+        }
+
+        public void addWatch(FileSet watch) {
+            watches.add(watch);
+        }
+
+        public void assertRecompiled() {
+            assertEquals(lastRecompilationCount + 1, recompilationCount.get());
+            lastRecompilationCount = recompilationCount.get();
+        }
+
+        public void assertNotRecompiled() {
+            assertEquals(lastRecompilationCount, recompilationCount.get());
+        }
+    }
+}


### PR DESCRIPTION
This commit reworks the file watching strategy, in order to make it easier to understand and to fix some bugs. In particular, the previous logic was broken in the context of multiproject builds, depending on whether the build was started from the root project, or from a submodule. It was for example possible that the whole project directory was watched, and not just the default sources and resources directories.

With this change, we removed the separate logic which existed for whether the user had defined watches or not, to replace it with a unified version. Tests were added to make sure that it's possible to watch changes in both single projects and multi-projects.