### PR TITLE
Fix the behaviour of `mn:run` in multi-module projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ target/
 
 # Ignore Gradle GUI config
 gradle-app.setting
-.mvn/.gradle-enterprise
+.mvn/.develocity
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app1/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app1/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>app1</artifactId>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <properties>
+    <packaging>jar</packaging>
+    <exec.mainClass>io.micronaut.build.examples.Application1</exec.mainClass>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.build.examples</groupId>
+      <artifactId>lib</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>${project.parent.name}-${project.artifactId}</image>
+          </to>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut.validation</groupId>
+              <artifactId>micronaut-validation-processor</artifactId>
+              <version>${micronaut.validation.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
+            </path>
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=oci</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app1/src/main/java/io/micronaut/build/examples/Application1.java
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app1/src/main/java/io/micronaut/build/examples/Application1.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application1 {
+    public static void main(String[] args) {
+        Micronaut.run(Application1.class, args);
+        System.exit(0);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app1/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app1/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app2/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app2/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>app2</artifactId>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <properties>
+    <packaging>jar</packaging>
+    <exec.mainClass>io.micronaut.build.examples.Application2</exec.mainClass>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.build.examples</groupId>
+      <artifactId>lib</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>${project.parent.name}-${project.artifactId}</image>
+          </to>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut.validation</groupId>
+              <artifactId>micronaut-validation-processor</artifactId>
+              <version>${micronaut.validation.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
+            </path>
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=oci</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app2/src/main/java/io/micronaut/build/examples/Application2.java
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app2/src/main/java/io/micronaut/build/examples/Application2.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application2 {
+    public static void main(String[] args) {
+        Micronaut.run(Application2.class, args);
+        System.exit(0);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app2/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/app2/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -ntp -e mn:run -Dmn.watch=false
+invoker.buildResult = failure

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/lib/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/lib/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>lib</artifactId>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <properties>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+      </resource>
+    </resources>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=lib</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.micronaut.platform</groupId>
+        <artifactId>micronaut-parent</artifactId>
+        <version>@it.micronaut.version@</version>
+    </parent>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+    <groupId>io.micronaut.build.examples</groupId>
+    <name>multi-project</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <micronaut.version>@it.micronaut.version@</micronaut.version>
+        <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+        <micronaut.runtime>netty</micronaut.runtime>
+        <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+    </properties>
+
+    <modules>
+        <module>lib</module>
+        <module>app1</module>
+        <module>app2</module>
+    </modules>
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable-error/verify.groovy
@@ -1,0 +1,4 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD FAILURE")
+assert log.text.contains("The Micronaut Maven Plugin is declared in the following projects: [app1, app2]. Please specify the project to run with the -pl option.")

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app1/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app1/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>app1</artifactId>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <properties>
+    <packaging>jar</packaging>
+    <exec.mainClass>io.micronaut.build.examples.Application1</exec.mainClass>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.build.examples</groupId>
+      <artifactId>lib</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>${project.parent.name}-${project.artifactId}</image>
+          </to>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut.validation</groupId>
+              <artifactId>micronaut-validation-processor</artifactId>
+              <version>${micronaut.validation.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
+            </path>
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=oci</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app1/src/main/java/io/micronaut/build/examples/Application1.java
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app1/src/main/java/io/micronaut/build/examples/Application1.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application1 {
+    public static void main(String[] args) {
+        Micronaut.run(Application1.class, args);
+        System.exit(0);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app1/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app1/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app2/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app2/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>app2</artifactId>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <properties>
+    <packaging>jar</packaging>
+    <exec.mainClass>io.micronaut.build.examples.Application2</exec.mainClass>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.build.examples</groupId>
+      <artifactId>lib</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>${project.parent.name}-${project.artifactId}</image>
+          </to>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut.validation</groupId>
+              <artifactId>micronaut-validation-processor</artifactId>
+              <version>${micronaut.validation.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
+            </path>
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=oci</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app2/src/main/java/io/micronaut/build/examples/Application2.java
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app2/src/main/java/io/micronaut/build/examples/Application2.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application2 {
+    public static void main(String[] args) {
+        Micronaut.run(Application2.class, args);
+        System.exit(0);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app2/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/app2/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals.1 = -ntp -e mn:run -Dmn.watch=false -pl app1 -am
+invoker.goals.2 = -ntp -e mn:run -Dmn.watch=false -pl app2 -am

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/lib/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/lib/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>lib</artifactId>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <properties>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.validation</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+      </resource>
+    </resources>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=lib</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.micronaut.platform</groupId>
+        <artifactId>micronaut-parent</artifactId>
+        <version>@it.micronaut.version@</version>
+    </parent>
+    <artifactId>multi-project-parent</artifactId>
+    <version>0.1</version>
+    <groupId>io.micronaut.build.examples</groupId>
+    <name>multi-project</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <micronaut.version>@it.micronaut.version@</micronaut.version>
+        <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+        <micronaut.runtime>netty</micronaut.runtime>
+        <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+    </properties>
+
+    <modules>
+        <module>lib</module>
+        <module>app1</module>
+        <module>app2</module>
+    </modules>
+</project>

--- a/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/multi-project-multi-runnable/verify.groovy
@@ -1,0 +1,5 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD SUCCESS")
+assert log.text.contains("Startup completed")
+assert log.text.contains("Embedded Application shutting down")

--- a/micronaut-maven-integration-tests/src/it/multi-project/app/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project/app/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <packaging>jar</packaging>
+    <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
   </properties>
 
   <dependencies>

--- a/micronaut-maven-integration-tests/src/it/multi-project/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/multi-project/pom.xml
@@ -18,7 +18,6 @@
         <micronaut.version>@it.micronaut.version@</micronaut.version>
         <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
         <micronaut.runtime>netty</micronaut.runtime>
-        <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
         <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
     </properties>
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/ImportFactoryMojo.java
@@ -36,6 +36,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
+import static io.micronaut.maven.RunMojo.THIS_PLUGIN;
+
 /**
  * Import beans from project dependencies by generating factories annotated with
  * <code>@Import</code> containing the list of packages.
@@ -272,7 +274,7 @@ public class ImportFactoryMojo extends AbstractMicronautMojo {
     code.add("import jakarta.annotation.Generated;");
     code.add("");
     code.add("/** Factory which allows Micronaut to import beans from the specified packages. */");
-    code.add("@Generated(\"io.micronaut.maven:micronaut-maven-plugin\")");
+    code.add("@Generated(\"%s\")".formatted(THIS_PLUGIN));
     code.add("@Factory");
     code.add("@Import(");
     code.add("    packages = {");

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
@@ -17,6 +17,7 @@ package io.micronaut.maven;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.util.Os;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micronaut.maven.AbstractDockerMojo.MOSTLY_STATIC_NATIVE_IMAGE_GRAALVM_FLAG;
+import static io.micronaut.maven.RunMojo.THIS_PLUGIN;
 
 /**
  * Utility methods for different mojos.
@@ -140,5 +142,19 @@ public final class MojoUtils {
                     .collect(Collectors.joining(","))
                     .transform(s -> "-H:ConfigurationFileDirectories=" + s);
         }
+    }
+
+    /**
+     * Checks if the project has the Micronaut Maven plugin defined.
+     *
+     * @param project the Maven project
+     * @return true if the project has the Micronaut Maven plugin defined
+     */
+    public static boolean hasMicronautMavenPlugin(MavenProject project) {
+        String[] parts = THIS_PLUGIN.split(":");
+        String groupId = parts[0];
+        String artifactId = parts[1];
+        return project.getBuildPlugins().stream()
+                .anyMatch(p -> p.getGroupId().equals(groupId) && p.getArtifactId().equals(artifactId));
     }
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -223,7 +223,11 @@ public class RunMojo extends AbstractTestResourcesMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        initialize();
+        try {
+            initialize();
+        } catch (Exception e) {
+            throw new MojoExecutionException(e.getMessage());
+        }
 
         try {
             maybeStartTestResourcesServer();
@@ -284,7 +288,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
         }
     }
 
-    protected final void initialize() throws MojoExecutionException {
+    protected final void initialize()  {
         final MavenProject currentProject = mavenSession.getCurrentProject();
         if (hasMicronautMavenPlugin(currentProject)) {
             runnableProject = currentProject;
@@ -296,8 +300,8 @@ public class RunMojo extends AbstractTestResourcesMojo {
                 runnableProject = projectsWithPlugin.get(0);
                 log.info("Running project %s".formatted(runnableProject.getArtifactId()));
             } else  {
-                throw new MojoExecutionException("%s is declared in the following projects: %s. Please specify the project to run with the -pl option."
-                        .formatted(THIS_PLUGIN, projectsWithPlugin.stream().map(MavenProject::getArtifactId).toList()));
+                throw new IllegalStateException("The Micronaut Maven Plugin is declared in the following projects: %s. Please specify the project to run with the -pl option."
+                        .formatted(projectsWithPlugin.stream().map(MavenProject::getArtifactId).toList()));
             }
         }
         this.targetDirectory = new File(runnableProject.getBuild().getDirectory());

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -323,6 +323,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
         // watch pom.xml file changes
         mavenSession.getAllProjects()
             .stream()
+            .filter(this::isDependencyOfRunnableProject)
             .map(MavenProject::getBasedir)
             .map(File::toPath)
             .forEach(path -> {
@@ -334,6 +335,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
         // Add the default watch paths
         mavenSession.getAllProjects()
             .stream()
+            .filter(this::isDependencyOfRunnableProject)
             .flatMap(p -> {
                 var basedir = p.getBasedir().toPath();
                 return RELEVANT_SRC_DIRS.stream().map(dir -> basedir.resolve("src/main/" + dir));
@@ -344,6 +346,11 @@ public class RunMojo extends AbstractTestResourcesMojo {
                 fileSet.addInclude("**/*");
                 watches.add(fileSet);
             });
+    }
+
+    private boolean isDependencyOfRunnableProject(MavenProject mavenProject) {
+        return mavenProject.equals(runnableProject) || runnableProject.getDependencies().stream()
+            .anyMatch(d -> d.getGroupId().equals(mavenProject.getGroupId()) && d.getArtifactId().equals(mavenProject.getArtifactId()));
     }
 
     protected final void setWatches(List<FileSet> watches) {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.micronaut.maven.MojoUtils.findJavaExecutable;
+import static io.micronaut.maven.MojoUtils.hasMicronautMavenPlugin;
 import static java.nio.file.Files.isDirectory;
 import static java.nio.file.Files.isReadable;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
@@ -105,13 +106,13 @@ public class RunMojo extends AbstractTestResourcesMojo {
     /**
      * The project's target directory.
      */
-    private final File targetDirectory;
+    private File targetDirectory;
 
     /**
      * The main class of the application, as defined in the
      * <a href="https://www.mojohaus.org/exec-maven-plugin/java-mojo.html#mainClass">Exec Maven Plugin</a>.
      */
-    @Parameter(defaultValue = EXEC_MAIN_CLASS, required = true)
+    @Parameter(defaultValue = EXEC_MAIN_CLASS)
     private String mainClass;
 
     /**
@@ -211,7 +212,6 @@ public class RunMojo extends AbstractTestResourcesMojo {
                    CompilerService compilerService,
                    ExecutorService executorService,
                    DependencyResolutionService dependencyResolutionService) {
-        this.runnableProject = compilerService.findRunnableProject();
         this.mavenSession = mavenSession;
         this.projectBuilder = projectBuilder;
         this.toolchainManager = toolchainManager;
@@ -219,26 +219,10 @@ public class RunMojo extends AbstractTestResourcesMojo {
         this.executorService = executorService;
         this.javaExecutable = findJavaExecutable(toolchainManager, mavenSession);
         this.dependencyResolutionService = dependencyResolutionService;
-        this.targetDirectory = new File(runnableProject.getBuild().getDirectory());
     }
 
     @Override
     public void execute() throws MojoExecutionException {
-        testResourcesHelper = new TestResourcesHelper(testResourcesEnabled,
-            shared,
-            buildDirectory,
-            explicitPort,
-            clientTimeout,
-            serverIdleTimeoutMinutes,
-            runnableProject,
-            mavenSession,
-            dependencyResolutionService,
-            toolchainManager,
-            testResourcesVersion,
-            classpathInference,
-            testResourcesDependencies,
-            sharedServerNamespace,
-            debugServer);
         initialize();
 
         try {
@@ -300,7 +284,38 @@ public class RunMojo extends AbstractTestResourcesMojo {
         }
     }
 
-    protected final void initialize() {
+    protected final void initialize() throws MojoExecutionException {
+        final MavenProject currentProject = mavenSession.getCurrentProject();
+        if (hasMicronautMavenPlugin(currentProject)) {
+            runnableProject = currentProject;
+        } else {
+            final List<MavenProject> projectsWithPlugin = mavenSession.getProjects().stream()
+                    .filter(MojoUtils::hasMicronautMavenPlugin)
+                    .toList();
+            if (projectsWithPlugin.size() == 1) {
+                runnableProject = projectsWithPlugin.get(0);
+                log.info("Running project %s".formatted(runnableProject.getArtifactId()));
+            } else  {
+                throw new MojoExecutionException("%s is declared in the following projects: %s. Please specify the project to run with the -pl option."
+                        .formatted(THIS_PLUGIN, projectsWithPlugin.stream().map(MavenProject::getArtifactId).toList()));
+            }
+        }
+        this.targetDirectory = new File(runnableProject.getBuild().getDirectory());
+        this.testResourcesHelper = new TestResourcesHelper(testResourcesEnabled,
+                shared,
+                buildDirectory,
+                explicitPort,
+                clientTimeout,
+                serverIdleTimeoutMinutes,
+                runnableProject,
+                mavenSession,
+                dependencyResolutionService,
+                toolchainManager,
+                testResourcesVersion,
+                classpathInference,
+                testResourcesDependencies,
+                sharedServerNamespace,
+                debugServer);
         resolveDependencies();
         if (watches == null) {
             watches = new ArrayList<>();
@@ -462,7 +477,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
 
     private boolean resolveDependencies() {
         try {
-            List<Dependency> dependencies = compilerService.resolveDependencies(JavaScopes.PROVIDED, JavaScopes.COMPILE, JavaScopes.RUNTIME);
+            List<Dependency> dependencies = compilerService.resolveDependencies(runnableProject, JavaScopes.PROVIDED, JavaScopes.COMPILE, JavaScopes.RUNTIME);
             if (dependencies.isEmpty()) {
                 return false;
             } else {
@@ -522,6 +537,10 @@ public class RunMojo extends AbstractTestResourcesMojo {
 
             if (!mavenSession.getUserProperties().isEmpty()) {
                 mavenSession.getUserProperties().forEach((k, v) -> args.add("-D" + k + "=" + v));
+            }
+
+            if (mainClass == null) {
+                mainClass = runnableProject.getProperties().getProperty("exec.mainClass");
             }
 
             args.add("-classpath");

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotCliMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotCliMojo.java
@@ -168,7 +168,7 @@ public abstract class AbstractMicronautAotCliMojo extends AbstractMicronautAotMo
         String projectJar = new File(mavenProject.getBuild().getDirectory(), mavenProject.getBuild().getFinalName() + ".jar").getAbsolutePath();
         List<String> result = new ArrayList<>();
         result.add(projectJar);
-        String classpath = compilerService.buildClasspath(compilerService.resolveDependencies(JavaScopes.RUNTIME));
+        String classpath = compilerService.buildClasspath(compilerService.resolveDependencies(mavenProject, JavaScopes.RUNTIME));
         result.addAll(Arrays.asList(classpath.split(File.pathSeparator)));
         return result;
     }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/services/CompilerService.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/services/CompilerService.java
@@ -33,15 +33,10 @@ import org.eclipse.aether.util.filter.DependencyFilterUtils;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -56,12 +51,8 @@ public class CompilerService {
     public static final String MAVEN_JAR_PLUGIN = "org.apache.maven.plugins:maven-jar-plugin";
 
     private static final String COMPILE_GOAL = "compile";
-    private static final String JAVA = "java";
-    private static final String GROOVY = "groovy";
-    private static final String KOTLIN = "kotlin";
 
     private final Log log;
-    private final MavenProject runnableProject;
     private final MavenSession mavenSession;
     private final ExecutorService executorService;
     private final ProjectDependenciesResolver resolver;
@@ -71,7 +62,6 @@ public class CompilerService {
     public CompilerService(MavenSession mavenSession, ExecutorService executorService,
                            ProjectDependenciesResolver resolver) {
         this.mavenSession = mavenSession;
-        this.runnableProject = findRunnableProject();
         this.resolver = resolver;
         this.log = new SystemStreamLog();
         this.executorService = executorService;
@@ -98,67 +88,13 @@ public class CompilerService {
     }
 
     /**
-     * Resolves the source directories by checking the existence of Java, Groovy or Kotlin sources.
-     *
-     * @return a map with the language as key and the source directory as value.
-     */
-    public List<Path> resolveSourceDirectories() {
-        if (log.isDebugEnabled()) {
-            log.debug("Resolving source directories...");
-        }
-        return mavenSession.getProjects().stream()
-                .map(this::resolveSourceDirectories)
-                .flatMap(Set::stream)
-                .toList();
-    }
-
-    private Set<Path> resolveSourceDirectories(MavenProject project) {
-        Set<Path> sourceDirectoriesToResolve = new HashSet<>(3);
-        for (String lang : Arrays.asList(JAVA, GROOVY, KOTLIN)) {
-            Path sourceDir = project.getBasedir().toPath().resolve("src/main/" + lang);
-            if (Files.exists(sourceDir)) {
-                sourceDirectoriesToResolve.add(sourceDir);
-            }
-        }
-        sourceDirectoriesToResolve.addAll(project.getCompileSourceRoots().stream()
-                .map(File::new)
-                .map(File::toPath)
-                .filter(Files::exists)
-                .collect(Collectors.toSet()));
-        return sourceDirectoriesToResolve;
-    }
-
-    /**
-     * Finds the Maven project that has the Micronaut Maven plugin defined.
-     *
-     * @return the Maven project
-     */
-    public MavenProject findRunnableProject() {
-        return mavenSession.getProjects().stream()
-                .filter(this::hasMicronautMavenPlugin)
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("There are no projects with the Micronaut Maven plugin defined"));
-    }
-
-    private boolean hasMicronautMavenPlugin(MavenProject project) {
-        return hasPlugin(project, "io.micronaut.maven:micronaut-maven-plugin");
-    }
-
-    private boolean hasPlugin(MavenProject project, String pluginKey) {
-        String[] parts = pluginKey.split(":");
-        String groupId = parts[0];
-        String artifactId = parts[1];
-        return project.getBuildPlugins().stream()
-                .anyMatch(p -> p.getGroupId().equals(groupId) && p.getArtifactId().equals(artifactId));
-    }
-
-    /**
      * Resolves project dependencies for the given scopes.
      *
+     * @param runnableProject the project to resolve dependencies for.
      * @param scopes the scopes to resolve dependencies for.
      * @return the list of dependencies.
      */
-    public List<Dependency> resolveDependencies(String... scopes) {
+    public List<Dependency> resolveDependencies(MavenProject runnableProject, String... scopes) {
         try {
             DependencyFilter filter = DependencyFilterUtils.classpathFilter(scopes);
             RepositorySystemSession session = mavenSession.getRepositorySession();

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/FileWatchingTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/FileWatchingTest.java
@@ -7,6 +7,7 @@ import io.micronaut.maven.services.DependencyResolutionService;
 import io.micronaut.maven.services.ExecutorService;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.FileSet;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -215,6 +216,9 @@ class FileWatchingTest {
         var build = mock(Build.class);
         when(build.getDirectory()).thenReturn("target");
         var project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn("io.micronaut.maven");
+        when(project.getArtifactId()).thenReturn(baseDir.getFileName().toString());
+        when(project.getVersion()).thenReturn("1.0.0");
         when(project.getBuild()).thenReturn(build);
         when(project.getBasedir()).thenReturn(baseDir.toFile());
         return project;
@@ -236,6 +240,18 @@ class FileWatchingTest {
         thisPlugin.setArtifactId("micronaut-maven-plugin");
         when(runnableProject.getPlugin(THIS_PLUGIN)).thenReturn(thisPlugin);
         when(runnableProject.getBuildPlugins()).thenReturn(List.of(thisPlugin));
+        var dependencies = modules.stream()
+            .filter(p -> !p.equals(runnableProject))
+            .filter(p -> !p.equals(rootProject))
+            .map(p -> {
+                var dependency = new Dependency();
+                dependency.setGroupId(p.getGroupId());
+                dependency.setArtifactId(p.getArtifactId());
+                dependency.setVersion(p.getVersion());
+                return dependency;
+            })
+            .toList();
+        when(runnableProject.getDependencies()).thenReturn(dependencies);
         when(mavenSession.getProjects()).thenReturn(modules);
         when(mavenSession.getCurrentProject()).thenReturn(runnableProject);
         when(mavenSession.getAllProjects()).thenReturn(

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/FileWatchingTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/FileWatchingTest.java
@@ -11,7 +11,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.FileSet;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.BuildPluginManager;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.toolchain.ToolchainManager;
@@ -42,7 +41,7 @@ class FileWatchingTest {
 
     @Test
     @DisplayName("should detect changes in a single module project")
-    void testFileWatchesSingleProject() throws IOException, MojoExecutionException {
+    void testFileWatchesSingleProject() throws IOException {
         // given:
         var mojo = createMojoForSingleProject();
         var javaSources = tempDir.resolve("src/main/java");
@@ -112,7 +111,7 @@ class FileWatchingTest {
 
     @Test
     @DisplayName("should detect changes in a multi-module project")
-    void testFileWatchesMultiProject() throws IOException, MojoExecutionException {
+    void testFileWatchesMultiProject() throws IOException {
         // given:
         var mojo = createMojoForMultiProject(2, 0);
         var module0 = tempDir.resolve("module0");
@@ -188,7 +187,7 @@ class FileWatchingTest {
 
     }
 
-    private MojoUnderTest createMojoForSingleProject() throws MojoExecutionException {
+    private MojoUnderTest createMojoForSingleProject() {
         var project = newProject(tempDir);
         var compilerService = createCompilerServices();
         var mavenSession = mock(MavenSession.class);
@@ -224,7 +223,7 @@ class FileWatchingTest {
         return project;
     }
 
-    private MojoUnderTest createMojoForMultiProject(int moduleCount, int consideredProject) throws MojoExecutionException {
+    private MojoUnderTest createMojoForMultiProject(int moduleCount, int consideredProject) {
         var rootProject = newProject(tempDir);
         var mavenSession = mock(MavenSession.class);
         when(mavenSession.getTopLevelProject()).thenReturn(rootProject);
@@ -260,7 +259,7 @@ class FileWatchingTest {
         return createMojoUnderTest(mavenSession, compilerService);
     }
 
-    private static MojoUnderTest createMojoUnderTest(MavenSession mavenSession, CompilerService compilerService) throws MojoExecutionException {
+    private static MojoUnderTest createMojoUnderTest(MavenSession mavenSession, CompilerService compilerService) {
         var recompilationCount = new AtomicInteger();
         var mojo = new RunMojo(
             mavenSession,


### PR DESCRIPTION
Previously, in multi-module projects we restricted to only one project to be the runnable project, where the Micronaut Maven Plugin (MMP) is applied.

However, there are valid use cases where the MMP can be applied to multiple submodules.

This PR fixes the behaviour, allowing to:
* Run `mn:run` on the root module, when only one submodule has the MMP. This fixes #1169.
* Run `mn:run -pl xxx` when more than one submodule has the MMP. Fixes #1108 
* Fail when `mn:run` is executed from the root and more than one submodule has the MMP.
