### PR TITLE
Remove an unnecessary initial compilation

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -339,8 +339,6 @@ public class RunMojo extends AbstractTestResourcesMojo {
                 fileSet.addInclude("**/*");
                 watches.add(fileSet);
             });
-
-        compileProject();
     }
 
     private boolean isDependencyOfRunnableProject(MavenProject mavenProject) {


### PR DESCRIPTION
When `mn:run` is invoked, the `process-classes` lifecycle phase is forked, and this phase is the one after `compile`, so no need to invoke compile again.

This behaviour was added in #1330, probably by mistake. Recompilation upon watch events is handled separately, and that code path does recompile the project.