### PR TITLE
fix: require explicit opt-in for configuration validation

### DIFF
--- a/micronaut-maven-integration-tests/src/it/configuration-validation-cache-failure/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-cache-failure/pom.xml
@@ -44,6 +44,11 @@
                 <groupId>io.micronaut.maven</groupId>
                 <artifactId>micronaut-maven-plugin</artifactId>
                 <version>${micronaut-maven-plugin.version}</version>
+                <configuration>
+                    <configurationValidation>
+                        <enabled>true</enabled>
+                    </configurationValidation>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-cache-invalidation/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-cache-invalidation/pom.xml
@@ -47,6 +47,7 @@
 
                 <configuration>
                     <configurationValidation>
+                        <enabled>true</enabled>
                         <packageValidation>
                             <resourceDirectories>
                                 <resourceDirectory>${project.basedir}/src/main/custom-resources</resourceDirectory>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-default-package/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-default-package/verify.groovy
@@ -3,6 +3,8 @@ assert log.exists()
 
 def text = log.text
 
-// Ensure validate-configuration is executed by default when running mvn package
 assert text.contains('validate-configuration')
-assert text.contains('Validating Micronaut configuration (package)')
+assert !text.contains('Validating Micronaut configuration (package)')
+
+File report = new File(basedir, 'target/micronaut/config-validation/package/configuration-errors.json')
+assert !report.exists()

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-default-test/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-default-test/verify.groovy
@@ -3,6 +3,8 @@ assert log.exists()
 
 def text = log.text
 
-// Ensure validate-test-configuration is executed by default when running mvn test
 assert text.contains('validate-test-configuration')
-assert text.contains('Validating Micronaut configuration (test)')
+assert !text.contains('Validating Micronaut configuration (test)')
+
+File report = new File(basedir, 'target/micronaut/config-validation/test/configuration-errors.json')
+assert !report.exists()

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-dependency-injection-suppress/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-dependency-injection-suppress/pom.xml
@@ -57,6 +57,7 @@
                 <version>${micronaut-maven-plugin.version}</version>
                 <configuration>
                     <configurationValidation>
+                        <enabled>true</enabled>
                         <format>json</format>
                         <validateDependencyInjection>true</validateDependencyInjection>
                         <suppressInjectErrors>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-dependency-injection/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-dependency-injection/pom.xml
@@ -57,6 +57,7 @@
                 <version>${micronaut-maven-plugin.version}</version>
                 <configuration>
                     <configurationValidation>
+                        <enabled>true</enabled>
                         <format>json</format>
                         <validateDependencyInjection>true</validateDependencyInjection>
                     </configurationValidation>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-di-cache-invalidation/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-di-cache-invalidation/pom.xml
@@ -47,6 +47,7 @@
 
                 <configuration>
                     <configurationValidation>
+                        <enabled>true</enabled>
                         <validateDependencyInjection>true</validateDependencyInjection>
                     </configurationValidation>
                 </configuration>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-invalid/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-invalid/pom.xml
@@ -57,6 +57,7 @@
                 <version>${micronaut-maven-plugin.version}</version>
                 <configuration>
                     <configurationValidation>
+                        <enabled>true</enabled>
                         <format>json</format>
                     </configurationValidation>
                 </configuration>

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-options/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-options/pom.xml
@@ -65,6 +65,7 @@
                         </goals>
                         <configuration>
                             <configurationValidation>
+                                <enabled>true</enabled>
                                 <cacheEnabled>false</cacheEnabled>
                                 <outputDirectory>${project.build.directory}/validation-reports</outputDirectory>
                                 <suppressions>
@@ -90,6 +91,7 @@
                         </goals>
                         <configuration>
                             <configurationValidation>
+                                <enabled>true</enabled>
                                 <cacheEnabled>false</cacheEnabled>
                                 <outputDirectory>${project.build.directory}/validation-reports</outputDirectory>
 

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-options/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-options/verify.groovy
@@ -7,7 +7,7 @@ def text = log.text
 
 // cacheEnabled=false => validation should run on both invocations
 assert (text.count('Validating Micronaut configuration (package)') == 2)
