### PR TITLE
Fix Oracle Function docker-native default base images

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol8 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes
@@ -10,7 +10,7 @@ RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-eleme
 
 FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM container-registry.oracle.com/os/oraclelinux:8-slim
 WORKDIR /function
 COPY --from=builder /home/app/application /function/func
 COPY --from=fnfdk /function/runtime/lib/* .

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol8 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes
@@ -10,7 +10,7 @@ RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-eleme
 
 FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM container-registry.oracle.com/os/oraclelinux:8-slim
 WORKDIR /function
 COPY --from=builder /home/app/application /function/func
 COPY --from=fnfdk /function/runtime/lib/* .

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -59,6 +59,10 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
 
     public static final String LATEST_TAG = "latest";
     public static final String DEFAULT_BASE_IMAGE_GRAALVM_RUN = "cgr.dev/chainguard/wolfi-base:latest";
+    public static final String DEFAULT_NATIVE_IMAGE_BUILDER = "ghcr.io/graalvm/native-image-community:";
+    public static final String ORACLE_FUNCTION_BASE_IMAGE_RUN = "container-registry.oracle.com/os/oraclelinux:8-slim";
+    public static final String ORACLE_FUNCTION_NATIVE_IMAGE_BUILDER = "container-registry.oracle.com/graalvm/native-image:";
+    public static final String ORACLE_FUNCTION_ORACLE_LINUX_VERSION = "ol8";
     public static final String MOSTLY_STATIC_NATIVE_IMAGE_GRAALVM_FLAG = "-H:+StaticExecutableWithDynamicLibC";
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "x64";
@@ -68,6 +72,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
 
     protected final MavenProject mavenProject;
     protected final MavenSession mavenSession;
+    protected final MojoExecution mojoExecution;
     protected final JibConfigurationService jibConfigurationService;
     protected final ApplicationConfigurationService applicationConfigurationService;
     protected final DockerService dockerService;
@@ -137,6 +142,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
                                  DockerService dockerService, MavenSession mavenSession, MojoExecution mojoExecution) {
         this.mavenProject = mavenProject;
         this.mavenSession = mavenSession;
+        this.mojoExecution = mojoExecution;
         this.jibConfigurationService = jibConfigurationService;
         this.applicationConfigurationService = applicationConfigurationService;
         this.dockerService = dockerService;
@@ -197,7 +203,19 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      * @return the base FROM image for the native image.
      */
     protected String getFrom() {
-        return getFromImage().orElse("ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
+        return getFromImage().orElseGet(() -> isOracleFunctionRuntime()
+            ? ORACLE_FUNCTION_NATIVE_IMAGE_BUILDER + graalVmTag(graalVmJvmVersion(), false, ORACLE_FUNCTION_ORACLE_LINUX_VERSION)
+            : DEFAULT_NATIVE_IMAGE_BUILDER + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
+    }
+
+    /**
+     * @return the runtime image to use for the native image.
+     */
+    protected String getBaseImageRun() {
+        if (isOracleFunctionRuntime() && DEFAULT_BASE_IMAGE_GRAALVM_RUN.equals(baseImageRun)) {
+            return ORACLE_FUNCTION_BASE_IMAGE_RUN;
+        }
+        return baseImageRun;
     }
 
     /**
@@ -230,6 +248,10 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      */
     protected Optional<String> getFromImage() {
         return jibConfigurationService.getFromImage();
+    }
+
+    private boolean isOracleFunctionRuntime() {
+        return MicronautRuntime.ORACLE_FUNCTION.name().equalsIgnoreCase(micronautRuntime);
     }
 
     /**

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -169,6 +169,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
     }
 
     private void buildDockerNative() throws IOException, InvalidImageReferenceException {
+        String baseImageRun = getBaseImageRun();
         String dockerfileName = DockerfileMojo.DOCKERFILE_NATIVE;
         if (Boolean.TRUE.equals(staticNativeImage)) {
             getLog().info("Generating a static native image");
@@ -192,6 +193,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         }
 
         String from = getFrom();
+        String baseImageRun = getBaseImageRun();
         String ports = getPorts();
         getLog().info("Exposing port(s): " + ports);
 
@@ -223,7 +225,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
 
     private BuildImageCmd addNativeImageBuildArgs(Map<String, String> buildImageCmdArguments, Supplier<BuildImageCmd> buildImageCmdSupplier) throws IOException {
         String argsFile = mavenProject.getProperties().getProperty(ARGS_FILE_PROPERTY_NAME);
-        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile);
+        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, getBaseImageRun(), argsFile);
         //Remove extra main class argument
         allNativeImageBuildArgs.remove(mainClass);
         getLog().info("GraalVM native image build args: " + allNativeImageBuildArgs);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -159,6 +159,7 @@ public class DockerfileMojo extends AbstractDockerMojo {
         getLog().info("Generating GraalVM args file");
         executorService.invokeGoal(NATIVE_BUILD_TOOLS_MAVEN_PLUGIN, "write-args-file");
         File dockerfile;
+        String baseImageRun = getBaseImageRun();
         switch (runtime.getBuildStrategy()) {
             case LAMBDA -> dockerfile = dockerService.loadDockerfileAsResource(DOCKERFILE_AWS_CUSTOM_RUNTIME);
             case ORACLE_FUNCTION -> {
@@ -183,6 +184,7 @@ public class DockerfileMojo extends AbstractDockerMojo {
     }
 
     private void processDockerfile(File dockerfile) throws IOException {
+        String baseImageRun = getBaseImageRun();
 
         if (dockerfile != null) {
             var allLines = Files.readAllLines(dockerfile.toPath());

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeOracleCloud
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeOracleCloud
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-ARG BASE_IMAGE_RUN=cgr.dev/chainguard/wolfi-base:latest
+ARG BASE_IMAGE_RUN=container-registry.oracle.com/os/oraclelinux:8-slim
 FROM ${BASE_IMAGE} AS builder
 WORKDIR /home/app
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -214,7 +214,10 @@ command line:
 * `jib.to.credHelper`.
 
 Note that changing the base image to a totally different one than the default might break image building, since the rest
-of the build steps expect a certain base image. By default, the native images are built from an `ghcr.io/graalvm/native-image-community` image.
+of the build steps expect a certain base image. By default, the native images are built from an `ghcr.io/graalvm/native-image-community`
+builder image and run on `cgr.dev/chainguard/wolfi-base:latest`. Oracle Cloud Function native builds use
+`container-registry.oracle.com/graalvm/native-image:<jdk>-ol8` and `container-registry.oracle.com/os/oraclelinux:8-slim`
+unless you override them.
 
 In the case of AWS custom runtime, it starts from `amazonlinux:2023`, and this cannot be changed. Also, in this case the
 result is not a tagged Docker image, but a `function.zip` archive that contains the launch script and the native binary.

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
@@ -22,6 +22,8 @@ import java.net.http.HttpResponse;
 import java.util.Optional;
 import java.util.Properties;
 
+import static io.micronaut.maven.AbstractDockerMojo.DEFAULT_BASE_IMAGE_GRAALVM_RUN;
+import static io.micronaut.maven.AbstractDockerMojo.ORACLE_FUNCTION_BASE_IMAGE_RUN;
 import static io.micronaut.maven.AbstractDockerMojo.X86_64_ARCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -126,6 +128,50 @@ class DockerNativeMojoTest {
         var ports = mojo.getPorts();
 
         assertEquals("8081", ports);
+    }
+
+    @Test
+    void testOracleFunctionDefaultsUseOracleImages() {
+        var project = mock(MavenProject.class);
+        var session = mock(MavenSession.class);
+        var execution = mock(MojoExecution.class);
+        var properties = new Properties(1);
+        properties.put("maven.compiler.target", "25");
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getSystemProperties()).thenReturn(new Properties());
+        when(project.getProperties()).thenReturn(properties);
+
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
+
+        var mojo = new DockerNativeMojo(project, jibConfigurationService, null, null, session, execution);
+        mojo.micronautRuntime = "oracle_function";
+        mojo.baseImageRun = DEFAULT_BASE_IMAGE_GRAALVM_RUN;
+
+        assertEquals("container-registry.oracle.com/graalvm/native-image:25-ol8", mojo.getFrom());
+        assertEquals(ORACLE_FUNCTION_BASE_IMAGE_RUN, mojo.getBaseImageRun());
+    }
+
+    @Test
+    void testOracleFunctionOverridesStillWin() {
+        var project = mock(MavenProject.class);
+        var session = mock(MavenSession.class);
+        var execution = mock(MojoExecution.class);
+        var properties = new Properties(1);
+        properties.put("maven.compiler.target", "25");
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getSystemProperties()).thenReturn(new Properties());
+        when(project.getProperties()).thenReturn(properties);
+
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("example.com/custom-builder:1"));
+
+        var mojo = new DockerNativeMojo(project, jibConfigurationService, null, null, session, execution);
+        mojo.micronautRuntime = "oracle_function";
+        mojo.baseImageRun = "example.com/custom-run:1";
+
+        assertEquals("example.com/custom-builder:1", mojo.getFrom());
+        assertEquals("example.com/custom-run:1", mojo.getBaseImageRun());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- use Oracle GraalVM and Oracle Linux defaults for Oracle Function `docker-native` builds when no custom images are configured
- keep custom builder and runtime image overrides working while updating the Oracle native Dockerfile template and invoker fixtures
- add unit coverage for Oracle Function default image resolution and document the Oracle-specific native image defaults

## Verification
- `./mvnw -pl micronaut-maven-plugin -am -Dtest=DockerNativeMojoTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=dockerfile-docker-native-oracle*"`

Fixes #933