### PR TITLE
Cancel superseded Java and Windows CI workflow runs

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,6 +14,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -11,6 +11,11 @@ on:
       - '[1-9]+.[0-9]+.x'
   merge_group:
     types: [checks_requested]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest
@@ -40,5 +45,4 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-
 


### PR DESCRIPTION
## Summary
- add workflow-level concurrency controls to `Java CI` and `Windows CI`
- group runs by workflow name and ref so newer commits cancel superseded runs
- keep the existing triggers and job graph unchanged

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/snapshot.yml"); YAML.load_file(".github/workflows/windows-ci.yml")'`
- `actionlint .github/workflows/snapshot.yml .github/workflows/windows-ci.yml` *(reports only pre-existing `snapshot.yml` warnings about shellcheck and deprecated `set-output` usage)*
