### PR TITLE
Native image args windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 .project
 .factorypath
 .micronaut/
+.develocity/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/.mvn/.develocity/develocity-workspace-id
+++ b/.mvn/.develocity/develocity-workspace-id
@@ -1,0 +1,1 @@
+4d2cj2iefbdsdbytuqrvdutvty

--- a/.mvn/.develocity/develocity-workspace-id
+++ b/.mvn/.develocity/develocity-workspace-id
@@ -1,1 +1,0 @@
-4d2cj2iefbdsdbytuqrvdutvty

--- a/micronaut-maven-integration-tests/src/it/aot-sample/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/aot-sample/invoker.properties
@@ -1,2 +1,4 @@
 invoker.goals = -ntp mn:aot-sample-config
 #invoker.mavenOpts = -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-crac
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-lambda/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker compile docker:build
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/invoker.properties
@@ -1,2 +1,2 @@
 invoker.goals = -ntp -e mn:dockerfile -Dpackaging=docker-native compile docker:build docker:start docker:stop
-invoker.os.family = !windows
+

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native -Dmicronaut.runtime=lambda compile docker:build docker:copy
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native compile docker:build docker:start docker:stop
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native -Dmicronaut.native-image.ol.version=ol7 compile docker:build docker:start docker:stop
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native compile docker:build docker:start docker:stop
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native compile docker:build
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native compile docker:build
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native -Dmicronaut.native-image.static=true
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-function/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-function/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker compile docker:build
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-http-function/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-http-function/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker compile docker:build
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker/invoker.properties
@@ -1,3 +1,2 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker compile docker:build docker:start docker:stop
 
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp compile
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/import-factory-disabled/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/import-factory-disabled/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp compile
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/import-factory-enabled/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/import-factory-enabled/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/issue1005/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/issue1005/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = help:evaluate -Dexpression=project.version -q -DforceStdout
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/issue375/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/issue375/invoker.properties
@@ -2,3 +2,4 @@ invoker.goals.1 = -ntp test
 invoker.goals.2 = -ntp integration-test
 invoker.goals.3 = -ntp verify
 #invoker.mavenOpts = -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/issue465/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/issue465/invoker.properties
@@ -1,2 +1,3 @@
 invoker.goals = -ntp mn:run -Dmn.watch=false
 #invoker.mavenOpts = -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/mn-graalvm-resources-deprecated/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/mn-graalvm-resources-deprecated/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp mn:graalvm-resources
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/multi-project/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/multi-project/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp -e mn:run -Dmn.watch=false
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-client-kotlin/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-client-kotlin/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-client/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-client/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-server-kotlin/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-server-kotlin/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-server-mapped-types/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-server-mapped-types/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-server/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-server/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-sources/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-sources/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/openapi-setup/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/openapi-setup/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp install -Dcheckstyle.skip -Dspotless.check.skip
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-crac-aot/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-crac-aot/invoker.properties
@@ -1,3 +1,1 @@
 invoker.goals = -ntp package -Dpackaging=docker-crac docker:start docker:stop
-
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-crac/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-crac/invoker.properties
@@ -1,3 +1,1 @@
 invoker.goals = -ntp -e package -Dpackaging=docker-crac docker:start docker:stop
-
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-down/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-down/invoker.properties
@@ -1,4 +1,3 @@
 invoker.goals = -ntp package -Dpackaging=docker -Djib.dockerClient.environment="DOCKER_HOST=tcp://localhost:65432"
 
-invoker.os.family = !windows
 invoker.buildResult = failure

--- a/micronaut-maven-integration-tests/src/it/package-docker-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-lambda/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp package -Dpackaging=docker
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-distroless/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-distroless/invoker.properties
@@ -1,4 +1,3 @@
 invoker.goals = -ntp package -Dpackaging=docker-native docker:start docker:stop
 
 invoker.profiles = graalvm
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-docker-down/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-docker-down/invoker.properties
@@ -1,5 +1,4 @@
 invoker.goals = -ntp package -Dpackaging=docker-native -DDOCKER_HOST=tcp://localhost:65432
 
 invoker.profiles = graalvm
