### PR TITLE
Update CCUD Maven extension to 1.13

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -9,6 +9,6 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>1.12.5</version>
+        <version>1.13</version>
     </extension>
 </extensions>


### PR DESCRIPTION
Updating the common custom user data maven extension to 1.13, which adds the `CI provider` custom value. 

The update is needed manually, as renovate doesn't support managing maven extensions (yet). See issue https://github.com/renovatebot/renovate/issues/24328.