### PR TITLE
feat: simplify importing beans from project dependencies

### DIFF
--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -ntp compile

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>import-factory-disabled</artifactId>
+  <version>0.1</version>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.platform</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>@it.micronaut.version@</version>
+  </parent>
+
+  <properties>
+    <packaging>jar</packaging>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+    <micronaut.runtime>netty</micronaut.runtime>
+    <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
+    <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <version>${micronaut-maven-plugin.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=import-factory-disabled</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: importFactoryDisabled

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/test/java/io/micronaut/build/examples/ImportFactoryDisabledTest.java
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/src/test/java/io/micronaut/build/examples/ImportFactoryDisabledTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class ImportFactoryDisabledTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/verify.groovy
@@ -1,0 +1,6 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD SUCCESS")
+assert log.text.contains("generate-import-factory")
+assert !log.text.contains("matching dependencies")
+assert !log.text.contains("matching packages")

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -ntp compile

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>import-factory-enabled</artifactId>
+  <version>0.1</version>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.platform</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>@it.micronaut.version@</version>
+  </parent>
+
+  <properties>
+    <packaging>jar</packaging>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+    <micronaut.runtime>netty</micronaut.runtime>
+    <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
+    <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+    <micronaut.importfactory.enabled>true</micronaut.importfactory.enabled>
+    <micronaut.importfactory.includeDependenciesFilter>io.micronaut:micronaut-c.*</micronaut.importfactory.includeDependenciesFilter>
+    <micronaut.importfactory.excludeDependenciesFilter>io.micronaut:micronaut-context.*</micronaut.importfactory.excludeDependenciesFilter>
+    <micronaut.importfactory.includePackagesFilter>io.micronaut.core.convert.*</micronaut.importfactory.includePackagesFilter>
+    <micronaut.importfactory.excludePackagesFilter>io.micronaut.core.convert.exceptions</micronaut.importfactory.excludePackagesFilter>
+    <micronaut.importfactory.targetPackage>io.micronaut.build.examples</micronaut.importfactory.targetPackage>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <version>${micronaut-maven-plugin.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=import-factory-enabled</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: importFactoryEnabled

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/test/java/io/micronaut/build/examples/ImportFactoryEnabledTest.java
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/src/test/java/io/micronaut/build/examples/ImportFactoryEnabledTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class ImportFactoryEnabledTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/verify.groovy
@@ -1,0 +1,12 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD SUCCESS")
+assert log.text.contains("generate-import-factory")
+assert log.text.contains("matching dependencies")
+assert log.text.contains("matching packages")
+
+File factorySource = new File(basedir, 'target/generated-sources/importfactory/io/micronaut/build/examples/ImportFactory.java')
+assert factorySource.exists()
+
+File factoryClass = new File(basedir, 'target/classes/io/micronaut/build/examples/ImportFactory.class')
+assert factoryClass.exists()

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
@@ -269,7 +269,7 @@ public class ImportFactoryMojo extends AbstractMicronautMojo {
     code.add("");
     code.add("import io.micronaut.context.annotation.Factory;");
     code.add("import io.micronaut.context.annotation.Import;");
-    code.add("jakarta.annotation.Generated");
+    code.add("import jakarta.annotation.Generated");
     code.add("");
     code.add("/** Factory which allows Micronaut to import beans from the specified packages. */");
     code.add("@Generated(\"io.micronaut.maven:micronaut-maven-plugin\")");

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Import beans from project dependencies by generating factories annotated with
+ * <code>@Import</code> containing the list of packages.
+ *
+ * @author Auke Schrijnen
+ * @since 4.5.0
+ */
+@Mojo(name = ImportFactoryMojo.MOJO_NAME, defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class ImportFactoryMojo extends AbstractMicronautMojo {
+
+  /**
+   * Name of the import factory mojo.
+   */
+  public static final String MOJO_NAME = "generate-import-factory";
+
+  private static final String MICRONAUT_IMPORTFACTORY_PREFIX = "micronaut.importfactory";
+
+  /**
+   * Reference to the Maven project on which the plugin is invoked.
+   */
+  private final MavenProject project;
+
+  /**
+   * Whether to enable or disable the generation of the import factory.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(property = MICRONAUT_IMPORTFACTORY_PREFIX + ".enabled", defaultValue = "false")
+  private boolean enabled;
+
+  /**
+   * The output directory to which all the sources will be generated.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(defaultValue = "${project.build.directory}/generated-sources/importfactory", property = MICRONAUT_IMPORTFACTORY_PREFIX + ".outputDirectory", required = true)
+  private File outputDirectory;
+
+  /**
+   * Add the output directory to the project as a source root in order to let the generated java
+   * classes be compiled and included in the project artifact.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(defaultValue = "true", property = MICRONAUT_IMPORTFACTORY_PREFIX + ".addCompileSourceRoot")
+  private boolean addCompileSourceRoot;
+
+  /**
+   * Regexp pattern which allows including certain dependencies.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(defaultValue = "^.*:.*$", property = MICRONAUT_IMPORTFACTORY_PREFIX + ".includeDependenciesFilter", required = true)
+  private String includeDependenciesFilter;
+
+  /**
+   * Regexp pattern which allows excluding certain dependencies.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(defaultValue = "^$", property = MICRONAUT_IMPORTFACTORY_PREFIX + ".excludeDependenciesFilter", required = true)
+  private String excludeDependenciesFilter;
+
+  /**
+   * Regexp pattern which allows including certain packages.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(defaultValue = "^.*$", property = MICRONAUT_IMPORTFACTORY_PREFIX + ".includePackagesFilter", required = true)
+  private String includePackagesFilter;
+
+  /**
+   * Regexp pattern which allows excluding certain packages.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(defaultValue = "^$", property = MICRONAUT_IMPORTFACTORY_PREFIX + ".excludePackagesFilter", required = true)
+  private String excludePackagesFilter;
+
+  /**
+   * The package name which is used for the generated import factories. When not specified a factory
+   * is generated for each package within that package in order to access package protected fields.
+   *
+   * @since 4.5.0
+   */
+  @Parameter(property = MICRONAUT_IMPORTFACTORY_PREFIX + ".targetPackage")
+  private String targetPackage;
+
+  @Inject
+  public ImportFactoryMojo(MavenProject project) {
+    this.project = project;
+  }
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    if (!enabled) {
+      getLog().debug(this.getClass().getSimpleName() + " is disabled");
+      return;
+    }
+
+    if (addCompileSourceRoot) {
+      project.addCompileSourceRoot(outputDirectory.getPath());
+    }
+
+    List<Artifact> dependencies = getFilteredDependencies();
+
+    if (dependencies.isEmpty()) {
+      getLog().warn("No matching dependencies.");
+      return;
+    }
+
+    getLog().info("Found " + dependencies.size() + " matching dependencies:");
+    dependencies.forEach(
+        dependency -> getLog().info(getIdentifier(dependency) + " at " + dependency.getFile()));
+
+    List<String> packages = getFilteredPackages(dependencies);
+
+    if (packages.isEmpty()) {
+      getLog().warn("No matching packages.");
+      return;
+    }
+
+    getLog().info("Found " + packages.size() + " matching packages:");
+    packages.forEach(getLog()::info);
+
+    if (targetPackage == null || targetPackage.isEmpty()) {
+      for (String packageName : packages) {
+        try {
+          generateImportFactory(packageName, Collections.singletonList(packageName));
+        } catch (IOException e) {
+          throw new MojoExecutionException("Error creating factory for " + packageName, e);
+        }
+      }
+    } else {
+      try {
+        generateImportFactory(targetPackage, packages);
+      } catch (IOException e) {
+        throw new MojoExecutionException("Error creating factory for " + targetPackage, e);
+      }
+    }
+  }
+
+  /**
+   * Get the list of matching packages from the given list of dependencies.
+   *
+   * @param dependencies the Maven dependencies
+   * @return a list of matching packages
+   * @throws MojoExecutionException when the artifacts can't be read
+   */
+  private List<String> getFilteredPackages(List<Artifact> dependencies)
+      throws MojoExecutionException {
+    List<String> packages = new ArrayList<>();
+    for (Artifact dependency : dependencies) {
+      packages.addAll(getPackages(dependency));
+    }
+
+    Pattern includePackages = Pattern.compile(includePackagesFilter);
+    Pattern excludePackages = Pattern.compile(excludePackagesFilter);
+
+    return packages.stream().filter(includePackages.asMatchPredicate())
+        .filter(excludePackages.asMatchPredicate().negate()).sorted().toList();
+  }
+
+  /**
+   * Get the list of matching dependencies.
+   *
+   * @return the matching dependencies
+   */
+  private List<Artifact> getFilteredDependencies() {
+    Pattern includeDependency = Pattern.compile(includeDependenciesFilter);
+    Pattern excludeDependency = Pattern.compile(excludeDependenciesFilter);
+
+    return project.getArtifacts().stream()
+        .filter(dependency -> includeDependency.matcher(getIdentifier(dependency)).matches())
+        .filter(dependency -> !excludeDependency.matcher(getIdentifier(dependency)).matches())
+        .toList();
+  }
+
+  /**
+   * Get the packages from the given artifact.
+   *
+   * @param artifact the Maven artifact
+   * @return the list of packages
+   * @throws MojoExecutionException when the artifacts can't be read
+   */
+  private List<String> getPackages(Artifact artifact) throws MojoExecutionException {
+    try (JarFile file = new JarFile(artifact.getFile(), false)) {
+      return file.stream()
+          .filter(entry -> entry.getName().endsWith(".class") && entry.getName().contains("/"))
+          .map(this::getPackageName).distinct().sorted().toList();
+    } catch (IOException e) {
+      throw new MojoExecutionException("Unable to read " + artifact.getFile(), e);
+    }
+  }
+
+  /**
+   * Get the identifier for the given Maven artifact.
+   *
+   * @param artifact the Maven artifact
+   * @return the identifier for the artifact
+   */
+  private String getIdentifier(Artifact artifact) {
+    return artifact.getGroupId() + ":" + artifact.getArtifactId();
+  }
+
+  /**
+   * Get the Java package name from the given Jar entry.
+   *
+   * @param entry the Jar entry
+   * @return the Java package name
+   */
+  private String getPackageName(JarEntry entry) {
+    String entryName = entry.getName();
+    // remove .class from the end and change format to use periods instead of forward slashes
+    return entryName.substring(0, entryName.lastIndexOf('/')).replace('/', '.');
+  }
+
+  /**
+   * Generate the import factory with the given packages in the given package.
+   *
+   * @param packageName the package in which the factory is generated
+   * @param packages    the list of the packages which are imported
+   * @throws IOException when the writing of the factory class fails
+   */
+  private void generateImportFactory(String packageName, List<String> packages) throws IOException {
+    Path factoryPath = outputDirectory.toPath().resolve(packageName.replace('.', '/'))
+        .resolve("ImportFactory.java");
+
+    List<String> code = new ArrayList<>();
+    code.add("package " + packageName + ";");
+    code.add("");
+    code.add("import io.micronaut.context.annotation.Factory;");
+    code.add("import io.micronaut.context.annotation.Import;");
+    code.add("jakarta.annotation.Generated");
+    code.add("");
+    code.add("/** Factory which allows Micronaut to import beans from the specified packages. */");
+    code.add("@Generated(\"io.micronaut.maven:micronaut-maven-plugin\")");
+    code.add("@Factory");
+    code.add("@Import(");
+    code.add("    packages = {");
+    for (String name : packages) {
+      code.add("      \"" + name + "\",");
+    }
+    code.add("    })");
+    code.add("public class ImportFactory {}\n");
+
+    Files.createDirectories(factoryPath.getParent());
+    Files.write(factoryPath, code, StandardCharsets.UTF_8, StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING);
+  }
+
+}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
@@ -269,7 +269,7 @@ public class ImportFactoryMojo extends AbstractMicronautMojo {
     code.add("");
     code.add("import io.micronaut.context.annotation.Factory;");
     code.add("import io.micronaut.context.annotation.Import;");
-    code.add("import jakarta.annotation.Generated");
+    code.add("import jakarta.annotation.Generated;");
     code.add("");
     code.add("/** Factory which allows Micronaut to import beans from the specified packages. */");
     code.add("@Generated(\"io.micronaut.maven:micronaut-maven-plugin\")");

--- a/micronaut-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/micronaut-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -15,6 +15,7 @@
                         <id>default</id>
                         <phases>
                             <generate-sources>
+                                ${project.groupId}:${project.artifactId}:${project.version}:generate-import-factory,
                                 ${project.groupId}:${project.artifactId}:${project.version}:generate-openapi-generic,
                                 ${project.groupId}:${project.artifactId}:${project.version}:generate-openapi-client,
                                 ${project.groupId}:${project.artifactId}:${project.version}:generate-openapi-server

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/bean-import.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/bean-import.adoc
@@ -1,0 +1,37 @@
+=== Importing beans from dependencies
+
+When project dependencies contain beans but don't contain the Micronaut bean definitions the `@Import` annotation can
+be used to import those beans and allow them to be injected in the Micronaut application context. Since this annotation
+is handled by an annotation processor which can't list the available packages each package must be defined in the
+`@Import` annotation which can be cumbersome.
+
+This plugin is able to generate a Micronaut bean factory which imports the beans from the dependencies. The list of
+packages from which the beans are imported can be controlled by filtering the dependencies and the packages using
+regular expressions.
+
+In order to import beans from the dependencies the minimal thing to do is to enable the import factory:
+
+[source,xml]
+----
+<properties>
+   ...
+    <micronaut.importfactory.enabled>true</micronaut.importfactory.enabled>
+</properties>
+----
+
+It is however recommended to define a filter for the dependencies and for the packages:
+
+[source,xml]
+----
+<properties>
+   ...
+    <micronaut.importfactory.enabled>true</micronaut.importfactory.enabled>
+    <micronaut.importfactory.includeDependenciesFilter>my.company:.*</micronaut.importfactory.includeDependenciesFilter>
+    <micronaut.importfactory.excludeDependenciesFilter>my.company:exclude-this.*</micronaut.importfactory.excludeDependenciesFilter>
+    <micronaut.importfactory.includePackagesFilter>my.company.library.*</micronaut.importfactory.includePackagesFilter>
+    <micronaut.importfactory.excludePackagesFilter>my.company.library.internal.*</micronaut.importfactory.excludePackagesFilter>
+    <micronaut.importfactory.targetPackage>my.company.application</micronaut.importfactory.targetPackage>
+</properties>
+----
+
+The full list of configuration properties can be found link:../generate-import-factory-mojo.html[here].

--- a/micronaut-maven-plugin/src/site/asciidoc/index.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/index.adoc
@@ -9,6 +9,7 @@ This plugin has the following features:
 5. link:examples/aot.html[Using Micronaut AOT].
 6. link:examples/test-resources.html[Integration with Micronaut Test Resources].
 7. link:examples/openapi.html[Integration with Micronaut OpenAPI].
+8. link:examples/bean-import.html[Importing beans from project dependencies].
 
 === Usage
 

--- a/micronaut-maven-plugin/src/site/site.xml
+++ b/micronaut-maven-plugin/src/site/site.xml
@@ -28,6 +28,7 @@
             <item name="Using Micronaut AOT" href="examples/aot.html"/>
             <item name="Integration with Micronaut Test Resources" href="examples/test-resources.html"/>
             <item name="Generating OpenAPI clients or servers" href="examples/openapi.html"/>
+            <item name="Importing beans from project dependencies" href="examples/bean-import.html"/>
         </menu>
 
         <menu ref="reports"/>


### PR DESCRIPTION
Importing beans from dependencies which don't contain Micronaut bean definition classes can be cumbersome, it requires all the packages to be known upfront.

By generating a factory class with the `@Import` annotation for selected packages changes to the packages in dependencies are automatically handled.

See https://github.com/codegen-io/micronaut-import-plugin

Fixes https://github.com/micronaut-projects/micronaut-maven-plugin/issues/1021