### PR TITLE
Fix reloading of submodules

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/services/ExecutorService.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/services/ExecutorService.java
@@ -142,8 +142,21 @@ public class ExecutorService {
      * @throws MavenInvocationException If the goal execution fails
      */
     public InvocationResult invokeGoals(String... goals) throws MavenInvocationException {
+        return invokeGoals(mavenProject, goals);
+    }
+
+    /**
+     * Executes a goal using the Maven shared invoker.
+     *
+     * @param project The Maven project
+     * @param goals The goals to execute
+     * @return The result of the invocation
+     * @throws MavenInvocationException If the goal execution fails
+     */
+
+    public InvocationResult invokeGoals(MavenProject project, String... goals) throws MavenInvocationException {
         var request = new DefaultInvocationRequest();
-        request.setPomFile(mavenProject.getFile());
+        request.setPomFile(project.getFile());
         File settingsFile = mavenSession.getRequest().getUserSettingsFile();
         if (settingsFile.exists()) {
             request.setUserSettingsFile(settingsFile);
@@ -155,6 +168,7 @@ public class ExecutorService {
         request.addArgs(Arrays.asList(goals));
         request.setBatchMode(true);
         request.setQuiet(true);
+        request.setAlsoMake(true);
         request.setErrorHandler(LOG::error);
         request.setOutputHandler(LOG::info);
         request.setProperties(properties);


### PR DESCRIPTION
Reloading changes in submodules was broken. Changes were detected and application was restarted, but with no effect.

This PR correctly computes the classpath of the runnable application by using target/classes of all projects in the session, and effectively recompiles the whole project upon changes (note that Maven Compiler Plugin itslef  will only compile what really changed)