### PR TITLE
Support the http_server_jdk runtime alias in Docker builds

### DIFF
--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/core/MicronautRuntime.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/core/MicronautRuntime.java
@@ -35,6 +35,11 @@ public enum MicronautRuntime {
     NETTY(),
 
     /**
+     * Starter compatibility alias for the JDK HTTP server runtime.
+     */
+    HTTP_SERVER_JDK(),
+
+    /**
      * Tomcat server.
      */
     TOMCAT(),

--- a/micronaut-maven-jib-integration/src/test/java/io/micronaut/maven/jib/JibMicronautExtensionTest.java
+++ b/micronaut-maven-jib-integration/src/test/java/io/micronaut/maven/jib/JibMicronautExtensionTest.java
@@ -9,6 +9,7 @@ import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.api.buildplan.Port;
 import com.google.cloud.tools.jib.maven.extension.MavenData;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
+import io.micronaut.maven.core.MicronautRuntime;
 import io.micronaut.maven.core.DockerBuildStrategy;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
@@ -191,7 +192,7 @@ class JibMicronautExtensionTest {
                 .setBaseImage("")
                 .build();
         var properties = new Properties();
-        properties.setProperty("micronaut.runtime", "http_server_jdk");
+        properties.setProperty(MicronautRuntime.PROPERTY, "http_server_jdk");
 
         var finalPlan = extendContainerBuildPlan(originalPlan, properties);
 

--- a/micronaut-maven-jib-integration/src/test/java/io/micronaut/maven/jib/JibMicronautExtensionTest.java
+++ b/micronaut-maven-jib-integration/src/test/java/io/micronaut/maven/jib/JibMicronautExtensionTest.java
@@ -186,6 +186,19 @@ class JibMicronautExtensionTest {
     }
 
     @Test
+    void testSupportsHttpServerJdkRuntimeProperty() {
+        var originalPlan = ContainerBuildPlan.builder()
+                .setBaseImage("")
+                .build();
+        var properties = new Properties();
+        properties.setProperty("micronaut.runtime", "http_server_jdk");
+
+        var finalPlan = extendContainerBuildPlan(originalPlan, properties);
+
+        assertEquals("eclipse-temurin:25-jre", finalPlan.getBaseImage());
+    }
+
+    @Test
     void testGetJdkVersionPrefersReleaseFromProjectProperties() {
         MavenProject project = mock(MavenProject.class);
         Properties props = new Properties();
@@ -233,18 +246,22 @@ class JibMicronautExtensionTest {
     }
 
     private ContainerBuildPlan extendContainerBuildPlan(ContainerBuildPlan originalPlan) {
+        return extendContainerBuildPlan(originalPlan, new Properties());
+    }
+
+    private ContainerBuildPlan extendContainerBuildPlan(ContainerBuildPlan originalPlan, Properties properties) {
         var extension = new JibMicronautExtension();
+        var project = mock(MavenProject.class);
+        when(project.getProperties()).thenReturn(properties);
         var mavenData = new MavenData() {
             @Override
             public MavenProject getMavenProject() {
-                var project = mock(MavenProject.class);
-                when(project.getProperties()).thenReturn(new Properties());
                 return project;
             }
 
             @Override
             public MavenSession getMavenSession() {
-                return mock(MavenSession.class);
+                return mockSessionFor(getMavenProject());
             }
         };
         ExtensionLogger extensionLogger = (logLevel, s) -> LOG.info(s);

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MicronautRuntimeCompatibilityTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MicronautRuntimeCompatibilityTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.maven;
+
+import io.micronaut.maven.core.DockerBuildStrategy;
+import io.micronaut.maven.core.MicronautRuntime;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MicronautRuntimeCompatibilityTest {
+
+    @Test
+    void supportsHttpServerJdkRuntimeGeneratedByStarter() {
+        var runtime = MicronautRuntime.valueOf("http_server_jdk".toUpperCase(Locale.ROOT));
+
+        assertEquals(MicronautRuntime.HTTP_SERVER_JDK, runtime);
+        assertEquals(DockerBuildStrategy.DEFAULT, runtime.getBuildStrategy());
+    }
+}


### PR DESCRIPTION
## Summary
- add `HTTP_SERVER_JDK` as a first-class `MicronautRuntime` so the starter-emitted `http_server_jdk` value is accepted by Docker and Jib flows
- keep the default Docker build strategy for that runtime so base-image resolution and docker goals stay aligned
- add regression coverage for the runtime handling and Jib base-image selection

## Verification
- ./mvnw -pl micronaut-maven-plugin,micronaut-maven-jib-integration -am test

Closes #1515