### PR TITLE
Allow excluding dependencies from AOT processing classpath

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -479,7 +479,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
 
     private boolean resolveDependencies() {
         try {
-            List<Dependency> dependencies = compilerService.resolveDependencies(runnableProject, JavaScopes.PROVIDED, JavaScopes.COMPILE, JavaScopes.RUNTIME);
+            List<Dependency> dependencies = compilerService.resolveDependencies(runnableProject, true, JavaScopes.PROVIDED, JavaScopes.COMPILE, JavaScopes.RUNTIME);
             if (dependencies.isEmpty()) {
                 return false;
             } else {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotCliMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotCliMojo.java
@@ -186,7 +186,9 @@ public abstract class AbstractMicronautAotCliMojo extends AbstractMicronautAotMo
             .getAbsolutePath();
         var result = new ArrayList<String>();
         result.add(projectJar);
-        String classpath = compilerService.buildClasspath(compilerService.resolveDependencies(mavenProject, JavaScopes.RUNTIME));
+        String classpath = compilerService.buildClasspath(compilerService.resolveDependencies(mavenProject, JavaScopes.RUNTIME)
+                .stream().filter(dep -> this.isDependencyIncluded(dep.getArtifact())).toList()
+        );
         result.addAll(Arrays.asList(classpath.split(File.pathSeparator)));
         return result;
     }
@@ -194,17 +196,29 @@ public abstract class AbstractMicronautAotCliMojo extends AbstractMicronautAotMo
     private List<String> resolveAotClasspath() throws DependencyResolutionException {
         Stream<Artifact> aotArtifacts = Arrays.stream(AOT_MODULES)
             .map(m -> new DefaultArtifact(MICRONAUT_AOT_GROUP_ID + ":" + MICRONAUT_AOT_ARTIFACT_ID_PREFIX + m + ":" + micronautAotVersion));
-        return toClasspath(dependencyResolutionService.artifactResultsFor(aotArtifacts, false));
+        return toClasspath(dependencyResolutionService.artifactResultsFor(aotArtifacts, false)
+                .stream().filter(r -> this.isDependencyIncluded(r.getArtifact())).toList()
+        );
     }
 
     private List<String> resolveAotPluginsClasspath() throws DependencyResolutionException {
         if (aotDependencies != null && !aotDependencies.isEmpty()) {
             Stream<Artifact> aotPlugins = aotDependencies.stream()
                 .map(d -> new DefaultArtifact(d.getGroupId(), d.getArtifactId(), d.getType(), d.getVersion()));
-            return toClasspath(dependencyResolutionService.artifactResultsFor(aotPlugins, false));
+            return toClasspath(dependencyResolutionService.artifactResultsFor(aotPlugins, false)
+                    .stream().filter(r -> this.isDependencyIncluded(r.getArtifact())).toList()
+            );
         } else {
             return Collections.emptyList();
         }
+    }
+
+    private boolean isDependencyIncluded(Artifact dependency) {
+        if (aotExclusions == null) {
+            return true;
+        }
+        return aotExclusions.stream()
+                .noneMatch(e -> e.getGroupId().equals(dependency.getGroupId()) && e.getArtifactId().equals(dependency.getArtifactId()));
     }
 
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotCliMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotCliMojo.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.maven.aot;
 
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.maven.MojoUtils;
 import io.micronaut.maven.services.CompilerService;
 import io.micronaut.maven.services.DependencyResolutionService;
@@ -158,6 +159,13 @@ public abstract class AbstractMicronautAotCliMojo extends AbstractMicronautAotMo
         classpath.addAll(aotClasspath);
         classpath.addAll(aotPluginsClasspath);
         classpath.addAll(applicationClasspath);
+
+        if (!CollectionUtils.isEmpty(aotExclusions)) {
+            getLog().info("Using exclusions for the AOT classpath: " +
+                    aotExclusions.stream().map(v -> v.getGroupId() + ":" + v.getArtifactId()).collect(Collectors.joining(", ")));
+            getLog().info("Resulting AOT classpath: " + String.join(", ", classpath));
+        }
+
         Stream<String> jvmArgs = Optional.ofNullable(aotJvmArgs).orElse(List.of()).stream();
         Stream<String> mainArgs = Stream.of(
             "-classpath",

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotMojo.java
@@ -19,6 +19,7 @@ import io.micronaut.maven.AbstractMicronautMojo;
 import io.micronaut.maven.Packaging;
 import io.micronaut.maven.services.CompilerService;
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Exclusion;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -26,6 +27,7 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Abstract Mojo for Micronaut AOT.
@@ -59,6 +61,12 @@ public abstract class AbstractMicronautAotMojo extends AbstractMicronautMojo {
      */
     @Parameter(defaultValue = "${project.build.outputDirectory}", required = true)
     protected File outputDirectory;
+
+    /**
+     * Packages that would be excluded from the AOT processing.
+     */
+    @Parameter(property = "exclusions")
+    protected List<Exclusion> aotExclusions;
 
     public AbstractMicronautAotMojo(CompilerService compilerService, MavenProject mavenProject) {
         this.compilerService = compilerService;

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AbstractMicronautAotMojo.java
@@ -64,6 +64,7 @@ public abstract class AbstractMicronautAotMojo extends AbstractMicronautMojo {
 
     /**
      * Packages that would be excluded from the AOT processing.
+     * @since 4.11.0
      */
     @Parameter(property = "exclusions")
     protected List<Exclusion> aotExclusions;

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/services/CompilerService.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/services/CompilerService.java
@@ -95,18 +95,30 @@ public class CompilerService {
     }
 
     /**
+     * Resolves project dependencies for given scopes.
+     *
+     * @param runnableProject The project
+     * @param scopes The scopes
+     * @return The dependencies
+     */
+    public List<Dependency> resolveDependencies(MavenProject runnableProject, String... scopes) {
+        return resolveDependencies(runnableProject, false, scopes);
+    }
+
+    /**
      * Resolves project dependencies for the given scopes.
      *
      * @param runnableProject the project to resolve dependencies for.
+     * @param excludeProjects Whether to exclude projects (of this build) from the dependencies.
      * @param scopes the scopes to resolve dependencies for.
      * @return the list of dependencies.
      */
-    public List<Dependency> resolveDependencies(MavenProject runnableProject, String... scopes) {
+    public List<Dependency> resolveDependencies(MavenProject runnableProject, boolean excludeProjects, String... scopes) {
         try {
-            DependencyFilter filter = DependencyFilterUtils.andFilter(
-                    DependencyFilterUtils.classpathFilter(scopes),
-                    new ReactorProjectsFilter(mavenSession.getAllProjects())
-            );
+            DependencyFilter filter = DependencyFilterUtils.classpathFilter(scopes);
+            if (excludeProjects) {
+                DependencyFilterUtils.andFilter(filter, new ReactorProjectsFilter(mavenSession.getAllProjects()));
+            }
             RepositorySystemSession session = mavenSession.getRepositorySession();
             DependencyResolutionRequest dependencyResolutionRequest = new DefaultDependencyResolutionRequest(runnableProject, session);
             dependencyResolutionRequest.setResolutionFilter(filter);

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/aot.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/aot.adoc
@@ -88,3 +88,32 @@ Then, copy the `target/aot/jit/aot.properties` to your root directory, and adapt
 directory, use the `micronaut.aot.config` property to specify its location.
 
 For a full list of configuration options, check the link:../aot-analysis-mojo.html[`aot-analysis` goal documentation].
+
+==== Excluding dependencies
+
+If you want to exclude a dependency from AOT processing, use the `aotExclusions` configuration property.
+For example, to exclude `com.example:example` use the following configuration:
+
+[source,xml]
+----
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <configuration>
+          <aotExclusions>
+            <exclusion>
+              <groupId>com.example</groupId>
+              <artifactId>example</artifactId>
+            </exclusion>
+          </aotExclusions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+----
+
+NOTE: It is recommended to add AOT exclusions if you are building native imagen and have
+exclusions in the `native-maven-plugin`.
+


### PR DESCRIPTION
This allows excluding dependencies from AOT processing, for example:

```xml
<aotExcludes>
  <aotExclude>
    <groupId>com.example</groupId>
    <artifactId>example</artifactId>
  </aotExclude>
</aotExcludes>
```

This matches a similar issue for native-maven-plugin: https://github.com/graalvm/native-build-tools/pull/684.
Since aot is compatible with native image, the same excludes might need to be applied for correct application.