### PR TITLE
docs: refresh stale README and site examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To see the documentation of a particular version, replace `latest` or `snapshot`
 
 ## Snapshots and Releases
 
-Snaphots and releases are automatically published to Maven Central using [GitHub Actions](https://github.com/micronaut-projects/micronaut-maven-plugin/actions).
+Snapshots and releases are automatically published to Maven Central using [GitHub Actions](https://github.com/micronaut-projects/micronaut-maven-plugin/actions).
 
 A release is performed with the following steps:
 
@@ -46,10 +46,11 @@ $ mvn install
 You can skip execution of integration tests by adding `-Dinvoker.skip=true` to the command line.
 
 Then you need a sample application. The one at `examples/java` is the most up-to-date, but you can in principle generate
-a new one from Micronaut Starter. Then, change its `pom.xml` to set the following property:
+a new one from Micronaut Starter. Then, change its `pom.xml` to set the following property. For the current `5.0.x`
+branch, a locally built snapshot would typically use:
 
 ```xml
-<micronaut-maven-plugin.version>1.1.5-SNAPSHOT</micronaut-maven-plugin.version>
+<micronaut-maven-plugin.version>5.0.0-SNAPSHOT</micronaut-maven-plugin.version>
 ```
 
 Pointing to whatever snapshot version you published before.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ $ mvn install
 You can skip execution of integration tests by adding `-Dinvoker.skip=true` to the command line.
 
 Then you need a sample application. The one at `examples/java` is the most up-to-date, but you can in principle generate
-a new one from Micronaut Starter. Then, change its `pom.xml` to set the following property. For the current `5.0.x`
-branch, a locally built snapshot would typically use:
+a new one from Micronaut Starter. Then, change its `pom.xml` to set the following property, using the snapshot version
+you published locally. For branch-specific examples and current documentation, refer to the Snapshot Documentation link
+above:
 
 ```xml
-<micronaut-maven-plugin.version>5.0.0-SNAPSHOT</micronaut-maven-plugin.version>
+<micronaut-maven-plugin.version>X.Y.Z-SNAPSHOT</micronaut-maven-plugin.version>
 ```
 
 Pointing to whatever snapshot version you published before.
@@ -66,5 +67,5 @@ Then in your IDE, attach a remote debugger to port 8000.
 ### Preparing for a new minor/major version
 
 ```shell
-mvn release:update-versions -DautoVersionSubmodules=true -DdevelopmentVersion=4.6.0-SNAPSHOT
+mvn release:update-versions -DautoVersionSubmodules=true -DdevelopmentVersion=X.Y.Z-SNAPSHOT
 ```

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/test-resources.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/test-resources.adoc
@@ -50,7 +50,7 @@ server, separate of the others.
 
 However, you might want to run the consumer in one terminal, and the producer in another, and still want them to talk to
 the same Kafka cluster. For this you can use a shared test server, by passing the `micronaut.test.resources.shared`
-system property, or setting `<shared>true<shared>` in the Micronaut Maven Plugin configuration.
+system property, or setting `<shared>true</shared>` in the Micronaut Maven Plugin configuration.
 
 ==== Test Resource Service lifecycle
 
@@ -148,4 +148,3 @@ https://micronaut-projects.github.io/micronaut-test-resources/latest/guide/#modu
 
 You can see all the additional configuration options in the
 link:../start-testresources-service-mojo.html[`start-testresources-service` goal documentation].
-


### PR DESCRIPTION
## Summary
- fix the README snapshot debugging example for the active `5.0.x` branch and correct the nearby typo
- fix the malformed shared test resources XML snippet in the site AsciiDoc example

## Verification
- confirmed `README.md` now uses `5.0.0-SNAPSHOT`
- generated `micronaut-maven-plugin/target/site/examples/test-resources.html` and confirmed it renders `&lt;shared&gt;true&lt;/shared&gt;`
- `./mvnw -pl micronaut-maven-plugin -am -DskipTests -Dmaven.javadoc.skip=true site:site` renders the site content, then continues into long-running repo-wide report generation unrelated to this docs patch

## Tracking
- Internal tracking: CLI-64
- No linked GitHub issue exists for this repository maintenance change