-invoker.os.family = !windows
 invoker.buildResult = failure

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/invoker.properties
@@ -1,4 +1,3 @@
 invoker.goals = -ntp package -Dpackaging=docker-native
 
 invoker.profiles = graalvm
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-static/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-static/invoker.properties
@@ -1,4 +1,3 @@
 invoker.goals = -ntp package -Dpackaging=docker-native -Dmicronaut.native-image.static=true docker:start docker:stop
 
 invoker.profiles = graalvm
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-native/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native/invoker.properties
@@ -1,3 +1,4 @@
 invoker.goals = -ntp package -Dpackaging=docker-native docker:start docker:stop
 
 invoker.profiles = graalvm
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-native/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native/invoker.properties
@@ -1,4 +1,3 @@
 invoker.goals = -ntp package -Dpackaging=docker-native docker:start docker:stop
 
 invoker.profiles = graalvm
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp package -Dpackaging=docker
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker/invoker.properties
@@ -1,3 +1,2 @@
 invoker.goals = -ntp package -Dpackaging=docker docker:start docker:stop
 
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-native-image-aot/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-native-image-aot/invoker.properties
@@ -1,1 +1,3 @@
 invoker.goals = -ntp package -Dpackaging=native-image exec:exec@native
+
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-native-image/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-native-image/invoker.properties
@@ -1,3 +1,1 @@
 invoker.goals = -ntp -e package -Dpackaging=native-image exec:exec@native
-
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-native-image/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-native-image/invoker.properties
@@ -1,1 +1,3 @@
 invoker.goals = -ntp -e package -Dpackaging=native-image exec:exec@native
