### PR TITLE
Fix DockerfileNative: to avoid parsing error if space present in home…

### DIFF
--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNative
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNative
@@ -9,7 +9,7 @@ COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/*:/home/app/classes/"
+RUN native-image "@/home/app/graalvm-native-image.args" -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/*:/home/app/classes/"
 
 FROM ${BASE_IMAGE_RUN}
 COPY --from=builder /home/app/application /app/application


### PR DESCRIPTION
The docker native build fails due to spaces present in the user home folder 

`
[INFO] Step 11/16 : RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/*:/home/app/classes/"
[INFO]
[INFO]  ---> Running in 3e421fdefdd6

[INFO] Error: Found unrecognized options while parsing argument file '/home/app/graalvm-native-image.args':
ADDALI\\\\.m2\\\\repository\\\\io\\\\netty\\\\netty-codec-http2\\\\4.1.108.Final\\\\netty-codec-http2-4.1.108.Final.jar\\\\E
^/META-INF/native-image/
ADDALI\\\\.m2\\\\repository\\\\io\\\\netty\\\\netty-handler\\\\4.1.108.Final\\\\netty-handler-4.1.108.Final.jar\\\\E
^/META-INF/native-image/
ADDALI\\\\.m2\\\\repository\\\\io\\\\netty\\\\netty-common\\\\4.1.108.Final\\\\netty-common-4.1.108.Final.jar\\\\E
^/META-INF/native-image/
ADDALI\\\\.m2\\\\repository\\\\io\\\\netty\\\\netty-buffer\\\\4.1.108.Final\\\\netty-buffer-4.1.108.Final.jar\\\\E
^/META-INF/native-image/
ADDALI\\\\.m2\\\\repository\\\\io\\\\netty\\\\netty-transport\\\\4.1.108.Final\\\\netty-transport-4.1.108.Final.jar\\\\E
^/META-INF/native-image/
ADDALI\\\\.m2\\\\repository\\\\io\\\\netty\\\\netty-codec-http\\\\4.1.108.Final\\\\netty-codec-http-4.1.108.Final.jar\\\\E
^/META-INF/native-image/
`