### PR TITLE
Restrict StartTestResourcesServerMojo to skip only on integration test skipping

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StartTestResourcesServerMojo.java
@@ -60,7 +60,7 @@ public class StartTestResourcesServerMojo extends AbstractTestResourcesMojo {
     public final void execute() throws MojoExecutionException {
         // Skip starting test resources if tests are being skipped
         if (isTestExecutionSkipped()) {
-            getLog().debug("Skipping test resources service start because test execution is disabled");
+            getLog().warn("Skipping Test Resources service start because integration test execution is disabled with skipITs");
             return;
         }
         
@@ -73,7 +73,7 @@ public class StartTestResourcesServerMojo extends AbstractTestResourcesMojo {
     }
 
     /**
-     * Checks whether test execution is skipped using either skipTests, maven.test.skip, or skipITs properties.
+     * Checks whether integration test execution is skipped using skipITs properties.
      *
      * @return true if tests are being skipped, false otherwise
      */
@@ -83,9 +83,7 @@ public class StartTestResourcesServerMojo extends AbstractTestResourcesMojo {
             var evaluator = new PluginParameterExpressionEvaluator(mavenSession, execution);
             
             // Check skip properties (from maven-surefire-plugin, maven-compiler-plugin, and maven-failsafe-plugin)
-            return isPropertyTrue(evaluator, "skipTests") ||
-                   isPropertyTrue(evaluator, "maven.test.skip") ||
-                   isPropertyTrue(evaluator, "skipITs");
+            return isPropertyTrue(evaluator, "skipITs");
             
         } catch (ExpressionEvaluationException e) {
             getLog().debug("Could not evaluate test skip properties: " + e.getMessage());

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/StartTestResourcesServerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/StartTestResourcesServerMojoTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Unit test for StartTestResourcesServerMojo to verify skipTests functionality.
+ * Unit test for StartTestResourcesServerMojo.
  */
 class StartTestResourcesServerMojoTest {
 
@@ -50,19 +50,18 @@ class StartTestResourcesServerMojoTest {
         when(mavenSession.getSystemProperties()).thenReturn(new Properties());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"skipTests", "maven.test.skip", "skipITs"})
-    void shouldSkipWhenSkipPropertyIsTrue(String skipProperty) {
+    @Test
+    void shouldSkipWhenSkipPropertyIsTrue() {
         // Given
         Properties userProps = new Properties();
-        userProps.setProperty(skipProperty, "true");
+        userProps.setProperty("skipITs", "true");
         when(mavenSession.getUserProperties()).thenReturn(userProps);
 
         // When
         boolean result = mojo.isTestExecutionSkipped();
 
         // Then
-        assertTrue(result, "Should skip when " + skipProperty + " is true");
+        assertTrue(result, "Should skip when skipITs is true");
     }
 
     @Test
@@ -77,11 +76,9 @@ class StartTestResourcesServerMojoTest {
     }
 
     @Test
-    void shouldNotSkipWhenSkipPropertiesAreFalse() {
+    void shouldNotSkipWhenSkipPropertyIsFalse() {
         // Given
         Properties userProps = new Properties();
-        userProps.setProperty("skipTests", "false");
-        userProps.setProperty("maven.test.skip", "false");
         userProps.setProperty("skipITs", "false");
         when(mavenSession.getUserProperties()).thenReturn(userProps);
 


### PR DESCRIPTION
- Change isTestExecutionSkipped() to only check skipITs property instead of skipTests, maven.test.skip, and skipITs
- Update debug log to warn level with clearer message about integration test skipping
- Update JavaDoc and tests to reflect the more specific integration test focus