### PR TITLE
stop-testresources-service should only fail the build if invoked directly

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -586,11 +586,11 @@ public class RunMojo extends AbstractTestResourcesMojo {
     }
 
     private void maybeStartTestResourcesServer() throws MojoExecutionException {
-        testResourcesHelper.start();
+        testResourcesHelper.start(false);
     }
 
     private void maybeStopTestResourcesServer() throws MojoExecutionException {
-        testResourcesHelper.stop(false);
+        testResourcesHelper.stop(true);
     }
 
     private boolean compileProject() {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -586,7 +586,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
     }
 
     private void maybeStartTestResourcesServer() throws MojoExecutionException {
-        testResourcesHelper.start(false);
+        testResourcesHelper.start();
     }
 
     private void maybeStopTestResourcesServer() throws MojoExecutionException {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
@@ -68,7 +68,7 @@ public class StartTestResourcesServerMojo extends AbstractTestResourcesMojo {
                 serverIdleTimeoutMinutes, mavenProject, mavenSession, dependencyResolutionService, toolchainManager,
                 testResourcesVersion, classpathInference, testResourcesDependencies, sharedServerNamespace, debugServer,
                 foreground, testResourcesSystemProperties);
-        helper.start();
+        helper.start(true);
 
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
@@ -68,7 +68,7 @@ public class StartTestResourcesServerMojo extends AbstractTestResourcesMojo {
                 serverIdleTimeoutMinutes, mavenProject, mavenSession, dependencyResolutionService, toolchainManager,
                 testResourcesVersion, classpathInference, testResourcesDependencies, sharedServerNamespace, debugServer,
                 foreground, testResourcesSystemProperties);
-        helper.start(true);
+        helper.start();
 
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -153,16 +153,22 @@ public class TestResourcesHelper {
     }
 
     /**
-     * Starts the Test Resources Service.
+     * Starts the Test Resources Service. If the service is not enabled, this method does nothing.
+     *
+     * @param shouldFailBuild whether to throw a MojoExecutionException if there's an error starting the service.
+     *                        If false, the error will be swallowed and the method will return normally.
+     * @throws MojoExecutionException if there's an error starting the service and shouldFailBuild is true
      */
-    public void start() throws MojoExecutionException {
+    public void start(boolean shouldFailBuild) throws MojoExecutionException {
         if (!enabled) {
             return;
         }
         try {
             doStart();
         } catch (Exception e) {
-            throw new MojoExecutionException("Unable to start test resources server", e);
+            if (shouldFailBuild) {
+                throw new MojoExecutionException("Unable to start test resources server", e);
+            }
         }
     }
 
@@ -319,7 +325,12 @@ public class TestResourcesHelper {
                 }
             }
         } catch (Exception e) {
-            throw new MojoExecutionException("Unable to stop test resources server", e);
+            var message = "Unable to stop test resources server";
+            if (quiet) {
+                log.warn(message, e);
+            } else {
+                throw new MojoExecutionException(message, e);
+            }
         }
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -153,22 +153,16 @@ public class TestResourcesHelper {
     }
 
     /**
-     * Starts the Test Resources Service. If the service is not enabled, this method does nothing.
-     *
-     * @param shouldFailBuild whether to throw a MojoExecutionException if there's an error starting the service.
-     *                        If false, the error will be swallowed and the method will return normally.
-     * @throws MojoExecutionException if there's an error starting the service and shouldFailBuild is true
+     * Starts the Test Resources Service.
      */
-    public void start(boolean shouldFailBuild) throws MojoExecutionException {
+    public void start() throws MojoExecutionException {
         if (!enabled) {
             return;
         }
         try {
             doStart();
         } catch (Exception e) {
-            if (shouldFailBuild) {
-                throw new MojoExecutionException("Unable to start test resources server", e);
-            }
+            throw new MojoExecutionException("Unable to start test resources server", e);
         }
     }
 


### PR DESCRIPTION
When attempting start/stop of the Test Resources Service as part of `mn:run`, a failure instopping the service should be warned, but should not prevent the application from running

Fixes #1466