### PR TITLE
Add enforcer rule for mixed Micronaut major versions

### DIFF
--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionAnalysis.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionAnalysis.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.compat;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+public record MicronautMajorVersionAnalysis(
+    List<MicronautMajorVersionCoordinate> coordinates,
+    OptionalInt baselineMajor,
+    List<MicronautMajorVersionCoordinate> conflicts
+) {
+    public boolean hasConflict() {
+        return !conflicts.isEmpty();
+    }
+}

--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
@@ -54,8 +54,8 @@ public final class MicronautMajorVersionChecker {
     ) {
         return Stream.of(
                 collectMicronautParent(parent),
-                collectDirectCompatibilitySignals(dependencies, "dependency"),
-                collectDirectCompatibilitySignals(dependencyManagementDependencies, "dependencyManagement")
+                collectLifecycleBaselineSignals(dependencyManagementDependencies),
+                collectDirectCompatibilitySignals(dependencies, "dependency")
             )
             .flatMap(List::stream)
             .filter(coordinate -> coordinate.majorVersion().isPresent())
@@ -65,7 +65,7 @@ public final class MicronautMajorVersionChecker {
 
     public MicronautMajorVersionAnalysis analyzeForLifecycle(List<MicronautMajorVersionCoordinate> coordinates) {
         OptionalInt baselineMajor = coordinates.stream()
-            .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
+            .filter(this::isMicronautBaselineCoordinate)
             .map(MicronautMajorVersionCoordinate::majorVersion)
             .filter(OptionalInt::isPresent)
             .mapToInt(OptionalInt::getAsInt)
@@ -134,7 +134,7 @@ public final class MicronautMajorVersionChecker {
         int baselineMajor = analysis.baselineMajor().orElseThrow();
         String baseline = analysis.coordinates().stream()
             .filter(coordinate -> coordinate.majorVersion().isPresent() && coordinate.majorVersion().getAsInt() == baselineMajor)
-            .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
+            .filter(this::isMicronautBaselineCoordinate)
             .findFirst()
             .map(coordinate -> coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
             .orElse("major " + baselineMajor);
@@ -178,6 +178,20 @@ public final class MicronautMajorVersionChecker {
             .toList();
     }
 
+    public List<MicronautMajorVersionCoordinate> collectLifecycleBaselineSignals(List<Dependency> dependencies) {
+        return dependencies.stream()
+            .filter(Objects::nonNull)
+            .filter(this::isLifecycleBaselineSignal)
+            .map(dependency -> new MicronautMajorVersionCoordinate(
+                dependency.getGroupId(),
+                dependency.getArtifactId(),
+                dependency.getVersion(),
+                "dependencyManagement",
+                parseMajorVersion(dependency.getVersion())
+            ))
+            .toList();
+    }
+
     public List<MicronautMajorVersionCoordinate> collectMicronautParent(Parent parent) {
         if (parent == null || parent.getGroupId() == null || parent.getArtifactId() == null) {
             return List.of();
@@ -192,6 +206,22 @@ public final class MicronautMajorVersionChecker {
             "parent",
             parseMajorVersion(parent.getVersion())
         ));
+    }
+
+    private boolean isLifecycleBaselineSignal(Dependency dependency) {
+        return dependency.getGroupId() != null
+            && dependency.getArtifactId() != null
+            && dependency.getVersion() != null
+            && (("io.micronaut.platform".equals(dependency.getGroupId())
+                && ("micronaut-parent".equals(dependency.getArtifactId()) || "micronaut-platform".equals(dependency.getArtifactId())))
+                || ("io.micronaut".equals(dependency.getGroupId()) && "micronaut-core-bom".equals(dependency.getArtifactId())));
+    }
+
+    private boolean isMicronautBaselineCoordinate(MicronautMajorVersionCoordinate coordinate) {
+        return ("parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
+            && (("io.micronaut.platform".equals(coordinate.groupId())
+                && ("micronaut-parent".equals(coordinate.artifactId()) || "micronaut-platform".equals(coordinate.artifactId())))
+                || ("io.micronaut".equals(coordinate.groupId()) && "micronaut-core-bom".equals(coordinate.artifactId())));
     }
 
     private boolean isMicronautDependency(Dependency dependency) {

--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.compat;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Parent;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class MicronautMajorVersionChecker {
+
+    private static final Pattern LEADING_MAJOR_PATTERN = Pattern.compile("^(\\d+)");
+
+    public List<MicronautMajorVersionCoordinate> collectEnforcerCoordinates(
+        List<Dependency> dependencies,
+        List<Dependency> dependencyManagementDependencies,
+        List<Dependency> annotationProcessorPaths
+    ) {
+        return Stream.of(
+                collectMicronautDependencies(dependencies, "dependency"),
+                collectMicronautDependencies(dependencyManagementDependencies, "dependencyManagement"),
+                collectMicronautDependencies(annotationProcessorPaths, "annotationProcessorPath")
+            )
+            .flatMap(List::stream)
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .distinct()
+            .toList();
+    }
+
+    public List<MicronautMajorVersionCoordinate> collectLifecycleCoordinates(
+        Parent parent,
+        List<Dependency> dependencies,
+        List<Dependency> dependencyManagementDependencies
+    ) {
+        return Stream.of(
+                collectMicronautParent(parent),
+                collectDirectCompatibilitySignals(dependencies, "dependency"),
+                collectDirectCompatibilitySignals(dependencyManagementDependencies, "dependencyManagement")
+            )
+            .flatMap(List::stream)
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .distinct()
+            .toList();
+    }
+
+    public MicronautMajorVersionAnalysis analyzeForLifecycle(List<MicronautMajorVersionCoordinate> coordinates) {
+        OptionalInt baselineMajor = coordinates.stream()
+            .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
+            .map(MicronautMajorVersionCoordinate::majorVersion)
+            .filter(OptionalInt::isPresent)
+            .mapToInt(OptionalInt::getAsInt)
+            .findFirst();
+
+        if (baselineMajor.isEmpty()) {
+            return new MicronautMajorVersionAnalysis(coordinates, OptionalInt.empty(), List.of());
+        }
+
+        List<MicronautMajorVersionCoordinate> conflicts = coordinates.stream()
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .filter(coordinate -> coordinate.majorVersion().getAsInt() != baselineMajor.getAsInt())
+            .sorted(defaultOrdering())
+            .toList();
+
+        return new MicronautMajorVersionAnalysis(coordinates, baselineMajor, conflicts);
+    }
+
+    public boolean hasMixedMajors(List<MicronautMajorVersionCoordinate> coordinates) {
+        return coordinates.stream()
+            .map(MicronautMajorVersionCoordinate::majorVersion)
+            .filter(OptionalInt::isPresent)
+            .mapToInt(OptionalInt::getAsInt)
+            .distinct()
+            .count() > 1;
+    }
+
+    public OptionalInt parseMajorVersion(String version) {
+        if (version == null) {
+            return OptionalInt.empty();
+        }
+        Matcher matcher = LEADING_MAJOR_PATTERN.matcher(version);
+        if (!matcher.find()) {
+            return OptionalInt.empty();
+        }
+        try {
+            return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
+    }
+
+    public String buildEnforcerFailureMessage(List<MicronautMajorVersionCoordinate> coordinates) {
+        String details = coordinates.stream()
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .collect(Collectors.groupingBy(
+                coordinate -> coordinate.majorVersion().orElseThrow(),
+                java.util.LinkedHashMap::new,
+                Collectors.toList()
+            ))
+            .entrySet().stream()
+            .map(entry -> "- major " + entry.getKey() + ':' + System.lineSeparator() + entry.getValue().stream()
+                .sorted(defaultOrdering())
+                .map(coordinate -> "  - " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
+                .collect(Collectors.joining(System.lineSeparator())))
+            .collect(Collectors.joining(System.lineSeparator()));
+
+        return "Mixed Micronaut major versions detected in the build configuration. "
+            + "Make sure dependencies, dependencyManagement entries, and annotation processor paths all use the same Micronaut major version."
+            + System.lineSeparator()
+            + System.lineSeparator()
+            + details;
+    }
+
+    public String buildLifecycleFailureMessage(String projectArtifactId, MicronautMajorVersionAnalysis analysis) {
+        int baselineMajor = analysis.baselineMajor().orElseThrow();
+        String baseline = analysis.coordinates().stream()
+            .filter(coordinate -> coordinate.majorVersion().isPresent() && coordinate.majorVersion().getAsInt() == baselineMajor)
+            .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
+            .findFirst()
+            .map(coordinate -> coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
+            .orElse("major " + baselineMajor);
+
+        String details = analysis.conflicts().stream()
+            .map(coordinate -> "- " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + "] (major " + coordinate.majorVersion().orElseThrow() + ')')
+            .collect(Collectors.joining(System.lineSeparator()));
+
+        return "Mixed Micronaut major versions detected in project " + projectArtifactId + ". "
+            + "Baseline major is " + baselineMajor + " from " + baseline + "."
+            + System.lineSeparator()
+            + System.lineSeparator()
+            + details;
+    }
+
+    public List<MicronautMajorVersionCoordinate> collectMicronautDependencies(List<Dependency> dependencies, String source) {
+        return dependencies.stream()
+            .filter(Objects::nonNull)
+            .filter(this::isMicronautDependency)
+            .map(dependency -> new MicronautMajorVersionCoordinate(
+                dependency.getGroupId(),
+                dependency.getArtifactId(),
+                dependency.getVersion(),
+                source,
+                parseMajorVersion(dependency.getVersion())
+            ))
+            .toList();
+    }
+
+    public List<MicronautMajorVersionCoordinate> collectDirectCompatibilitySignals(List<Dependency> dependencies, String source) {
+        return dependencies.stream()
+            .filter(Objects::nonNull)
+            .filter(this::isDirectCompatibilitySignal)
+            .map(dependency -> new MicronautMajorVersionCoordinate(
+                dependency.getGroupId(),
+                dependency.getArtifactId(),
+                dependency.getVersion(),
+                source,
+                parseMajorVersion(dependency.getVersion())
+            ))
+            .toList();
+    }
+
+    public List<MicronautMajorVersionCoordinate> collectMicronautParent(Parent parent) {
+        if (parent == null || parent.getGroupId() == null || parent.getArtifactId() == null) {
+            return List.of();
+        }
+        if (!isMicronautGroup(parent.getGroupId())) {
+            return List.of();
+        }
+        return List.of(new MicronautMajorVersionCoordinate(
+            parent.getGroupId(),
+            parent.getArtifactId(),
+            parent.getVersion(),
+            "parent",
+            parseMajorVersion(parent.getVersion())
+        ));
+    }
+
+    private boolean isMicronautDependency(Dependency dependency) {
+        return dependency.getGroupId() != null
+            && dependency.getArtifactId() != null
+            && isMicronautGroup(dependency.getGroupId());
+    }
+
+    private boolean isDirectCompatibilitySignal(Dependency dependency) {
+        return dependency.getGroupId() != null
+            && dependency.getArtifactId() != null
+            && dependency.getVersion() != null
+            && ((dependency.getGroupId().equals("io.micronaut.platform")
+                && (dependency.getArtifactId().equals("micronaut-parent") || dependency.getArtifactId().equals("micronaut-platform")))
+                || (dependency.getGroupId().equals("io.micronaut.starter") && dependency.getArtifactId().startsWith("micronaut-starter-"))
+                || (dependency.getGroupId().equals("io.micronaut") && dependency.getArtifactId().startsWith("micronaut-")));
+    }
+
+    private boolean isMicronautGroup(String groupId) {
+        return groupId != null && groupId.startsWith("io.micronaut");
+    }
+
+    private Comparator<MicronautMajorVersionCoordinate> defaultOrdering() {
+        return Comparator
+            .comparingInt((MicronautMajorVersionCoordinate coordinate) -> coordinate.majorVersion().orElseThrow())
+            .thenComparing(MicronautMajorVersionCoordinate::groupId)
+            .thenComparing(MicronautMajorVersionCoordinate::artifactId)
+            .thenComparing(MicronautMajorVersionCoordinate::source);
+    }
+}

--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
@@ -53,7 +53,7 @@ public final class MicronautMajorVersionChecker {
         List<Dependency> dependencyManagementDependencies
     ) {
         return Stream.of(
-                collectMicronautParent(parent),
+                collectLifecycleParent(parent),
                 collectLifecycleBaselineSignals(dependencyManagementDependencies),
                 collectDirectCompatibilitySignals(dependencies, "dependency")
             )
@@ -192,11 +192,12 @@ public final class MicronautMajorVersionChecker {
             .toList();
     }
 
-    public List<MicronautMajorVersionCoordinate> collectMicronautParent(Parent parent) {
+    public List<MicronautMajorVersionCoordinate> collectLifecycleParent(Parent parent) {
         if (parent == null || parent.getGroupId() == null || parent.getArtifactId() == null) {
             return List.of();
         }
-        if (!isMicronautGroup(parent.getGroupId())) {
+        if (!("io.micronaut.platform".equals(parent.getGroupId())
+            && ("micronaut-parent".equals(parent.getArtifactId()) || "micronaut-platform".equals(parent.getArtifactId())))) {
             return List.of();
         }
         return List.of(new MicronautMajorVersionCoordinate(

--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionChecker.java
@@ -85,12 +85,8 @@ public final class MicronautMajorVersionChecker {
     }
 
     public boolean hasMixedMajors(List<MicronautMajorVersionCoordinate> coordinates) {
-        return coordinates.stream()
-            .map(MicronautMajorVersionCoordinate::majorVersion)
-            .filter(OptionalInt::isPresent)
-            .mapToInt(OptionalInt::getAsInt)
-            .distinct()
-            .count() > 1;
+        return hasMixedMajorsInFamily(coordinates, "io.micronaut.platform")
+            || hasMixedMajorsInFamily(coordinates, "io.micronaut");
     }
 
     public OptionalInt parseMajorVersion(String version) {
@@ -109,18 +105,9 @@ public final class MicronautMajorVersionChecker {
     }
 
     public String buildEnforcerFailureMessage(List<MicronautMajorVersionCoordinate> coordinates) {
-        String details = coordinates.stream()
-            .filter(coordinate -> coordinate.majorVersion().isPresent())
-            .collect(Collectors.groupingBy(
-                coordinate -> coordinate.majorVersion().orElseThrow(),
-                java.util.LinkedHashMap::new,
-                Collectors.toList()
-            ))
-            .entrySet().stream()
-            .map(entry -> "- major " + entry.getKey() + ':' + System.lineSeparator() + entry.getValue().stream()
-                .sorted(defaultOrdering())
-                .map(coordinate -> "  - " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
-                .collect(Collectors.joining(System.lineSeparator())))
+        String details = Stream.of("io.micronaut.platform", "io.micronaut")
+            .map(family -> buildFamilyMismatchDetails(coordinates, family))
+            .filter(familyDetails -> !familyDetails.isBlank())
             .collect(Collectors.joining(System.lineSeparator()));
 
         return "Mixed Micronaut major versions detected in the build configuration. "
@@ -153,7 +140,7 @@ public final class MicronautMajorVersionChecker {
     public List<MicronautMajorVersionCoordinate> collectMicronautDependencies(List<Dependency> dependencies, String source) {
         return dependencies.stream()
             .filter(Objects::nonNull)
-            .filter(this::isMicronautDependency)
+            .filter(this::isMicronautFamilyDependency)
             .map(dependency -> new MicronautMajorVersionCoordinate(
                 dependency.getGroupId(),
                 dependency.getArtifactId(),
@@ -225,10 +212,10 @@ public final class MicronautMajorVersionChecker {
                 || ("io.micronaut".equals(coordinate.groupId()) && "micronaut-core-bom".equals(coordinate.artifactId())));
     }
 
-    private boolean isMicronautDependency(Dependency dependency) {
+    private boolean isMicronautFamilyDependency(Dependency dependency) {
         return dependency.getGroupId() != null
             && dependency.getArtifactId() != null
-            && isMicronautGroup(dependency.getGroupId());
+            && ("io.micronaut".equals(dependency.getGroupId()) || "io.micronaut.platform".equals(dependency.getGroupId()));
     }
 
     private boolean isDirectCompatibilitySignal(Dependency dependency) {
@@ -241,8 +228,36 @@ public final class MicronautMajorVersionChecker {
                 || (dependency.getGroupId().equals("io.micronaut") && dependency.getArtifactId().startsWith("micronaut-")));
     }
 
-    private boolean isMicronautGroup(String groupId) {
-        return groupId != null && groupId.startsWith("io.micronaut");
+    private boolean hasMixedMajorsInFamily(List<MicronautMajorVersionCoordinate> coordinates, String familyGroupId) {
+        return coordinates.stream()
+            .filter(coordinate -> familyGroupId.equals(coordinate.groupId()))
+            .map(MicronautMajorVersionCoordinate::majorVersion)
+            .filter(OptionalInt::isPresent)
+            .mapToInt(OptionalInt::getAsInt)
+            .distinct()
+            .count() > 1;
+    }
+
+    private String buildFamilyMismatchDetails(List<MicronautMajorVersionCoordinate> coordinates, String familyGroupId) {
+        var byMajor = coordinates.stream()
+            .filter(coordinate -> familyGroupId.equals(coordinate.groupId()))
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .collect(Collectors.groupingBy(
+                coordinate -> coordinate.majorVersion().orElseThrow(),
+                java.util.LinkedHashMap::new,
+                Collectors.toList()
+            ));
+
+        if (byMajor.size() <= 1) {
+            return "";
+        }
+
+        return "- family " + familyGroupId + ':' + System.lineSeparator() + byMajor.entrySet().stream()
+            .map(entry -> "  - major " + entry.getKey() + ':' + System.lineSeparator() + entry.getValue().stream()
+                .sorted(defaultOrdering())
+                .map(coordinate -> "    - " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
+                .collect(Collectors.joining(System.lineSeparator())))
+            .collect(Collectors.joining(System.lineSeparator()));
     }
 
     private Comparator<MicronautMajorVersionCoordinate> defaultOrdering() {

--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionCoordinate.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/compat/MicronautMajorVersionCoordinate.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.compat;
+
+import java.util.Locale;
+import java.util.OptionalInt;
+
+public record MicronautMajorVersionCoordinate(
+    String groupId,
+    String artifactId,
+    String version,
+    String source,
+    OptionalInt majorVersion
+) {
+    public MicronautMajorVersionCoordinate {
+        version = version == null ? "<unknown>" : version;
+        source = source == null ? "unknown" : source.toLowerCase(Locale.ROOT);
+    }
+}

--- a/micronaut-maven-core/src/test/java/io/micronaut/maven/compat/MicronautMajorVersionCheckerTest.java
+++ b/micronaut-maven-core/src/test/java/io/micronaut/maven/compat/MicronautMajorVersionCheckerTest.java
@@ -48,10 +48,24 @@ class MicronautMajorVersionCheckerTest {
     }
 
     @Test
-    void detectsMixedMajorsForEnforcerCoordinates() {
+    void ignoresSiblingMicronautRepositoryMajorsForEnforcerCoordinates() {
         var coordinates = checker.collectEnforcerCoordinates(
             List.of(dependency("io.micronaut", "micronaut-inject", "5.0.0")),
             List.of(dependency("io.micronaut.validation", "micronaut-validation", "4.9.1")),
+            List.of()
+        );
+
+        assertFalse(checker.hasMixedMajors(coordinates));
+    }
+
+    @Test
+    void detectsMixedMajorsWithinIoMicronautFamily() {
+        var coordinates = checker.collectEnforcerCoordinates(
+            List.of(
+                dependency("io.micronaut", "micronaut-inject", "5.0.0"),
+                dependency("io.micronaut", "micronaut-runtime", "4.9.1")
+            ),
+            List.of(),
             List.of()
         );
 

--- a/micronaut-maven-core/src/test/java/io/micronaut/maven/compat/MicronautMajorVersionCheckerTest.java
+++ b/micronaut-maven-core/src/test/java/io/micronaut/maven/compat/MicronautMajorVersionCheckerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.compat;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Parent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MicronautMajorVersionCheckerTest {
+
+    private final MicronautMajorVersionChecker checker = new MicronautMajorVersionChecker();
+
+    @Test
+    void analyzesLifecycleCoordinatesAgainstBaseline() {
+        Parent parent = new Parent();
+        parent.setGroupId("io.micronaut.platform");
+        parent.setArtifactId("micronaut-parent");
+        parent.setVersion("5.0.0-SNAPSHOT");
+
+        var coordinates = checker.collectLifecycleCoordinates(parent, List.of(
+            dependency("io.micronaut.starter", "micronaut-starter-aws-cdk", "4.10.9")
+        ), List.of());
+
+        var analysis = checker.analyzeForLifecycle(coordinates);
+        assertEquals(OptionalInt.of(5), analysis.baselineMajor());
+        assertEquals(1, analysis.conflicts().size());
+        assertTrue(analysis.hasConflict());
+    }
+
+    @Test
+    void detectsMixedMajorsForEnforcerCoordinates() {
+        var coordinates = checker.collectEnforcerCoordinates(
+            List.of(dependency("io.micronaut", "micronaut-inject", "5.0.0")),
+            List.of(dependency("io.micronaut.validation", "micronaut-validation", "4.9.1")),
+            List.of()
+        );
+
+        assertTrue(checker.hasMixedMajors(coordinates));
+        assertFalse(checker.buildEnforcerFailureMessage(coordinates).isBlank());
+    }
+
+    private Dependency dependency(String groupId, String artifactId, String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        return dependency;
+    }
+}

--- a/micronaut-maven-enforcer-rules/pom.xml
+++ b/micronaut-maven-enforcer-rules/pom.xml
@@ -22,6 +22,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.micronaut.maven</groupId>
+            <artifactId>micronaut-maven-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>

--- a/micronaut-maven-enforcer-rules/src/main/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersions.java
+++ b/micronaut-maven-enforcer-rules/src/main/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersions.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.enforcer;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Enforcer rule that checks that Micronaut dependencies participating in the build use the same major version.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 5.0.0
+ */
+@Named("checkMicronautMajorVersions")
+public class CheckMicronautMajorVersions extends AbstractEnforcerRule {
+
+    private static final String MAVEN_COMPILER_PLUGIN_ARTIFACT_ID = "maven-compiler-plugin";
+    private static final Pattern LEADING_MAJOR_PATTERN = Pattern.compile("^(\\d+)");
+
+    private final MavenProject project;
+
+    @Inject
+    public CheckMicronautMajorVersions(MavenProject project) {
+        this.project = project;
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        List<MicronautCoordinate> coordinates = Stream.of(
+                micronautDependencies(project.getDependencies(), "dependency"),
+                micronautDependencies(project.getDependencyManagement() != null ? project.getDependencyManagement().getDependencies() : List.of(), "dependencyManagement"),
+                micronautDependencies(compilerAnnotationProcessorPaths(), "annotationProcessorPath")
+            )
+            .flatMap(List::stream)
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .distinct()
+            .toList();
+
+        Set<Integer> detectedMajors = coordinates.stream()
+            .map(MicronautCoordinate::majorVersion)
+            .filter(OptionalInt::isPresent)
+            .mapToInt(OptionalInt::getAsInt)
+            .boxed()
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (detectedMajors.size() > 1) {
+            throw new EnforcerRuleException(buildFailureMessage(coordinates));
+        }
+    }
+
+    private List<Dependency> compilerAnnotationProcessorPaths() {
+        return Stream.concat(
+                project.getBuildPlugins().stream(),
+                project.getBuild() != null ? project.getBuild().getPlugins().stream() : Stream.empty()
+            )
+            .filter(plugin -> Objects.equals(plugin.getArtifactId(), MAVEN_COMPILER_PLUGIN_ARTIFACT_ID))
+            .findFirst()
+            .map(this::annotationProcessorPaths)
+            .orElseGet(List::of);
+    }
+
+    private List<Dependency> annotationProcessorPaths(Plugin plugin) {
+        Object configuration = plugin.getConfiguration();
+        if (!(configuration instanceof Xpp3Dom dom)) {
+            return List.of();
+        }
+
+        Xpp3Dom annotationProcessorPaths = dom.getChild("annotationProcessorPaths");
+        if (annotationProcessorPaths == null) {
+            return List.of();
+        }
+
+        List<Dependency> dependencies = new ArrayList<>();
+        for (Xpp3Dom child : annotationProcessorPaths.getChildren()) {
+            if (!"path".equals(child.getName()) && !"annotationProcessorPath".equals(child.getName())) {
+                continue;
+            }
+            Dependency dependency = new Dependency();
+            dependency.setGroupId(childValue(child, "groupId"));
+            dependency.setArtifactId(childValue(child, "artifactId"));
+            dependency.setVersion(childValue(child, "version"));
+            dependencies.add(dependency);
+        }
+        return dependencies;
+    }
+
+    private String childValue(Xpp3Dom parent, String childName) {
+        Xpp3Dom child = parent.getChild(childName);
+        return child != null ? child.getValue() : null;
+    }
+
+    private List<MicronautCoordinate> micronautDependencies(List<Dependency> dependencies, String source) {
+        return dependencies.stream()
+            .filter(Objects::nonNull)
+            .filter(this::isMicronautDependency)
+            .map(dependency -> new MicronautCoordinate(
+                dependency.getGroupId(),
+                dependency.getArtifactId(),
+                dependency.getVersion(),
+                source,
+                parseMajorVersion(dependency.getVersion())
+            ))
+            .toList();
+    }
+
+    private boolean isMicronautDependency(Dependency dependency) {
+        return dependency.getGroupId() != null
+            && dependency.getArtifactId() != null
+            && dependency.getGroupId().startsWith("io.micronaut");
+    }
+
+    private OptionalInt parseMajorVersion(String version) {
+        if (version == null) {
+            return OptionalInt.empty();
+        }
+        Matcher matcher = LEADING_MAJOR_PATTERN.matcher(version);
+        if (!matcher.find()) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+    }
+
+    private String buildFailureMessage(List<MicronautCoordinate> coordinates) {
+        Map<Integer, List<MicronautCoordinate>> byMajor = coordinates.stream()
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .sorted(Comparator
+                .comparingInt((MicronautCoordinate coordinate) -> coordinate.majorVersion().orElseThrow())
+                .thenComparing(MicronautCoordinate::groupId)
+                .thenComparing(MicronautCoordinate::artifactId)
+                .thenComparing(MicronautCoordinate::source))
+            .collect(Collectors.groupingBy(
+                coordinate -> coordinate.majorVersion().orElseThrow(),
+                LinkedHashMap::new,
+                Collectors.toList()
+            ));
+
+        String details = byMajor.entrySet().stream()
+            .map(entry -> "- major " + entry.getKey() + ':' + System.lineSeparator() + entry.getValue().stream()
+                .map(coordinate -> "  - " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
+                .collect(Collectors.joining(System.lineSeparator())))
+            .collect(Collectors.joining(System.lineSeparator()));
+
+        return "Mixed Micronaut major versions detected in the build configuration. "
+            + "Make sure dependencies, dependencyManagement entries, and annotation processor paths all use the same Micronaut major version."
+            + System.lineSeparator()
+            + System.lineSeparator()
+            + details;
+    }
+
+    @Override
+    public String toString() {
+        return "CheckMicronautMajorVersions";
+    }
+
+    private record MicronautCoordinate(
+        String groupId,
+        String artifactId,
+        String version,
+        String source,
+        OptionalInt majorVersion
+    ) {
+        private MicronautCoordinate {
+            version = version == null ? "<unknown>" : version;
+            source = source.toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/micronaut-maven-enforcer-rules/src/main/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersions.java
+++ b/micronaut-maven-enforcer-rules/src/main/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersions.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.maven.enforcer;
 
+import io.micronaut.maven.compat.MicronautMajorVersionChecker;
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.model.Dependency;
@@ -25,19 +26,9 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
 import java.util.Objects;
-import java.util.OptionalInt;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 /**
@@ -50,9 +41,9 @@ import java.util.stream.Stream;
 public class CheckMicronautMajorVersions extends AbstractEnforcerRule {
 
     private static final String MAVEN_COMPILER_PLUGIN_ARTIFACT_ID = "maven-compiler-plugin";
-    private static final Pattern LEADING_MAJOR_PATTERN = Pattern.compile("^(\\d+)");
 
     private final MavenProject project;
+    private final MicronautMajorVersionChecker checker = new MicronautMajorVersionChecker();
 
     @Inject
     public CheckMicronautMajorVersions(MavenProject project) {
@@ -61,25 +52,14 @@ public class CheckMicronautMajorVersions extends AbstractEnforcerRule {
 
     @Override
     public void execute() throws EnforcerRuleException {
-        List<MicronautCoordinate> coordinates = Stream.of(
-                micronautDependencies(project.getDependencies(), "dependency"),
-                micronautDependencies(project.getDependencyManagement() != null ? project.getDependencyManagement().getDependencies() : List.of(), "dependencyManagement"),
-                micronautDependencies(compilerAnnotationProcessorPaths(), "annotationProcessorPath")
-            )
-            .flatMap(List::stream)
-            .filter(coordinate -> coordinate.majorVersion().isPresent())
-            .distinct()
-            .toList();
+        var coordinates = checker.collectEnforcerCoordinates(
+            resolveVersions(project.getDependencies()),
+            resolveVersions(project.getDependencyManagement() != null ? project.getDependencyManagement().getDependencies() : List.of()),
+            resolveVersions(compilerAnnotationProcessorPaths())
+        );
 
-        Set<Integer> detectedMajors = coordinates.stream()
-            .map(MicronautCoordinate::majorVersion)
-            .filter(OptionalInt::isPresent)
-            .mapToInt(OptionalInt::getAsInt)
-            .boxed()
-            .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        if (detectedMajors.size() > 1) {
-            throw new EnforcerRuleException(buildFailureMessage(coordinates));
+        if (checker.hasMixedMajors(coordinates)) {
+            throw new EnforcerRuleException(checker.buildEnforcerFailureMessage(coordinates));
         }
     }
 
@@ -124,42 +104,17 @@ public class CheckMicronautMajorVersions extends AbstractEnforcerRule {
         return child != null ? child.getValue() : null;
     }
 
-    private List<MicronautCoordinate> micronautDependencies(List<Dependency> dependencies, String source) {
+    private List<Dependency> resolveVersions(List<Dependency> dependencies) {
         return dependencies.stream()
             .filter(Objects::nonNull)
-            .filter(this::isMicronautDependency)
             .map(dependency -> {
-                String resolvedVersion = resolveVersion(dependency.getVersion());
-                return new MicronautCoordinate(
-                    dependency.getGroupId(),
-                    dependency.getArtifactId(),
-                    resolvedVersion,
-                    source,
-                    parseMajorVersion(resolvedVersion)
-                );
+                Dependency resolved = new Dependency();
+                resolved.setGroupId(dependency.getGroupId());
+                resolved.setArtifactId(dependency.getArtifactId());
+                resolved.setVersion(resolveVersion(dependency.getVersion()));
+                return resolved;
             })
             .toList();
-    }
-
-    private boolean isMicronautDependency(Dependency dependency) {
-        return dependency.getGroupId() != null
-            && dependency.getArtifactId() != null
-            && dependency.getGroupId().startsWith("io.micronaut");
-    }
-
-    private OptionalInt parseMajorVersion(String version) {
-        if (version == null) {
-            return OptionalInt.empty();
-        }
-        Matcher matcher = LEADING_MAJOR_PATTERN.matcher(version);
-        if (!matcher.find()) {
-            return OptionalInt.empty();
-        }
-        try {
-            return OptionalInt.of(Integer.parseInt(matcher.group(1)));
-        } catch (NumberFormatException e) {
-            return OptionalInt.empty();
-        }
     }
 
     private String resolveVersion(String version) {
@@ -178,48 +133,8 @@ public class CheckMicronautMajorVersions extends AbstractEnforcerRule {
         return project.getModel().getProperties().getProperty(propertyName, version);
     }
 
-    private String buildFailureMessage(List<MicronautCoordinate> coordinates) {
-        Map<Integer, List<MicronautCoordinate>> byMajor = coordinates.stream()
-            .filter(coordinate -> coordinate.majorVersion().isPresent())
-            .sorted(Comparator
-                .comparingInt((MicronautCoordinate coordinate) -> coordinate.majorVersion().orElseThrow())
-                .thenComparing(MicronautCoordinate::groupId)
-                .thenComparing(MicronautCoordinate::artifactId)
-                .thenComparing(MicronautCoordinate::source))
-            .collect(Collectors.groupingBy(
-                coordinate -> coordinate.majorVersion().orElseThrow(),
-                LinkedHashMap::new,
-                Collectors.toList()
-            ));
-
-        String details = byMajor.entrySet().stream()
-            .map(entry -> "- major " + entry.getKey() + ':' + System.lineSeparator() + entry.getValue().stream()
-                .map(coordinate -> "  - " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
-                .collect(Collectors.joining(System.lineSeparator())))
-            .collect(Collectors.joining(System.lineSeparator()));
-
-        return "Mixed Micronaut major versions detected in the build configuration. "
-            + "Make sure dependencies, dependencyManagement entries, and annotation processor paths all use the same Micronaut major version."
-            + System.lineSeparator()
-            + System.lineSeparator()
-            + details;
-    }
-
     @Override
     public String toString() {
         return "CheckMicronautMajorVersions";
-    }
-
-    private record MicronautCoordinate(
-        String groupId,
-        String artifactId,
-        String version,
-        String source,
-        OptionalInt majorVersion
-    ) {
-        private MicronautCoordinate {
-            version = version == null ? "<unknown>" : version;
-            source = source.toLowerCase(Locale.ROOT);
-        }
     }
 }

--- a/micronaut-maven-enforcer-rules/src/main/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersions.java
+++ b/micronaut-maven-enforcer-rules/src/main/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersions.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -127,13 +128,16 @@ public class CheckMicronautMajorVersions extends AbstractEnforcerRule {
         return dependencies.stream()
             .filter(Objects::nonNull)
             .filter(this::isMicronautDependency)
-            .map(dependency -> new MicronautCoordinate(
-                dependency.getGroupId(),
-                dependency.getArtifactId(),
-                dependency.getVersion(),
-                source,
-                parseMajorVersion(dependency.getVersion())
-            ))
+            .map(dependency -> {
+                String resolvedVersion = resolveVersion(dependency.getVersion());
+                return new MicronautCoordinate(
+                    dependency.getGroupId(),
+                    dependency.getArtifactId(),
+                    resolvedVersion,
+                    source,
+                    parseMajorVersion(resolvedVersion)
+                );
+            })
             .toList();
     }
 
@@ -151,7 +155,27 @@ public class CheckMicronautMajorVersions extends AbstractEnforcerRule {
         if (!matcher.find()) {
             return OptionalInt.empty();
         }
-        return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+        try {
+            return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
+    }
+
+    private String resolveVersion(String version) {
+        if (version == null) {
+            return null;
+        }
+        if (!version.startsWith("${") || !version.endsWith("}")) {
+            return version;
+        }
+        String propertyName = version.substring(2, version.length() - 1);
+        Properties properties = project.getProperties();
+        String propertyValue = properties.getProperty(propertyName);
+        if (propertyValue != null) {
+            return propertyValue;
+        }
+        return project.getModel().getProperties().getProperty(propertyName, version);
     }
 
     private String buildFailureMessage(List<MicronautCoordinate> coordinates) {

--- a/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
+++ b/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
@@ -16,12 +16,9 @@
 package io.micronaut.maven.enforcer;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -83,37 +80,7 @@ class CheckMicronautMajorVersionsTest {
     private MavenProject projectWithDependencies(List<Dependency> dependencies) {
         MavenProject project = new MavenProject();
         project.setDependencies(dependencies);
-        project.setBuild(new Build());
         return project;
-    }
-
-    private Build buildWithCompilerPlugin(Xpp3Dom configuration) {
-        Plugin plugin = new Plugin();
-        plugin.setGroupId("org.apache.maven.plugins");
-        plugin.setArtifactId("maven-compiler-plugin");
-        plugin.setConfiguration(configuration);
-
-        Build build = new Build();
-        build.setPlugins(List.of(plugin));
-        return build;
-    }
-
-    private Xpp3Dom annotationProcessorPaths(Dependency... dependencies) {
-        Xpp3Dom annotationProcessorPaths = new Xpp3Dom("annotationProcessorPaths");
-        for (Dependency dependency : dependencies) {
-            Xpp3Dom path = new Xpp3Dom("path");
-            path.addChild(node("groupId", dependency.getGroupId()));
-            path.addChild(node("artifactId", dependency.getArtifactId()));
-            path.addChild(node("version", dependency.getVersion()));
-            annotationProcessorPaths.addChild(path);
-        }
-        return annotationProcessorPaths;
-    }
-
-    private Xpp3Dom node(String name, String value) {
-        Xpp3Dom node = new Xpp3Dom(name);
-        node.setValue(value);
-        return node;
     }
 
     private Dependency dependency(String groupId, String artifactId, String version) {

--- a/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
+++ b/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
@@ -40,24 +40,35 @@ class CheckMicronautMajorVersionsTest {
     }
 
     @Test
-    void failsWhenProjectDependenciesMixMicronautMajorVersions() {
+    void passesWhenSiblingMicronautRepositoriesUseDifferentMajorVersions() {
         MavenProject project = projectWithDependencies(List.of(
             dependency("io.micronaut", "micronaut-inject", "5.0.0"),
             dependency("io.micronaut.validation", "micronaut-validation", "4.9.1")
         ));
 
-        assertThrows(EnforcerRuleException.class, () -> new CheckMicronautMajorVersions(project).execute());
+        assertDoesNotThrow(() -> new CheckMicronautMajorVersions(project).execute());
     }
 
 
     @Test
-    void failsWhenMicronautVersionsAreProvidedViaProperties() {
+    void passesWhenPropertyDrivenSiblingMicronautRepositoriesUseDifferentMajorVersions() {
         MavenProject project = projectWithDependencies(List.of(
             dependency("io.micronaut", "micronaut-inject", "${micronaut.version}"),
             dependency("io.micronaut.validation", "micronaut-validation", "${micronaut.validation.version}")
         ));
         project.getProperties().setProperty("micronaut.version", "5.0.0");
         project.getProperties().setProperty("micronaut.validation.version", "4.9.1");
+
+        assertDoesNotThrow(() -> new CheckMicronautMajorVersions(project).execute());
+    }
+
+
+    @Test
+    void failsWhenIoMicronautDependenciesUseDifferentMajorVersions() {
+        MavenProject project = projectWithDependencies(List.of(
+            dependency("io.micronaut", "micronaut-inject", "5.0.0"),
+            dependency("io.micronaut", "micronaut-runtime", "4.9.1")
+        ));
 
         assertThrows(EnforcerRuleException.class, () -> new CheckMicronautMajorVersions(project).execute());
     }

--- a/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
+++ b/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
@@ -52,6 +52,19 @@ class CheckMicronautMajorVersionsTest {
         assertThrows(EnforcerRuleException.class, () -> new CheckMicronautMajorVersions(project).execute());
     }
 
+
+    @Test
+    void failsWhenMicronautVersionsAreProvidedViaProperties() {
+        MavenProject project = projectWithDependencies(List.of(
+            dependency("io.micronaut", "micronaut-inject", "${micronaut.version}"),
+            dependency("io.micronaut.validation", "micronaut-validation", "${micronaut.validation.version}")
+        ));
+        project.getProperties().setProperty("micronaut.version", "5.0.0");
+        project.getProperties().setProperty("micronaut.validation.version", "4.9.1");
+
+        assertThrows(EnforcerRuleException.class, () -> new CheckMicronautMajorVersions(project).execute());
+    }
+
     @Test
     void failsWhenDependencyManagementMixesMicronautMajorVersions() {
         MavenProject project = projectWithDependencies(List.of(

--- a/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
+++ b/micronaut-maven-enforcer-rules/src/test/java/io/micronaut/maven/enforcer/CheckMicronautMajorVersionsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.enforcer;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CheckMicronautMajorVersionsTest {
+
+    @Test
+    void passesWhenMicronautDependenciesUseSingleMajorVersion() {
+        MavenProject project = projectWithDependencies(List.of(
+            dependency("io.micronaut", "micronaut-inject", "5.0.0"),
+            dependency("io.micronaut.serde", "micronaut-serde-processor", "5.1.0"),
+            dependency("org.junit.jupiter", "junit-jupiter-api", "6.0.3")
+        ));
+
+        assertDoesNotThrow(() -> new CheckMicronautMajorVersions(project).execute());
+    }
+
+    @Test
+    void failsWhenProjectDependenciesMixMicronautMajorVersions() {
+        MavenProject project = projectWithDependencies(List.of(
+            dependency("io.micronaut", "micronaut-inject", "5.0.0"),
+            dependency("io.micronaut.validation", "micronaut-validation", "4.9.1")
+        ));
+
+        assertThrows(EnforcerRuleException.class, () -> new CheckMicronautMajorVersions(project).execute());
+    }
+
+    @Test
+    void failsWhenDependencyManagementMixesMicronautMajorVersions() {
+        MavenProject project = projectWithDependencies(List.of(
+            dependency("io.micronaut", "micronaut-inject", "5.0.0")
+        ));
+        DependencyManagement dependencyManagement = new DependencyManagement();
+        dependencyManagement.setDependencies(List.of(
+            dependency("io.micronaut.platform", "micronaut-platform", "5.0.0"),
+            dependency("io.micronaut", "micronaut-core-bom", "4.10.16")
+        ));
+        project.getModel().setDependencyManagement(dependencyManagement);
+
+        assertThrows(EnforcerRuleException.class, () -> new CheckMicronautMajorVersions(project).execute());
+    }
+
+    private MavenProject projectWithDependencies(List<Dependency> dependencies) {
+        MavenProject project = new MavenProject();
+        project.setDependencies(dependencies);
+        project.setBuild(new Build());
+        return project;
+    }
+
+    private Build buildWithCompilerPlugin(Xpp3Dom configuration) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId("org.apache.maven.plugins");
+        plugin.setArtifactId("maven-compiler-plugin");
+        plugin.setConfiguration(configuration);
+
+        Build build = new Build();
+        build.setPlugins(List.of(plugin));
+        return build;
+    }
+
+    private Xpp3Dom annotationProcessorPaths(Dependency... dependencies) {
+        Xpp3Dom annotationProcessorPaths = new Xpp3Dom("annotationProcessorPaths");
+        for (Dependency dependency : dependencies) {
+            Xpp3Dom path = new Xpp3Dom("path");
+            path.addChild(node("groupId", dependency.getGroupId()));
+            path.addChild(node("artifactId", dependency.getArtifactId()));
+            path.addChild(node("version", dependency.getVersion()));
+            annotationProcessorPaths.addChild(path);
+        }
+        return annotationProcessorPaths;
+    }
+
+    private Xpp3Dom node(String name, String value) {
+        Xpp3Dom node = new Xpp3Dom(name);
+        node.setValue(value);
+        return node;
+    }
+
+    private Dependency dependency(String groupId, String artifactId, String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        return dependency;
+    }
+}

--- a/micronaut-maven-integration-tests/pom.xml
+++ b/micronaut-maven-integration-tests/pom.xml
@@ -20,8 +20,8 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
-        <it.micronaut.core.version>5.0.0-M11</it.micronaut.core.version>
-        <it.micronaut.version>4.10.8</it.micronaut.version>
+        <it.micronaut.core.version>5.0.0-M16</it.micronaut.core.version>
+        <it.micronaut.version>5.0.0-SNAPSHOT</it.micronaut.version>
 
         <!-- Enable recording of coverage during execution of maven-invoker-plugin -->
         <jacoco.propertyName>invoker.mavenOpts</jacoco.propertyName>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-options/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-options/pom.xml
@@ -83,7 +83,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>validate-test-config</id>
+                        <id>default-validate-test-configuration</id>
                         <phase>test-compile</phase>
                         <goals>
                             <goal>validate-test-configuration</goal>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-options/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-options/verify.groovy
@@ -7,7 +7,7 @@ def text = log.text
 
 // cacheEnabled=false => validation should run on both invocations
 assert (text.count('Validating Micronaut configuration (package)') == 2)
-assert (text.count('Validating Micronaut configuration (test)') == 3)
+assert (text.count('Validating Micronaut configuration (test)') == 2)
 
 File packageJson = new File(basedir, 'target/validation-reports/package/configuration-errors.json')
 File packageHtml = new File(basedir, 'target/validation-reports/package/configuration-errors.html')
@@ -16,7 +16,11 @@ assert !packageHtml.exists()
 
 def packageJsonData = new JsonSlurper().parseText(packageJson.text)
 assert packageJsonData instanceof Map
-assert packageJsonData.isEmpty()
+assert packageJsonData.configurationErrors instanceof List
+assert packageJsonData.configurationErrors.size() == 1
+assert packageJsonData.configurationErrors[0].property == 'micronaut.server.port'
+assert packageJsonData.configurationErrors[0].type == 'WARNING'
+assert packageJsonData.configurationErrors[0].originLocation == 'application-prod.yml'
 
 File testHtml = new File(basedir, 'target/validation-reports/test/configuration-errors.html')
 File testJson = new File(basedir, 'target/validation-reports/test/configuration-errors.json')

--- a/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -ntp compile
+invoker.buildResult = failure

--- a/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/pom.xml
@@ -58,6 +58,7 @@
         <executions>
           <execution>
             <id>micronaut-enforce</id>
+            <phase>validate</phase>
             <goals>
               <goal>enforce</goal>
             </goals>

--- a/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>micronaut-mixed-major-versions</artifactId>
+  <version>0.1</version>
+
+  <parent>
+    <groupId>io.micronaut.platform</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>@it.micronaut.version@</version>
+  </parent>
+
+  <properties>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <version>5.0.0-M16</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-inject-java</artifactId>
+              <version>5.0.0-M16</version>
+            </path>
+            <path>
+              <groupId>io.micronaut.validation</groupId>
+              <artifactId>micronaut-validation-processor</artifactId>
+              <version>4.7.0</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>io.micronaut.maven</groupId>
+            <artifactId>micronaut-maven-enforcer-rules</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>micronaut-enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <checkMicronautMajorVersions />
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/verify.groovy
@@ -1,0 +1,6 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD FAILURE")
+assert log.text.contains("io.micronaut.maven.enforcer.CheckMicronautMajorVersions failed with message")
+assert log.text.contains("Mixed Micronaut major versions detected in the build configuration")
+assert log.text.contains("io.micronaut.validation:micronaut-validation-processor:4.7.0 [annotationprocessorpath]")

--- a/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/micronaut-mixed-major-versions/verify.groovy
@@ -1,6 +1,6 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
-assert log.text.contains("BUILD FAILURE")
-assert log.text.contains("io.micronaut.maven.enforcer.CheckMicronautMajorVersions failed with message")
 assert log.text.contains("Mixed Micronaut major versions detected in the build configuration")
+assert log.text.contains("- major 4:")
+assert log.text.contains("- major 5:")
 assert log.text.contains("io.micronaut.validation:micronaut-validation-processor:4.7.0 [annotationprocessorpath]")

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtension.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtension.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Parent;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+
+import java.util.List;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Lifecycle extension that fails fast when Micronaut major versions are mixed in project models.
+ */
+@Component(role = AbstractMavenLifecycleParticipant.class, hint = "micronaut-major-version-check")
+public final class MicronautMajorVersionLifecycleExtension extends AbstractMavenLifecycleParticipant {
+
+    private static final String MAVEN_COMPILER_PLUGIN_ARTIFACT_ID = "maven-compiler-plugin";
+    private static final Pattern LEADING_MAJOR_PATTERN = Pattern.compile("^(\\d+)");
+
+    @Override
+    public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
+        for (MavenProject project : session.getAllProjects()) {
+            List<MicronautCoordinate> coordinates = collectMicronautCoordinates(project);
+            OptionalInt baselineMajor = coordinates.stream()
+                .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
+                .map(MicronautCoordinate::majorVersion)
+                .filter(OptionalInt::isPresent)
+                .mapToInt(OptionalInt::getAsInt)
+                .findFirst();
+
+            if (baselineMajor.isEmpty()) {
+                continue;
+            }
+
+            List<MicronautCoordinate> conflicts = coordinates.stream()
+                .filter(coordinate -> coordinate.majorVersion().isPresent())
+                .filter(coordinate -> coordinate.majorVersion().getAsInt() != baselineMajor.getAsInt())
+                .toList();
+
+            if (!conflicts.isEmpty()) {
+                throw new MavenExecutionException(buildFailureMessage(project, baselineMajor.getAsInt(), coordinates, conflicts), project.getFile());
+            }
+        }
+    }
+
+    private List<MicronautCoordinate> collectMicronautCoordinates(MavenProject project) {
+        return Stream.of(
+                micronautParent(project.getModel().getParent()),
+                directMicronautDependencies(project.getDependencies(), "dependency"),
+                directMicronautDependencies(dependencyManagementDependencies(project), "dependencyManagement")
+            )
+            .flatMap(List::stream)
+            .filter(coordinate -> coordinate.majorVersion().isPresent())
+            .distinct()
+            .toList();
+    }
+
+    private List<Dependency> dependencyManagementDependencies(MavenProject project) {
+        DependencyManagement dependencyManagement = project.getModel().getDependencyManagement();
+        if (dependencyManagement == null) {
+            return List.of();
+        }
+        return dependencyManagement.getDependencies();
+    }
+
+    private List<MicronautCoordinate> micronautParent(Parent parent) {
+        if (parent == null || parent.getGroupId() == null || parent.getArtifactId() == null) {
+            return List.of();
+        }
+        if (!isMicronautGroup(parent.getGroupId())) {
+            return List.of();
+        }
+        String version = parent.getVersion();
+        return List.of(new MicronautCoordinate(
+            parent.getGroupId(),
+            parent.getArtifactId(),
+            version,
+            "parent",
+            parseMajorVersion(version)
+        ));
+    }
+
+    private List<MicronautCoordinate> directMicronautDependencies(List<Dependency> dependencies, String source) {
+        return dependencies.stream()
+            .filter(Objects::nonNull)
+            .filter(this::isDirectCompatibilitySignal)
+            .map(dependency -> new MicronautCoordinate(
+                dependency.getGroupId(),
+                dependency.getArtifactId(),
+                dependency.getVersion(),
+                source,
+                parseMajorVersion(dependency.getVersion())
+            ))
+            .toList();
+    }
+
+    private boolean isDirectCompatibilitySignal(Dependency dependency) {
+        return dependency.getGroupId() != null
+            && dependency.getArtifactId() != null
+            && dependency.getVersion() != null
+            && ((dependency.getGroupId().equals("io.micronaut.platform")
+                && (dependency.getArtifactId().equals("micronaut-parent") || dependency.getArtifactId().equals("micronaut-platform")))
+                || (dependency.getGroupId().equals("io.micronaut.starter") && dependency.getArtifactId().startsWith("micronaut-starter-"))
+                || (dependency.getGroupId().equals("io.micronaut") && dependency.getArtifactId().startsWith("micronaut-")));
+    }
+
+    private boolean isMicronautGroup(String groupId) {
+        return groupId != null && groupId.startsWith("io.micronaut");
+    }
+
+    private OptionalInt parseMajorVersion(String version) {
+        if (version == null) {
+            return OptionalInt.empty();
+        }
+        Matcher matcher = LEADING_MAJOR_PATTERN.matcher(version);
+        if (!matcher.find()) {
+            return OptionalInt.empty();
+        }
+        try {
+            return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
+    }
+
+    private String buildFailureMessage(MavenProject project, int baselineMajor, List<MicronautCoordinate> coordinates, List<MicronautCoordinate> conflicts) {
+        String baseline = coordinates.stream()
+            .filter(coordinate -> coordinate.majorVersion().isPresent() && coordinate.majorVersion().getAsInt() == baselineMajor)
+            .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
+            .findFirst()
+            .map(coordinate -> coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
+            .orElse("major " + baselineMajor);
+
+        String details = conflicts.stream()
+            .sorted(Comparator
+                .comparingInt((MicronautCoordinate coordinate) -> coordinate.majorVersion().orElseThrow())
+                .thenComparing(MicronautCoordinate::groupId)
+                .thenComparing(MicronautCoordinate::artifactId)
+                .thenComparing(MicronautCoordinate::source))
+            .map(coordinate -> "- " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + "] (major " + coordinate.majorVersion().orElseThrow() + ')')
+            .collect(Collectors.joining(System.lineSeparator()));
+
+        return "Mixed Micronaut major versions detected in project " + project.getArtifactId() + ". "
+            + "Baseline major is " + baselineMajor + " from " + baseline + "."
+            + System.lineSeparator()
+            + System.lineSeparator()
+            + details;
+    }
+
+    record MicronautCoordinate(
+        String groupId,
+        String artifactId,
+        String version,
+        String source,
+        OptionalInt majorVersion
+    ) {
+        MicronautCoordinate {
+            version = version == null ? "<unknown>" : version;
+            source = source.toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtension.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtension.java
@@ -20,12 +20,10 @@ import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * Lifecycle extension that fails fast when Micronaut major versions are mixed in project models.
  */
-@Component(role = AbstractMavenLifecycleParticipant.class, hint = "micronaut-major-version-check")
 public final class MicronautMajorVersionLifecycleExtension extends AbstractMavenLifecycleParticipant {
 
     private final MicronautMajorVersionChecker checker = new MicronautMajorVersionChecker();

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtension.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtension.java
@@ -15,24 +15,12 @@
  */
 package io.micronaut.maven;
 
+import io.micronaut.maven.compat.MicronautMajorVersionChecker;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.model.Parent;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
-
-import java.util.List;
-import java.util.Comparator;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.OptionalInt;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Lifecycle extension that fails fast when Micronaut major versions are mixed in project models.
@@ -40,149 +28,20 @@ import java.util.stream.Stream;
 @Component(role = AbstractMavenLifecycleParticipant.class, hint = "micronaut-major-version-check")
 public final class MicronautMajorVersionLifecycleExtension extends AbstractMavenLifecycleParticipant {
 
-    private static final String MAVEN_COMPILER_PLUGIN_ARTIFACT_ID = "maven-compiler-plugin";
-    private static final Pattern LEADING_MAJOR_PATTERN = Pattern.compile("^(\\d+)");
+    private final MicronautMajorVersionChecker checker = new MicronautMajorVersionChecker();
 
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
         for (MavenProject project : session.getAllProjects()) {
-            List<MicronautCoordinate> coordinates = collectMicronautCoordinates(project);
-            OptionalInt baselineMajor = coordinates.stream()
-                .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
-                .map(MicronautCoordinate::majorVersion)
-                .filter(OptionalInt::isPresent)
-                .mapToInt(OptionalInt::getAsInt)
-                .findFirst();
-
-            if (baselineMajor.isEmpty()) {
-                continue;
+            var coordinates = checker.collectLifecycleCoordinates(
+                project.getModel().getParent(),
+                project.getDependencies(),
+                project.getModel().getDependencyManagement() != null ? project.getModel().getDependencyManagement().getDependencies() : java.util.List.of()
+            );
+            var analysis = checker.analyzeForLifecycle(coordinates);
+            if (analysis.hasConflict()) {
+                throw new MavenExecutionException(checker.buildLifecycleFailureMessage(project.getArtifactId(), analysis), project.getFile());
             }
-
-            List<MicronautCoordinate> conflicts = coordinates.stream()
-                .filter(coordinate -> coordinate.majorVersion().isPresent())
-                .filter(coordinate -> coordinate.majorVersion().getAsInt() != baselineMajor.getAsInt())
-                .toList();
-
-            if (!conflicts.isEmpty()) {
-                throw new MavenExecutionException(buildFailureMessage(project, baselineMajor.getAsInt(), coordinates, conflicts), project.getFile());
-            }
-        }
-    }
-
-    private List<MicronautCoordinate> collectMicronautCoordinates(MavenProject project) {
-        return Stream.of(
-                micronautParent(project.getModel().getParent()),
-                directMicronautDependencies(project.getDependencies(), "dependency"),
-                directMicronautDependencies(dependencyManagementDependencies(project), "dependencyManagement")
-            )
-            .flatMap(List::stream)
-            .filter(coordinate -> coordinate.majorVersion().isPresent())
-            .distinct()
-            .toList();
-    }
-
-    private List<Dependency> dependencyManagementDependencies(MavenProject project) {
-        DependencyManagement dependencyManagement = project.getModel().getDependencyManagement();
-        if (dependencyManagement == null) {
-            return List.of();
-        }
-        return dependencyManagement.getDependencies();
-    }
-
-    private List<MicronautCoordinate> micronautParent(Parent parent) {
-        if (parent == null || parent.getGroupId() == null || parent.getArtifactId() == null) {
-            return List.of();
-        }
-        if (!isMicronautGroup(parent.getGroupId())) {
-            return List.of();
-        }
-        String version = parent.getVersion();
-        return List.of(new MicronautCoordinate(
-            parent.getGroupId(),
-            parent.getArtifactId(),
-            version,
-            "parent",
-            parseMajorVersion(version)
-        ));
-    }
-
-    private List<MicronautCoordinate> directMicronautDependencies(List<Dependency> dependencies, String source) {
-        return dependencies.stream()
-            .filter(Objects::nonNull)
-            .filter(this::isDirectCompatibilitySignal)
-            .map(dependency -> new MicronautCoordinate(
-                dependency.getGroupId(),
-                dependency.getArtifactId(),
-                dependency.getVersion(),
-                source,
-                parseMajorVersion(dependency.getVersion())
-            ))
-            .toList();
-    }
-
-    private boolean isDirectCompatibilitySignal(Dependency dependency) {
-        return dependency.getGroupId() != null
-            && dependency.getArtifactId() != null
-            && dependency.getVersion() != null
-            && ((dependency.getGroupId().equals("io.micronaut.platform")
-                && (dependency.getArtifactId().equals("micronaut-parent") || dependency.getArtifactId().equals("micronaut-platform")))
-                || (dependency.getGroupId().equals("io.micronaut.starter") && dependency.getArtifactId().startsWith("micronaut-starter-"))
-                || (dependency.getGroupId().equals("io.micronaut") && dependency.getArtifactId().startsWith("micronaut-")));
-    }
-
-    private boolean isMicronautGroup(String groupId) {
-        return groupId != null && groupId.startsWith("io.micronaut");
-    }
-
-    private OptionalInt parseMajorVersion(String version) {
-        if (version == null) {
-            return OptionalInt.empty();
-        }
-        Matcher matcher = LEADING_MAJOR_PATTERN.matcher(version);
-        if (!matcher.find()) {
-            return OptionalInt.empty();
-        }
-        try {
-            return OptionalInt.of(Integer.parseInt(matcher.group(1)));
-        } catch (NumberFormatException e) {
-            return OptionalInt.empty();
-        }
-    }
-
-    private String buildFailureMessage(MavenProject project, int baselineMajor, List<MicronautCoordinate> coordinates, List<MicronautCoordinate> conflicts) {
-        String baseline = coordinates.stream()
-            .filter(coordinate -> coordinate.majorVersion().isPresent() && coordinate.majorVersion().getAsInt() == baselineMajor)
-            .filter(coordinate -> "parent".equals(coordinate.source()) || "dependencymanagement".equals(coordinate.source()))
-            .findFirst()
-            .map(coordinate -> coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + ']')
-            .orElse("major " + baselineMajor);
-
-        String details = conflicts.stream()
-            .sorted(Comparator
-                .comparingInt((MicronautCoordinate coordinate) -> coordinate.majorVersion().orElseThrow())
-                .thenComparing(MicronautCoordinate::groupId)
-                .thenComparing(MicronautCoordinate::artifactId)
-                .thenComparing(MicronautCoordinate::source))
-            .map(coordinate -> "- " + coordinate.groupId() + ':' + coordinate.artifactId() + ':' + coordinate.version() + " [" + coordinate.source() + "] (major " + coordinate.majorVersion().orElseThrow() + ')')
-            .collect(Collectors.joining(System.lineSeparator()));
-
-        return "Mixed Micronaut major versions detected in project " + project.getArtifactId() + ". "
-            + "Baseline major is " + baselineMajor + " from " + baseline + "."
-            + System.lineSeparator()
-            + System.lineSeparator()
-            + details;
-    }
-
-    record MicronautCoordinate(
-        String groupId,
-        String artifactId,
-        String version,
-        String source,
-        OptionalInt majorVersion
-    ) {
-        MicronautCoordinate {
-            version = version == null ? "<unknown>" : version;
-            source = source.toLowerCase(Locale.ROOT);
         }
     }
 }

--- a/micronaut-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/micronaut-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -279,6 +279,14 @@
             </configuration>
         </component>
 
+        <component>
+            <role>org.apache.maven.AbstractMavenLifecycleParticipant</role>
+            <role-hint>micronaut-major-version-check</role-hint>
+            <implementation>io.micronaut.maven.MicronautMajorVersionLifecycleExtension</implementation>
+            <description>Micronaut major version compatibility extension</description>
+            <isolated-realm>false</isolated-realm>
+        </component>
+
         <!-- Test resources lifecycle management -->
         <component>
             <role>org.apache.maven.AbstractMavenLifecycleParticipant</role>

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtensionTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MicronautMajorVersionLifecycleExtensionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven;
+
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Parent;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MicronautMajorVersionLifecycleExtensionTest {
+
+    @Test
+    void passesWhenMicronautCoordinatesUseSingleMajorVersion() throws MavenExecutionException {
+        MavenProject project = projectWithDependencies(List.of(
+            dependency("io.micronaut", "micronaut-inject", "5.0.0"),
+            dependency("io.micronaut.serde", "micronaut-serde-processor", "5.1.0")
+        ));
+        Parent parent = new Parent();
+        parent.setGroupId("io.micronaut.platform");
+        parent.setArtifactId("micronaut-parent");
+        parent.setVersion("5.0.0-SNAPSHOT");
+        project.getModel().setParent(parent);
+
+        MavenSession session = mock(MavenSession.class);
+        when(session.getAllProjects()).thenReturn(List.of(project));
+
+        assertDoesNotThrow(() -> new MicronautMajorVersionLifecycleExtension().afterProjectsRead(session));
+    }
+
+    @Test
+    void failsWhenParentAndDependencyManagementMixMicronautMajorVersions() {
+        MavenProject project = projectWithDependencies(List.of());
+        project.setArtifactId("foo-infra");
+
+        Parent parent = new Parent();
+        parent.setGroupId("io.micronaut.platform");
+        parent.setArtifactId("micronaut-parent");
+        parent.setVersion("5.0.0-SNAPSHOT");
+        project.getModel().setParent(parent);
+
+        DependencyManagement dependencyManagement = new DependencyManagement();
+        dependencyManagement.setDependencies(List.of(
+            dependency("io.micronaut", "micronaut-core-bom", "4.10.16")
+        ));
+        project.getModel().setDependencyManagement(dependencyManagement);
+
+        MavenSession session = mock(MavenSession.class);
+        when(session.getAllProjects()).thenReturn(List.of(project));
+
+        assertThrows(MavenExecutionException.class, () -> new MicronautMajorVersionLifecycleExtension().afterProjectsRead(session));
+    }
+
+    private MavenProject projectWithDependencies(List<Dependency> dependencies) {
+        MavenProject project = new MavenProject();
+        project.setDependencies(dependencies);
+        return project;
+    }
+
+    private Dependency dependency(String groupId, String artifactId, String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        return dependency;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,20 @@
         </developer>
     </developers>
 
+
+    <repositories>
+        <repository>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <properties>
         <jdk.version>25</jdk.version>
         <maven.compiler.source>${jdk.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <maven.compiler.target>${jdk.version}</maven.compiler.target>
 
         <maven.version>3.9.13</maven.version>
-        <micronaut.version>5.0.0-M16</micronaut.version>
+        <micronaut.version>5.0.0-SNAPSHOT</micronaut.version>
         <native-maven-plugin.version>0.11.5</native-maven-plugin.version>
         <micronaut.aot.version>3.0.0-M2</micronaut.aot.version>
         <micronaut.test.resources.version>3.0.0-M6</micronaut.test.resources.version>


### PR DESCRIPTION
## What
- add `CheckMicronautMajorVersions` to `micronaut-maven-enforcer-rules`
- add focused unit coverage for mixed Micronaut majors in dependencies and dependency management
- add an invoker scenario proving the custom rule fails a mixed-major consumer build

## Why
Projects can currently mix Micronaut artifacts from different major lines and only fail much later with confusing dependency-resolution or build errors. This adds a Micronaut-specific enforcer rule that fails fast with a targeted message.

## Verification
- `./mvnw -pl micronaut-maven-enforcer-rules -Dtest=CheckMicronautMajorVersionsTest test`
- `./mvnw -pl micronaut-maven-integration-tests -am -DskipTests -Dinvoker.test=micronaut-mixed-major-versions -Dsurefire.failIfNoSpecifiedTests=false verify`
- invoker scenario result: `micronaut-mixed-major-versions/pom.xml ........... SUCCESS` (expected failure scenario asserted by `verify.groovy`)

## Notes
This PR implements the reusable custom rule in `micronaut-maven-plugin`. To enable it by default for consumer projects, `micronaut-parent` in `micronaut-platform` still needs a companion change to add `<checkMicronautMajorVersions/>` to its enforcer rules.