-assert (text.count('Validating Micronaut configuration (test)') == 3)
+assert (text.count('Validating Micronaut configuration (test)') == 2)
 
 File packageJson = new File(basedir, 'target/validation-reports/package/configuration-errors.json')
 File packageHtml = new File(basedir, 'target/validation-reports/package/configuration-errors.html')

--- a/micronaut-maven-integration-tests/src/it/configuration-validation-valid/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-valid/pom.xml
@@ -57,6 +57,7 @@
                 <version>${micronaut-maven-plugin.version}</version>
                 <configuration>
                     <configurationValidation>
+                        <enabled>true</enabled>
                         <format>json</format>
                     </configurationValidation>
                 </configuration>

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojo.java
@@ -256,6 +256,7 @@ abstract class AbstractConfigurationValidationMojo extends AbstractMicronautMojo
 
             If these dependency injection errors can be ignored, add the following to your pom.xml:
             <configurationValidation>
+                <enabled>true</enabled>
                 <validateDependencyInjection>true</validateDependencyInjection>
                 <suppressInjectErrors>
             %s
@@ -332,7 +333,7 @@ abstract class AbstractConfigurationValidationMojo extends AbstractMicronautMojo
     }
 
     private boolean isEnabled(ConfigurationValidationConfiguration cfg) {
-        return cfg.getEnabled() == null || cfg.getEnabled();
+        return Boolean.TRUE.equals(cfg.getEnabled());
     }
 
     private Path determineOutputDir(ConfigurationValidationConfiguration cfg, ConfigurationValidationConfiguration.ValidationSet set) {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/jsonschema/ConfigurationValidationConfiguration.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/jsonschema/ConfigurationValidationConfiguration.java
@@ -80,7 +80,7 @@ public final class ConfigurationValidationConfiguration {
     private ValidationSet test;
 
     /**
-     * @return Whether configuration validation is enabled. If {@code null}, validation is enabled.
+     * @return Whether configuration validation is enabled. If {@code null}, validation is disabled.
      */
     public Boolean getEnabled() {
         return enabled;
@@ -321,7 +321,9 @@ public final class ConfigurationValidationConfiguration {
         private List<File> resourceDirectories;
 
         /**
-         * @return Whether this validation scenario is enabled. If {@code null}, the scenario is enabled.
+         * @return Whether this validation scenario is enabled. If {@code null}, the scenario follows the global
+         * {@link ConfigurationValidationConfiguration#getEnabled()} setting. This flag cannot force execution if
+         * global validation is disabled.
          */
         public Boolean getEnabled() {
             return enabled;

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/configuration-validation.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/configuration-validation.adoc
@@ -101,7 +101,7 @@ The mojos share a `configurationValidation` block and expose options equivalent 
 </plugin>
 ----
 
-The `<enabled>` flag defaults to `false`, so you must set it to `true` to run validation.
+If `<enabled>` is not set (or is set to `false`), validation does not run; set it to `true` to enable validation.
 
 === Classpath configuration
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/configuration-validation.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/configuration-validation.adoc
@@ -2,12 +2,13 @@
 
 The Micronaut Maven Plugin can validate your application's configuration files (for example `application.yml`) using JSON Schema.
 The build fails when validation reports errors.
+Validation is disabled by default and must be explicitly enabled.
 
 == Goals
 
 * `mn:validate-dev-configuration`
 ** Validates using the `dev` environment.
-** This goal is automatically executed by `mn:run`.
+** This goal is invoked by `mn:run` and runs validation only when explicitly enabled.
 * `mn:validate-configuration`
 ** Intended for `mvn package` (for example production configuration).
 ** Default environments: none.
@@ -17,11 +18,11 @@ The build fails when validation reports errors.
 
 == Binding to the lifecycle
 
-Configuration validation runs automatically when using Micronaut packaging types (`jar`, `native-image`, `docker`, `docker-native`, `docker-crac`):
+Configuration validation goals are wired when using Micronaut packaging types (`jar`, `native-image`, `docker`, `docker-native`, `docker-crac`), but validation only executes when explicitly enabled:
 
 * `validate-configuration` runs during the `prepare-package` phase (before `mvn package`)
 * `validate-test-configuration` runs during the `test` phase (as part of `mvn test`)
-* `validate-dev-configuration` is automatically executed by `mn:run`
+* `validate-dev-configuration` is invoked by `mn:run`
 
 If you are not using Micronaut packaging or want to customize the phase bindings, you can configure explicit executions:
 
@@ -90,7 +91,7 @@ The mojos share a `configurationValidation` block and expose options equivalent 
                 </environments>
             </packageValidation>
             <test>
-                <!-- additional environments are appended; 'test' is enabled by default -->
+                <!-- additional environments are appended; 'test' environment is included by default when validation runs -->
                 <environments>
                     <environment>ci</environment>
                 </environments>
@@ -99,6 +100,8 @@ The mojos share a `configurationValidation` block and expose options equivalent 
     </configuration>
 </plugin>
 ----
+
+The `<enabled>` flag defaults to `false`, so you must set it to `true` to run validation.
 
 === Classpath configuration
 
@@ -115,6 +118,7 @@ You can also validate Micronaut dependency injection wiring (missing beans, unsa
 [source,xml]
 ----
 <configurationValidation>
+    <enabled>true</enabled>
     <validateDependencyInjection>true</validateDependencyInjection>
 </configurationValidation>
 ----
@@ -127,6 +131,7 @@ If you need to suppress known dependency-injection issues (for example optional 
 [source,xml]
 ----
 <configurationValidation>
+    <enabled>true</enabled>
     <validateDependencyInjection>true</validateDependencyInjection>
     <suppressInjectErrors>
         <suppressInjectError>com.example.optional.MissingBean</suppressInjectError>
@@ -156,6 +161,7 @@ Disable caching with:
 [source,xml]
 ----
 <configurationValidation>
+    <enabled>true</enabled>
     <cacheEnabled>false</cacheEnabled>
 </configurationValidation>
 ----

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
@@ -14,8 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -107,17 +106,22 @@ class AbstractConfigurationValidationMojoTest {
     }
 
     @Test
-    void configurationValidationIsDisabledByDefaultUnlessExplicitlyEnabled() {
+    void configurationValidationEnabledIsNullByDefault() {
         ConfigurationValidationConfiguration configuration = new ConfigurationValidationConfiguration();
 
-        // By default (enabled == null), configuration should be treated as disabled
-        assertFalse(Boolean.TRUE.equals(configuration.getEnabled()));
+        // By default, enabled is null (unset), not explicitly false
+        assertNull(configuration.getEnabled());
+    }
+
+    @Test
+    void configurationValidationEnabledReflectsExplicitlySetValue() {
+        ConfigurationValidationConfiguration configuration = new ConfigurationValidationConfiguration();
 
         configuration.setEnabled(Boolean.TRUE);
-        assertTrue(Boolean.TRUE.equals(configuration.getEnabled()));
+        assertEquals(Boolean.TRUE, configuration.getEnabled());
 
         configuration.setEnabled(Boolean.FALSE);
-        assertFalse(Boolean.TRUE.equals(configuration.getEnabled()));
+        assertEquals(Boolean.FALSE, configuration.getEnabled());
     }
 
     private static String invokeSuppressionHint(AbstractConfigurationValidationMojo mojo,

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
@@ -8,7 +8,6 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -107,17 +106,17 @@ class AbstractConfigurationValidationMojoTest {
     }
 
     @Test
-    void configurationValidationIsDisabledByDefaultUnlessExplicitlyEnabled() throws Exception {
-        TestConfigurationValidationMojo mojo = new TestConfigurationValidationMojo();
+    void configurationValidationIsDisabledByDefaultUnlessExplicitlyEnabled() {
         ConfigurationValidationConfiguration configuration = new ConfigurationValidationConfiguration();
 
-        assertFalse(invokeIsEnabled(mojo, configuration));
+        // By default (enabled == null), configuration should be treated as disabled
+        assertFalse(Boolean.TRUE.equals(configuration.getEnabled()));
 
         configuration.setEnabled(Boolean.TRUE);
-        assertTrue(invokeIsEnabled(mojo, configuration));
+        assertTrue(Boolean.TRUE.equals(configuration.getEnabled()));
 
         configuration.setEnabled(Boolean.FALSE);
-        assertFalse(invokeIsEnabled(mojo, configuration));
+        assertFalse(Boolean.TRUE.equals(configuration.getEnabled()));
     }
 
     private static String invokeSuppressionHint(AbstractConfigurationValidationMojo mojo,
@@ -128,13 +127,6 @@ class AbstractConfigurationValidationMojoTest {
         return (String) method.invoke(mojo, errors);
     }
 
-    private static boolean invokeIsEnabled(AbstractConfigurationValidationMojo mojo,
-                                           ConfigurationValidationConfiguration configuration) throws Exception {
-        Method method = AbstractConfigurationValidationMojo.class
-            .getDeclaredMethod("isEnabled", ConfigurationValidationConfiguration.class);
-        method.setAccessible(true);
-        return (boolean) method.invoke(mojo, configuration);
-    }
 
     private static final class TestConfigurationValidationMojo extends AbstractConfigurationValidationMojo {
 

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
@@ -8,6 +8,7 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
@@ -8,13 +8,13 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -106,12 +106,34 @@ class AbstractConfigurationValidationMojoTest {
         assertEquals(List.of(outputDirectory.toString(), testOutputDirectory.toString()), classpath);
     }
 
+    @Test
+    void configurationValidationIsDisabledByDefaultUnlessExplicitlyEnabled() throws Exception {
+        TestConfigurationValidationMojo mojo = new TestConfigurationValidationMojo();
+        ConfigurationValidationConfiguration configuration = new ConfigurationValidationConfiguration();
+
+        assertFalse(invokeIsEnabled(mojo, configuration));
+
+        configuration.setEnabled(Boolean.TRUE);
+        assertTrue(invokeIsEnabled(mojo, configuration));
+
+        configuration.setEnabled(Boolean.FALSE);
+        assertFalse(invokeIsEnabled(mojo, configuration));
+    }
+
     private static String invokeSuppressionHint(AbstractConfigurationValidationMojo mojo,
                                                 Set<DependencyInjectionError> errors) throws Exception {
         Method method = AbstractConfigurationValidationMojo.class
             .getDeclaredMethod("buildDependencyInjectionSuppressionHint", Set.class);
         method.setAccessible(true);
         return (String) method.invoke(mojo, errors);
+    }
+
+    private static boolean invokeIsEnabled(AbstractConfigurationValidationMojo mojo,
+                                           ConfigurationValidationConfiguration configuration) throws Exception {
+        Method method = AbstractConfigurationValidationMojo.class
+            .getDeclaredMethod("isEnabled", ConfigurationValidationConfiguration.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(mojo, configuration);
     }
 
     private static final class TestConfigurationValidationMojo extends AbstractConfigurationValidationMojo {


### PR DESCRIPTION
## Summary
- change configuration validation execution to be opt-in by default, so it only runs when `configurationValidation.enabled` is explicitly set to `true`
- update configuration-validation integration scenarios to opt in explicitly where validation is expected, and adjust default-behavior scenarios to assert validation does not run by default
- align docs and suppression hint snippets with the new opt-in behavior to avoid copy/paste misconfiguration

## Verification
- `./mvnw -pl micronaut-maven-plugin -Dtest=AbstractConfigurationValidationMojoTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=configuration-validation*"`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=configuration-validation-dependency-injection*"`