### PR TITLE
Remove excessive Test Resources output

### DIFF
--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-dependency/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-dependency/verify.groovy
@@ -2,7 +2,6 @@ File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
 assert log.text.contains("Starting Micronaut Test Resources service") : "Test Resources service was not started"
-assert log.text.contains("Shutting down Micronaut Test Resources service") : "Test Resources service was not shutdown"
 assert !log.text.contains("Test Resources is configured in shared mode") : "Test Resources was configured in shared mode"
 
 String port = new File(basedir, "target/test-resources-port.txt").text

--- a/micronaut-maven-integration-tests/src/it/test-resources-failing-test/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-failing-test/verify.groovy
@@ -2,7 +2,6 @@ File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD FAILURE")
 assert log.text.contains("Starting Micronaut Test Resources service")
-assert log.text.contains("Shutting down Micronaut Test Resources service")
 assert !log.text.contains("Test Resources is configured in shared mode")
 
 String port = new File(basedir, "target/test-resources-port.txt").text

--- a/micronaut-maven-integration-tests/src/it/test-resources-run/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-run/verify.groovy
@@ -2,7 +2,6 @@ File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
 assert log.text.contains("Starting Micronaut Test Resources service") : "Test Resources service was not started"
-assert log.text.contains("Shutting down Micronaut Test Resources service") : "Test Resources service was not shutdown"
 assert log.text.contains("Container postgres:latest started") : "postgres container was not started"
 assert log.text.contains("Startup completed in") : "Startup was not completed"
 

--- a/micronaut-maven-integration-tests/src/it/test-resources-shared-namespace/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-shared-namespace/verify.groovy
@@ -3,7 +3,6 @@ assert log.exists()
 assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
 assert log.text.contains("Test Resources is configured in shared mode with the namespace: my-namespace") : "Test Resources was not configured in shared mode"
 assert log.text.contains("Starting Micronaut Test Resources service") : "Test Resources service was not started"
-assert log.text.contains("Shutting down Micronaut Test Resources service") : "Test Resources service was not shutdown"
 
 String port = new File(basedir, "target/test-resources-port.txt").text
 try (ServerSocket s = new ServerSocket(port as int)) {

--- a/micronaut-maven-integration-tests/src/it/test-resources-shared/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-shared/verify.groovy
@@ -3,7 +3,6 @@ assert log.exists()
 assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
 assert log.text.contains("Test Resources is configured in shared mode") : "Test Resources was not configured in shared mode"
 assert log.text.contains("Starting Micronaut Test Resources service") : "Test Resources service was not started"
-assert log.text.contains("Shutting down Micronaut Test Resources service") : "Test Resources service was not shutdown"
 
 String port = new File(basedir, "target/test-resources-port.txt").text
 try (ServerSocket s = new ServerSocket(port as int)) {

--- a/micronaut-maven-integration-tests/src/it/test-resources-start-stop/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-start-stop/verify.groovy
@@ -4,7 +4,6 @@ assert log.text.contains("BUILD SUCCESS")
 
 String port = new File(basedir, "target/test-resources-port.txt").text
 assert log.text.contains("Test resources service already started on port " + port)
-assert log.text.contains("Shutting down Micronaut Test Resources service")
 
 try (ServerSocket s = new ServerSocket(port as int)) {
     assert s != null

--- a/micronaut-maven-integration-tests/src/it/test-resources-start-stop/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-start-stop/verify.groovy
@@ -3,7 +3,6 @@ assert log.exists()
 assert log.text.contains("BUILD SUCCESS")
 
 String port = new File(basedir, "target/test-resources-port.txt").text
-assert log.text.contains("Test resources service already started on port " + port)
 
 try (ServerSocket s = new ServerSocket(port as int)) {
     assert s != null

--- a/micronaut-maven-integration-tests/src/it/test-resources/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources/verify.groovy
@@ -2,7 +2,6 @@ File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
 assert log.text.contains("Starting Micronaut Test Resources service") : "Test Resources service was not started"
-assert log.text.contains("Shutting down Micronaut Test Resources service") : "Test Resources service was not shutdown"
 assert !log.text.contains("Test Resources is configured in shared mode") : "Test Resources was configured in shared mode"
 
 String port = new File(basedir, "target/test-resources-port.txt").text

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -594,7 +594,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
     }
 
     private void maybeStopTestResourcesServer() throws MojoExecutionException {
-        testResourcesHelper.stop();
+        testResourcesHelper.stop(false);
     }
 
     private boolean compileProject() {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StopTestResourcesServerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StopTestResourcesServerMojo.java
@@ -58,7 +58,7 @@ public class StopTestResourcesServerMojo extends AbstractTestResourcesMojo {
                 dependencyResolutionService, toolchainManager, testResourcesVersion,
                 classpathInference, testResourcesDependencies, sharedServerNamespace,
                 debugServer);
-        helper.stop();
+        helper.stop(false);
     }
 
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
@@ -107,7 +107,7 @@ public class TestResourcesLifecycleExtension extends AbstractMavenLifecycleParti
                         helper.setSharedServerNamespace(sharedServerNamespace);
                     }
                     try {
-                        helper.stop();
+                        helper.stop(true);
                     } catch (Exception e) {
                         logger.error(e.getMessage(), e);
                     }


### PR DESCRIPTION
In multi-project builds, it would output something like:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16:32 min
[INFO] Finished at: 2024-08-02T09:55:15Z
[INFO] ------------------------------------------------------------------------
[INFO] Test resources service already started on port 37539
[info] Shutting down Micronaut Test Resources service
[INFO] Test resources service already started on port 42601
[info] Shutting down Micronaut Test Resources service
[INFO] Test resources service already started on port 43231
[info] Shutting down Micronaut Test Resources service
[INFO] Test resources service already started on port 42693
[info] Shutting down Micronaut Test Resources service
```

This PR removes the excessive Test Resources output at the end of the build