### PR TITLE
Allow using Google application default credentials for Artifact Registry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,12 @@
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java-core</artifactId>
                 <version>${docker-java.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.docker-java</groupId>


### PR DESCRIPTION
With GoogleContainerTools/jib#1902 and GoogleContainerTools/jib#3241 JIB is able to use Google Application Default Credentials for authenticating against Google Container Registry and Google Artifact Registry. 

Therefore the CredentialRetriever `googleApplicationDefaultCredentials` was implemented in [CredentiaReceiver](https://github.com/GoogleContainerTools/jib/blob/master/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.java). At the moment, only the CredentialRetriever `wellKnownCredentialHelpers` is used in micornaut-maven-plugin. The `googleApplicationDefaultCredentials` CredentialRetriever isn't used at the moment. Therefor Google Application Default Credentials cannot be used for authenticating against Google Container Registry and Google Artifact Registry. 

This PR fixes this issue.

At fixing this issue I ran into the problem, that Guava 19 is a transitive dependency of  `com.github.docker-java:docker-java-core` .
There are also version 32.1.2 (transitive dependency of `com.google.cloud.tools:jib-maven-plugin`) and version 33.2.1 (transitive dependency of `org.apache.maven:maven-core`) in the classpath. Guava 19 seems to be a problem, because `java.lang.NoSuchMethodError: 'long com.google.common.io.ByteStreams.exhaust(java.io.InputStream)'` is thrown, when `googleCredentials.refreshIfExpired()` in `googleApplicationDefaultCredentials` is called.  After excluding  Guava 19 everything works fine for me.