### PR TITLE
Added dependabot config for com.gradle maven extensions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+    allow:
+      - dependency-name: "com.gradle:gradle-enterprise-maven-extension"
+        dependency-type: "production"
+      - dependency-name: "com.gradle:common-custom-user-data-maven-extension"
+        dependency-type: "production"


### PR DESCRIPTION
Added dependabot config for com.gradle maven extensions as renovate doesn't support updating `extensions.xml` - https://github.com/renovatebot/renovate/issues/24328