### PR TITLE
`stop-testresources-service` should never fail the build

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: "🔎 Run static analysis"
         if: env.SONAR_TOKEN != '' && matrix.java == '17'
-        run: ./mvnw sonar:sonar
+        run: ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -590,7 +590,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
     }
 
     private void maybeStopTestResourcesServer() throws MojoExecutionException {
-        testResourcesHelper.stop(true);
+        testResourcesHelper.stop();
     }
 
     private boolean compileProject() {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StopTestResourcesServerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/StopTestResourcesServerMojo.java
@@ -57,7 +57,7 @@ public class StopTestResourcesServerMojo extends AbstractTestResourcesMojo {
                 serverIdleTimeoutMinutes, mavenProject, mavenSession, dependencyResolutionService, toolchainManager,
                 testResourcesVersion, classpathInference, testResourcesDependencies, sharedServerNamespace, debugServer,
                 foreground, testResourcesSystemProperties);
-        helper.stop(false);
+        helper.stop();
     }
 
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -292,25 +292,23 @@ public class TestResourcesHelper {
 
     /**
      * Contains the logic to stop the Test Resources Service.
-     *
-     * @param quiet Whether to perform logging or not.
      */
-    public void stop(boolean quiet) throws MojoExecutionException {
+    public void stop() throws MojoExecutionException {
         if (!enabled) {
             return;
         }
         if (isKeepAlive()) {
-            log("Keeping Micronaut Test Resources service alive", quiet);
+            log.info("Keeping Micronaut Test Resources service alive");
             return;
         }
         try {
             Optional<ServerSettings> optionalServerSettings = ServerUtils.readServerSettings(getServerSettingsDirectory());
             if (optionalServerSettings.isPresent()) {
                 if (isServerStarted(optionalServerSettings.get().getPort())) {
-                    log("Shutting down Micronaut Test Resources service", quiet);
+                    log.info("Shutting down Micronaut Test Resources service");
                     doStop();
                 } else {
-                    log("Cannot find Micronaut Test Resources service settings, server may already be shutdown", quiet);
+                    log.info("Cannot find Micronaut Test Resources service settings, server may already be shutdown");
                     Files.deleteIfExists(getServerSettingsDirectory().resolve(PROPERTIES_FILE_NAME));
                 }
                 if (shared && sharedServerNamespace != null) {
@@ -319,12 +317,7 @@ public class TestResourcesHelper {
                 }
             }
         } catch (Exception e) {
-            var message = "Unable to stop test resources server";
-            if (quiet) {
-                log.warn(message, e);
-            } else {
-                throw new MojoExecutionException(message, e);
-            }
+            log.error("Unable to stop test resources server", e);
         }
     }
 
@@ -333,16 +326,6 @@ public class TestResourcesHelper {
             return Boolean.getBoolean("test.resources.internal.server.started");
         } else {
             return !SocketUtils.isTcpPortAvailable(port);
-        }
-    }
-
-    private void log(String message, boolean quiet) {
-        if (quiet) {
-            if (log.isDebugEnabled()) {
-                log.debug(message);
-            }
-        } else {
-            log.info(message);
         }
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesLifecycleExtension.java
@@ -105,7 +105,7 @@ public class TestResourcesLifecycleExtension extends AbstractMavenLifecycleParti
                         helper.setSharedServerNamespace(sharedServerNamespace);
                     }
                     try {
-                        helper.stop(true);
+                        helper.stop();
                     } catch (Exception e) {
                         logger.error(e.getMessage(), e);
                     }


### PR DESCRIPTION
In #1473 the intention was to only fail the build if the user invoked `mvn mn:stop-testresources-service`. This would prevent executions like `mvn mn:run` to fail the build if the Test Resources service was unresponsive.

The problem is that there are more executions that aren't really direct invocations. When the user invokes `mvn test`, the lifecycle is surrounded by a `start-testresources-service` before and a `stop-testresources-service` after. And there is no reliable way to differentiate them from a direct invocation.

Thinking about it, stopping the test resources service is a cleanup operation that is nice to have, but not a must. With this PR, the user will get a clear error message but the build will continue. If another execution is invoked afterwards, the client won't be able to connect to the unresponsive server and a new one will be started. And the unresponsive one should eventually die.