+
+invoker.os.family = !windows

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -224,7 +224,6 @@ public class DockerNativeMojo extends AbstractDockerMojo {
 
     private BuildImageCmd addNativeImageBuildArgs(Map<String, String> buildImageCmdArguments, Supplier<BuildImageCmd> buildImageCmdSupplier) throws IOException {
         String argsFile = mavenProject.getProperties().getProperty(ARGS_FILE_PROPERTY_NAME);
-        getLog().info("ARGSFILE"+ argsFile);
         List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile);
         //Remove extra main class argument
         allNativeImageBuildArgs.remove(mainClass);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -224,6 +224,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
 
     private BuildImageCmd addNativeImageBuildArgs(Map<String, String> buildImageCmdArguments, Supplier<BuildImageCmd> buildImageCmdSupplier) throws IOException {
         String argsFile = mavenProject.getProperties().getProperty(ARGS_FILE_PROPERTY_NAME);
+        getLog().info("ARGSFILE"+ argsFile);
         List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile);
         //Remove extra main class argument
         allNativeImageBuildArgs.remove(mainClass);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.micronaut.maven;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.execution.MavenSession;

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
@@ -77,67 +77,13 @@ public final class MojoUtils {
     }
 
     private static Stream<String> parseNativeImageArgsFile(String argsFile) {
-        System.out.println("------ HERE ---------"+ argsFile);
         Path argsFilePath = Paths.get(argsFile);
         if (Files.exists(argsFilePath)) {
             List<String> args;
             try {
                 args = Files.readAllLines(argsFilePath);
+                // TODO: fix native-build-tools write-args-file to avoid this
                 args = ignorePathWhiteSpaces(args);
-                System.out.println("resulted args:\n/I" + args);
-                /*if(argsFilePath.toString().contains("docker-native")) {
-                    System.out.println("TRUE");
-                    String[] test = new String[]{
-                            "-Ob",
-                            "--no-fallback",
-                            "-o",
-                            "\"\"C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\package-docker-native\"\"",
-                            "\"\"-H:ConfnFileDirectories=C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
-                                    "etty-common\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
-                                    "etty-handler\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
-                                    "etty-buffer\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
-                                    "etty-codec-http2\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
-                                    "etty-codec-http\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
-                                    "etty-transport\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\ch.qos.logback\\logback-classic\\1.4.9\"\"" ,
-                            "--no-fallback",
-                            "--exclude-config",
-                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
-                                    "etty\\n" + //
-                                    "etty-codec-http2\\4.1.108.Final\\n" + //
-                                    "etty-codec-http2-4.1.108.Final.jar\\E",
-                            "^/META-INF/native-image/",
-                            "--exclude-config",
-                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
-                                    "etty\\n" + //
-                                    "etty-handler\\4.1.108.Final\\n" + //
-                                    "etty-handler-4.1.108.Final.jar\\E",
-                            "^/META-INF/native-image/",
-                            "--exclude-config",
-                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
-                                    "etty\\n" + //
-                                    "etty-codec-http\\4.1.108.Final\\n" + //
-                                    "etty-codec-http-4.1.108.Final.jar\\E",
-                            "^/META-INF/native-image/",
-                            "--exclude-config",
-                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
-                                    "etty\\n" + //
-                                    "etty-common\\4.1.108.Final\\n" + //
-                                    "etty-common-4.1.108.Final.jar\\E",
-                            "^/META-INF/native-image/",
-                            "--exclude-config",
-                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
-                                    "etty\\n" + //
-                                    "etty-buffer\\4.1.108.Final\\n" + //
-                                    "etty-buffer-4.1.108.Final.jar\\E",
-                            "^/META-INF/native-image/",
-                            "--exclude-config",
-                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\netty\\netty-transport\\4.1.108.Final\\netty-transport-4.1.108.Final.jar\\E",
-                            "^/META-INF/native-image/",
-                            "-H:ConfigurationFileDirectories=/home/app/graalvm-reachability-metadata/generateResourceConfig,/generateTestResourceConfig"
-                    };
-                    args= Arrays.asList(test);
-                    System.out.println("ARGS:\n" + args);
-                }*/
             } catch (IOException e) {
                 throw new RuntimeException("Could not read the args file: " + argsFilePath, e);
             }
@@ -152,17 +98,15 @@ public final class MojoUtils {
                     .filter(arg -> !arg.startsWith("-H:Class"))
                     .filter(arg -> !arg.startsWith("-H:Path"))
                     .flatMap(arg -> {
-                        arg= arg.replace("\"", "");
+                        arg= arg.replaceAll("\"", "");
                         if (arg.startsWith("@")) {
                             String fileName = arg.substring(1);
                             return parseNativeImageArgsFile(fileName);
                         } else if (arg.startsWith("\\\\Q") && arg.endsWith("\\\\E")) {
                             // start the search at length - 3 to skip \Q or \E at the end
                             int lastIndexOfSlash = arg.lastIndexOf(File.separator , arg.length() - 4);
-                            System.out.println("HERE1" + arg.substring(lastIndexOfSlash ));
                             return Stream.of("\\Q/home/app/libs/" + arg.substring(lastIndexOfSlash + 1,arg.length()-3) +"\\E");
                         } else if (arg.startsWith("-H:ConfigurationFileDirectories")) {
-                            System.out.println("HERE2 CONFIG");
                             return Stream.of(parseConfigurationFilesDirectoriesArg(arg));
                         }else {
                             return Stream.of(arg);
@@ -173,14 +117,14 @@ public final class MojoUtils {
         }
     }
 
+    // to avoid the line breaks introduced by native:write-args-file
+    // to be deleted after fixing it
     private static List<String> ignorePathWhiteSpaces(List<String> args) {
         int i=0;
         List<String> result = new ArrayList<>();
         while(i < args.size()) {
-
             if(args.get(i).startsWith("\\\\Q") &&
                     !args.get(i).endsWith("\\\\E")) {
-                System.out.println("HERE");
                 StringBuilder line = new StringBuilder(args.get(i));
                 i++;
                 while(!args.get(i).endsWith("\\E")) {
@@ -195,7 +139,6 @@ public final class MojoUtils {
                 i++;
                 while( i< args.size() && args.get(i).toLowerCase().charAt(0) <='z'
                         && args.get(i).toLowerCase().charAt(0) >='a') {
-                    System.out.println("CCCC");
                     line.append(" ").append(args.get(i));
                     i++;
                 }
@@ -223,12 +166,10 @@ public final class MojoUtils {
                     .collect(Collectors.joining(","))
                     .transform(s -> "-H:ConfigurationFileDirectories=" + s);
         } else {
-            System.out.println("HOUCINE");
             return Stream.of(directories)
                     .map(FilenameUtils::separatorsToUnix)
                     .map(directory -> {
-                        String[] splitDirectory = directory.replace("//","/").split(separator);
-                        System.out.println(Arrays.toString(splitDirectory));
+                        String[] splitDirectory = directory.replaceAll("//","/").split(separator);
                         String last4Directories = splitDirectory[splitDirectory.length - 4] + separator +
                                                   splitDirectory[splitDirectory.length - 3] + separator +
                                                   splitDirectory[splitDirectory.length - 2] + separator +

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -76,11 +77,67 @@ public final class MojoUtils {
     }
 
     private static Stream<String> parseNativeImageArgsFile(String argsFile) {
+        System.out.println("------ HERE ---------"+ argsFile);
         Path argsFilePath = Paths.get(argsFile);
         if (Files.exists(argsFilePath)) {
             List<String> args;
             try {
                 args = Files.readAllLines(argsFilePath);
+                args = ignorePathWhiteSpaces(args);
+                System.out.println("resulted args:\n/I" + args);
+                /*if(argsFilePath.toString().contains("docker-native")) {
+                    System.out.println("TRUE");
+                    String[] test = new String[]{
+                            "-Ob",
+                            "--no-fallback",
+                            "-o",
+                            "\"\"C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\package-docker-native\"\"",
+                            "\"\"-H:ConfnFileDirectories=C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
+                                    "etty-common\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
+                                    "etty-handler\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
+                                    "etty-buffer\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
+                                    "etty-codec-http2\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
+                                    "etty-codec-http\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\io.netty\\n" + //
+                                    "etty-transport\\4.1.80.Final,C:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\it\\package-docker-native\\target\\graalvm-reachability-metadata\\2f4c00fdf0445087b50fa34cf9fa6555ab490d8d\\ch.qos.logback\\logback-classic\\1.4.9\"\"" ,
+                            "--no-fallback",
+                            "--exclude-config",
+                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
+                                    "etty\\n" + //
+                                    "etty-codec-http2\\4.1.108.Final\\n" + //
+                                    "etty-codec-http2-4.1.108.Final.jar\\E",
+                            "^/META-INF/native-image/",
+                            "--exclude-config",
+                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
+                                    "etty\\n" + //
+                                    "etty-handler\\4.1.108.Final\\n" + //
+                                    "etty-handler-4.1.108.Final.jar\\E",
+                            "^/META-INF/native-image/",
+                            "--exclude-config",
+                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
+                                    "etty\\n" + //
+                                    "etty-codec-http\\4.1.108.Final\\n" + //
+                                    "etty-codec-http-4.1.108.Final.jar\\E",
+                            "^/META-INF/native-image/",
+                            "--exclude-config",
+                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
+                                    "etty\\n" + //
+                                    "etty-common\\4.1.108.Final\\n" + //
+                                    "etty-common-4.1.108.Final.jar\\E",
+                            "^/META-INF/native-image/",
+                            "--exclude-config",
+                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\n" + //
+                                    "etty\\n" + //
+                                    "etty-buffer\\4.1.108.Final\\n" + //
+                                    "etty-buffer-4.1.108.Final.jar\\E",
+                            "^/META-INF/native-image/",
+                            "--exclude-config",
+                            "\\QC:\\Users\\Lahoucine EL ADDALI\\Desktop\\projects-p\\micronaut-maven-plugin\\target\\local-repo\\io\\netty\\netty-transport\\4.1.108.Final\\netty-transport-4.1.108.Final.jar\\E",
+                            "^/META-INF/native-image/",
+                            "-H:ConfigurationFileDirectories=/home/app/graalvm-reachability-metadata/generateResourceConfig,/generateTestResourceConfig"
+                    };
+                    args= Arrays.asList(test);
+                    System.out.println("ARGS:\n" + args);
+                }*/
             } catch (IOException e) {
                 throw new RuntimeException("Could not read the args file: " + argsFilePath, e);
             }
@@ -95,16 +152,19 @@ public final class MojoUtils {
                     .filter(arg -> !arg.startsWith("-H:Class"))
                     .filter(arg -> !arg.startsWith("-H:Path"))
                     .flatMap(arg -> {
+                        arg= arg.replace("\"", "");
                         if (arg.startsWith("@")) {
                             String fileName = arg.substring(1);
                             return parseNativeImageArgsFile(fileName);
-                        } else if (arg.startsWith("\\Q") && arg.endsWith("\\E")) {
+                        } else if (arg.startsWith("\\\\Q") && arg.endsWith("\\\\E")) {
                             // start the search at length - 3 to skip \Q or \E at the end
-                            int lastIndexOfSlash = arg.lastIndexOf(File.separator, arg.length() - 3);
-                            return Stream.of("\\Q/home/app/libs/" + arg.substring(lastIndexOfSlash + 1));
+                            int lastIndexOfSlash = arg.lastIndexOf(File.separator , arg.length() - 4);
+                            System.out.println("HERE1" + arg.substring(lastIndexOfSlash ));
+                            return Stream.of("\\Q/home/app/libs/" + arg.substring(lastIndexOfSlash + 1,arg.length()-3) +"\\E");
                         } else if (arg.startsWith("-H:ConfigurationFileDirectories")) {
+                            System.out.println("HERE2 CONFIG");
                             return Stream.of(parseConfigurationFilesDirectoriesArg(arg));
-                        } else {
+                        }else {
                             return Stream.of(arg);
                         }
                     });
@@ -113,6 +173,42 @@ public final class MojoUtils {
         }
     }
 
+    private static List<String> ignorePathWhiteSpaces(List<String> args) {
+        int i=0;
+        List<String> result = new ArrayList<>();
+        while(i < args.size()) {
+
+            if(args.get(i).startsWith("\\\\Q") &&
+                    !args.get(i).endsWith("\\\\E")) {
+                System.out.println("HERE");
+                StringBuilder line = new StringBuilder(args.get(i));
+                i++;
+                while(!args.get(i).endsWith("\\E")) {
+                    line.append(" ").append(args.get(i));
+                    i++;
+                }
+                line.append(" ").append(args.get(i));
+                result.add(line.toString());
+                i++;
+            }else if(args.get(i).startsWith("-H:ConfigurationFileDirectories")) {
+                StringBuilder line = new StringBuilder(args.get(i));
+                i++;
+                while( i< args.size() && args.get(i).toLowerCase().charAt(0) <='z'
+                        && args.get(i).toLowerCase().charAt(0) >='a') {
+                    System.out.println("CCCC");
+                    line.append(" ").append(args.get(i));
+                    i++;
+                }
+                result.add(line.toString());
+                i++;
+            }
+            else{
+                result.add(args.get(i));
+                i++;
+            }
+        }
+        return result;
+    }
     static String parseConfigurationFilesDirectoriesArg(String arg) {
         String[] split = arg.split("=");
         String[] directories = split[1].split(",");
@@ -127,15 +223,17 @@ public final class MojoUtils {
                     .collect(Collectors.joining(","))
                     .transform(s -> "-H:ConfigurationFileDirectories=" + s);
         } else {
+            System.out.println("HOUCINE");
             return Stream.of(directories)
                     .map(FilenameUtils::separatorsToUnix)
                     .map(directory -> {
-                        String[] splitDirectory = directory.split(separator);
+                        String[] splitDirectory = directory.replace("//","/").split(separator);
+                        System.out.println(Arrays.toString(splitDirectory));
                         String last4Directories = splitDirectory[splitDirectory.length - 4] + separator +
                                                   splitDirectory[splitDirectory.length - 3] + separator +
                                                   splitDirectory[splitDirectory.length - 2] + separator +
                                                   splitDirectory[splitDirectory.length - 1];
-                        return "/home/app/graalvm-reachability-metadata/" + last4Directories;
+                        return "/home/app/graalvm-reachability-metadata/" +last4Directories;
                     })
                     .collect(Collectors.joining(","))
                     .transform(s -> "-H:ConfigurationFileDirectories=" + s);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
@@ -98,27 +98,27 @@ public final class MojoUtils {
                     .filter(arg -> !arg.startsWith("-H:Class"))
                     .filter(arg -> !arg.startsWith("-H:Path"))
                     .flatMap(arg -> {
-                        arg= arg.replace("\"", ""); // remove the " quotation from the arg
-                        String[] patterns = new String[]{"\\Q","\\E"};
+                        arg = arg.replace("\"", ""); // remove the " quotation from the arg
+                        String[] patterns = new String[]{"\\Q", "\\E"};
                         boolean isWindows = false;
-                        if(File.separator.equals("\\")) {
-                            patterns = new String[]{"\\\\Q","\\\\E"};
-                            isWindows=true;
+                        if (File.separator.equals("\\")) {
+                            patterns = new String[]{"\\\\Q", "\\\\E"};
+                            isWindows = true;
                         }
                         if (arg.startsWith("@")) {
                             String fileName = arg.substring(1);
                             return parseNativeImageArgsFile(fileName);
                         } else if (arg.startsWith(patterns[0]) && arg.endsWith(patterns[1])) {
                             // start the search at length - 3 to skip \Q or \E at the end
-                            int skip = isWindows ? 4: 3;
+                            int skip = isWindows ? 4 : 3;
                             int lastIndexOfSlash = arg.lastIndexOf(File.separator , arg.length() - skip);
-                            if(isWindows) {
-                                return Stream.of("\\Q/home/app/libs/" + arg.substring(lastIndexOfSlash + 1,arg.length()-3) +"\\E");
+                            if (isWindows) {
+                                return Stream.of("\\Q/home/app/libs/" + arg.substring(lastIndexOfSlash + 1, arg.length() - 3) + "\\E");
                             }
                             return Stream.of("\\Q/home/app/libs/" + arg.substring(lastIndexOfSlash + 1));
                         } else if (arg.startsWith("-H:ConfigurationFileDirectories")) {
                             return Stream.of(parseConfigurationFilesDirectoriesArg(arg));
-                        }else {
+                        } else {
                             return Stream.of(arg);
                         }
                     });
@@ -130,38 +130,38 @@ public final class MojoUtils {
     // remove lines breaks introduced by write-args-file
     // with maven build-tools plugin
     private static List<String> ignorePathWhiteSpaces(List<String> args) {
-        int i=0;
+        int i = 0;
         List<String> result = new ArrayList<>();
-        while(i < args.size()) {
-            if(args.get(i).startsWith("\\\\Q") &&
+        while (i < args.size()) {
+            if (args.get(i).startsWith("\\\\Q") &&
                     !args.get(i).endsWith("\\\\E")) {
                 StringBuilder line = new StringBuilder(args.get(i));
                 i++;
-                while(!args.get(i).endsWith("\\E")) {
+                while (!args.get(i).endsWith("\\E")) {
                     line.append(" ").append(args.get(i));
                     i++;
                 }
                 line.append(" ").append(args.get(i));
                 result.add(line.toString());
                 i++;
-            }else if(args.get(i).startsWith("-H:ConfigurationFileDirectories")) {
+            } else if (args.get(i).startsWith("-H:ConfigurationFileDirectories")) {
                 StringBuilder line = new StringBuilder(args.get(i));
                 i++;
-                while( i< args.size() && args.get(i).toLowerCase().charAt(0) <='z'
-                        && args.get(i).toLowerCase().charAt(0) >='a') {
+                while (i < args.size() && args.get(i).toLowerCase().charAt(0) <= 'z'
+                        && args.get(i).toLowerCase().charAt(0) >= 'a') {
                     line.append(" ").append(args.get(i));
                     i++;
                 }
                 result.add(line.toString());
                 i++;
-            }
-            else{
+            } else {
                 result.add(args.get(i));
                 i++;
             }
         }
         return result;
     }
+
     static String parseConfigurationFilesDirectoriesArg(String arg) {
         String[] split = arg.split("=");
         String[] directories = split[1].split(",");
@@ -179,12 +179,12 @@ public final class MojoUtils {
             return Stream.of(directories)
                     .map(FilenameUtils::separatorsToUnix)
                     .map(directory -> {
-                        String[] splitDirectory = directory.replaceAll("//","/").split(separator);
+                        String[] splitDirectory = directory.replaceAll("//", "/").split(separator);
                         String last4Directories = splitDirectory[splitDirectory.length - 4] + separator +
                                 splitDirectory[splitDirectory.length - 3] + separator +
                                 splitDirectory[splitDirectory.length - 2] + separator +
                                 splitDirectory[splitDirectory.length - 1];
-                        return "/home/app/graalvm-reachability-metadata/" +last4Directories;
+                        return "/home/app/graalvm-reachability-metadata/" + last4Directories;
                     })
                     .collect(Collectors.joining(","))
                     .transform(s -> "-H:ConfigurationFileDirectories=" + s);

--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,7 @@
                     <failsOnError>true</failsOnError>
                     <failOnViolation>true</failOnViolation>
                     <linkXRef>false</linkXRef>
+                    <skip>true</skip>
                     <maxAllowedViolations>1</maxAllowedViolations>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -590,7 +590,6 @@
                     <failsOnError>true</failsOnError>
                     <failOnViolation>true</failOnViolation>
                     <linkXRef>false</linkXRef>
-                    <skip>true</skip>
                     <maxAllowedViolations>1</maxAllowedViolations>
                 </configuration>
                 <executions>


### PR DESCRIPTION
- a temporary fix for spaces introduced by native:wrtie-args-file.
- fix split regex that makes container fails to start.
- fix argument parsing in windows env.