### PR TITLE
Update openapi version to 6.7.0

### DIFF
--- a/micronaut-maven-core/pom.xml
+++ b/micronaut-maven-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin-parent</artifactId>
-        <version>4.5.2-SNAPSHOT</version>
+        <version>4.5.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>micronaut-maven-core</artifactId>

--- a/micronaut-maven-enforcer-rules/pom.xml
+++ b/micronaut-maven-enforcer-rules/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin-parent</artifactId>
-        <version>4.5.2-SNAPSHOT</version>
+        <version>4.5.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>micronaut-maven-enforcer-rules</artifactId>

--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin-parent</artifactId>
-        <version>4.5.2-SNAPSHOT</version>
+        <version>4.5.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>micronaut-maven-integration-tests</artifactId>

--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -19,7 +19,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
-        <it.micronaut.version>4.2.3</it.micronaut.version>
+        <it.micronaut.version>4.4.0</it.micronaut.version>
 
         <!-- Enable recording of coverage during execution of maven-invoker-plugin -->
         <jacoco.propertyName>invoker.mavenOpts</jacoco.propertyName>

--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -106,8 +106,6 @@
                     <writeJunitReport>true</writeJunitReport>
                     <properties>
                         <jdk.version>${java.specification.version}</jdk.version>
-                        <!-- TODO: remove when using Micronaut 4.3 -->
-                        <resources.autodetection.enabled>true</resources.autodetection.enabled>
                     </properties>
                 </configuration>
                 <executions>

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-client/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-client/verify.groovy
@@ -5,6 +5,7 @@ assert log.text.contains("BUILD SUCCESS")
 
 def petApi = new File(basedir, "target/generated-sources/openapi/src/main/java/io/micronaut/openapi/api/PetApi.java")
 assert petApi.exists()
+assert petApi.text.contains('@Client("${openapi-micronaut-client.base-path}")')
 assert new File(basedir, "target/generated-sources/openapi/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
 assert new File(basedir, "target/classes/io/micronaut/openapi/api/PetApi.class").exists()
 assert new File(basedir, "target/classes/io/micronaut/openapi/model/Pet.class").exists()

--- a/micronaut-maven-integration-tests/src/it/package-docker-crac-aot/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/package-docker-crac-aot/pom.xml
@@ -137,6 +137,7 @@
             <image>
               <name>alvarosanchez/${project.artifactId}:${project.version}</name>
               <run>
+                <privileged>true</privileged>
                 <wait>
                   <log>Restore completed!</log>
                   <time>20000</time>

--- a/micronaut-maven-jib-integration/pom.xml
+++ b/micronaut-maven-jib-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin-parent</artifactId>
-        <version>4.5.2-SNAPSHOT</version>
+        <version>4.5.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>micronaut-maven-jib-integration</artifactId>

--- a/micronaut-maven-plugin/pom.xml
+++ b/micronaut-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin-parent</artifactId>
-        <version>4.5.2-SNAPSHOT</version>
+        <version>4.5.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>micronaut-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.micronaut.maven</groupId>
     <artifactId>micronaut-maven-plugin-parent</artifactId>
-    <version>4.5.2-SNAPSHOT</version>
+    <version>4.5.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Micronaut Maven Plugin - Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <native-maven-plugin.version>0.10.1</native-maven-plugin.version>
         <micronaut.aot.version>2.2.0</micronaut.aot.version>
         <micronaut.test.resources.version>2.4.0</micronaut.test.resources.version>
-        <micronaut.openapi.version>6.8.0</micronaut.openapi.version>
+        <micronaut.openapi.version>6.7.0</micronaut.openapi.version>
 
         <maven.resources-plugin.version>3.3.1</maven.resources-plugin.version>
         <maven.archiver-plugin.version>3.6.0</maven.archiver-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <native-maven-plugin.version>0.10.1</native-maven-plugin.version>
         <micronaut.aot.version>2.2.0</micronaut.aot.version>
         <micronaut.test.resources.version>2.4.0</micronaut.test.resources.version>
-        <micronaut.openapi.version>6.6.3</micronaut.openapi.version>
+        <micronaut.openapi.version>6.8.0</micronaut.openapi.version>
 
         <maven.resources-plugin.version>3.3.1</maven.resources-plugin.version>
         <maven.archiver-plugin.version>3.6.0</maven.archiver-plugin.version>


### PR DESCRIPTION
In 6.7.0 a the base-url property was renamed to have a dot separator instead of hyphen.

https://github.com/micronaut-projects/micronaut-openapi/pull/1467

We are doing this in a patch release as it is an ongoing bug in Micronaut 4.4.0 and will be released with 4.4.1.