### PR TITLE
Add Windows smoke coverage for docker-native args handling

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
@@ -123,14 +123,17 @@ public final class MojoUtils {
 
     private static Path resolveNestedArgsFilePath(Path argsFilePath, String fileName) {
         Path nestedArgsFilePath = Paths.get(FilenameUtils.separatorsToSystem(fileName)).normalize();
-        if (nestedArgsFilePath.isAbsolute() || Files.exists(nestedArgsFilePath)) {
+        if (nestedArgsFilePath.isAbsolute()) {
             return nestedArgsFilePath;
         }
         Path parent = argsFilePath.getParent();
-        if (parent == null) {
-            return nestedArgsFilePath;
+        if (parent != null) {
+            Path resolved = parent.resolve(nestedArgsFilePath).normalize();
+            if (Files.exists(resolved)) {
+                return resolved;
+            }
         }
-        return parent.resolve(nestedArgsFilePath).normalize();
+        return nestedArgsFilePath;
     }
 
     private static String parseQuotedClasspathArg(String arg) {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/MojoUtils.java
@@ -83,7 +83,10 @@ public final class MojoUtils {
     }
 
     private static Stream<String> parseNativeImageArgsFile(String argsFile) {
-        Path argsFilePath = Paths.get(argsFile);
+        return parseNativeImageArgsFile(Paths.get(FilenameUtils.separatorsToSystem(argsFile)));
+    }
+
+    private static Stream<String> parseNativeImageArgsFile(Path argsFilePath) {
         if (Files.exists(argsFilePath)) {
             List<String> args;
             try {
@@ -104,11 +107,9 @@ public final class MojoUtils {
                 .flatMap(arg -> {
                     if (arg.startsWith("@")) {
                         String fileName = arg.substring(1);
-                        return parseNativeImageArgsFile(fileName);
+                        return parseNativeImageArgsFile(resolveNestedArgsFilePath(argsFilePath, fileName));
                     } else if (arg.startsWith("\\Q") && arg.endsWith("\\E")) {
-                        // start the search at length - 3 to skip \Q or \E at the end
-                        int lastIndexOfSlash = arg.lastIndexOf(File.separator, arg.length() - 3);
-                        return Stream.of("\\Q/home/app/libs/" + arg.substring(lastIndexOfSlash + 1));
+                        return Stream.of(parseQuotedClasspathArg(arg));
                     } else if (arg.startsWith("-H:ConfigurationFileDirectories")) {
                         return Stream.of(parseConfigurationFilesDirectoriesArg(arg));
                     } else {
@@ -118,6 +119,23 @@ public final class MojoUtils {
         } else {
             throw new RuntimeException("Unable to find args file: " + argsFilePath);
         }
+    }
+
+    private static Path resolveNestedArgsFilePath(Path argsFilePath, String fileName) {
+        Path nestedArgsFilePath = Paths.get(FilenameUtils.separatorsToSystem(fileName)).normalize();
+        if (nestedArgsFilePath.isAbsolute() || Files.exists(nestedArgsFilePath)) {
+            return nestedArgsFilePath;
+        }
+        Path parent = argsFilePath.getParent();
+        if (parent == null) {
+            return nestedArgsFilePath;
+        }
+        return parent.resolve(nestedArgsFilePath).normalize();
+    }
+
+    private static String parseQuotedClasspathArg(String arg) {
+        String quotedPath = arg.substring(2, arg.length() - 2);
+        return "\\Q/home/app/libs/" + FilenameUtils.getName(quotedPath) + "\\E";
     }
 
     static String parseConfigurationFilesDirectoriesArg(String arg) {

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MojoUtilsTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MojoUtilsTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
@@ -137,5 +138,28 @@ class MojoUtilsTest {
             "-H:ConfigurationFileDirectories=/home/app/graalvm-reachability-metadata/metadata/io.netty/netty-common/4.1.80.Final,/home/app/graalvm-reachability-metadata/metadata/io.netty/netty-buffer/4.1.80.Final",
             "-H:ConfigurationFileDirectories=/home/app/generateTestResourceConfig,/home/app/generateResourceConfig"
         ), result);
+    }
+
+    @Test
+    void testComputeNativeImageArgsPrefersParentRelativeNestedArgsFile(@TempDir Path tempDir) throws IOException {
+        Path nestedArgsFile = tempDir.resolve("target/cwd-collision/native-image-generated.args");
+        Files.createDirectories(nestedArgsFile.getParent());
+        Files.write(nestedArgsFile, List.of("\\QC:\\parent\\demo.jar\\E"));
+
+        Path cwdCollision = Paths.get("target/cwd-collision/native-image-generated.args");
+        Files.createDirectories(cwdCollision.getParent());
+        Files.write(cwdCollision, List.of("\\QC:\\cwd\\wrong.jar\\E"));
+
+        Path argsFile = tempDir.resolve("graalvm-native-image.args");
+        Files.write(argsFile, List.of("@target\\cwd-collision\\native-image-generated.args"));
+
+        try {
+            List<String> result = MojoUtils.computeNativeImageArgs(List.of(), "oraclelinux:9", argsFile.toString());
+
+            assertIterableEquals(List.of("\\Q/home/app/libs/demo.jar\\E"), result);
+        } finally {
+            Files.deleteIfExists(cwdCollision);
+            Files.deleteIfExists(cwdCollision.getParent());
+        }
     }
 }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MojoUtilsTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/MojoUtilsTest.java
@@ -4,15 +4,21 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.codehaus.plexus.util.Os;
 
+import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
-
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
 
 class MojoUtilsTest {
 
@@ -105,5 +111,31 @@ class MojoUtilsTest {
         String result = MojoUtils.parseConfigurationFilesDirectoriesArg(arg);
 
         assertEquals("-H:ConfigurationFileDirectories=/home/app/generateTestResourceConfig,/home/app/generateResourceConfig", result);
+    }
+
+    @Test
+    void testComputeNativeImageArgsExpandsWindowsStyleNestedArgsFile(@TempDir Path tempDir) throws IOException {
+        Path nestedArgsFile = tempDir.resolve("target/tmp/native-image-generated.args");
+        Files.createDirectories(nestedArgsFile.getParent());
+        Files.write(nestedArgsFile, List.of(
+            "\\QC:\\Users\\My User\\.m2\\repository\\com\\example\\demo.jar\\E",
+            "-H:ConfigurationFileDirectories=C:\\Users\\My User\\graalvm-reachability-metadata\\metadata\\io.netty\\netty-common\\4.1.80.Final,C:\\Users\\My User\\graalvm-reachability-metadata\\metadata\\io.netty\\netty-buffer\\4.1.80.Final",
+            "-H:ConfigurationFileDirectories=C:\\Users\\My User\\workspace\\target\\native\\generated\\generateTestResourceConfig,C:\\Users\\My User\\workspace\\target\\native\\generated\\generateResourceConfig"
+        ));
+
+        Path argsFile = tempDir.resolve("graalvm-native-image.args");
+        Files.write(argsFile, List.of(
+            "--no-fallback",
+            "@target\\tmp\\native-image-generated.args"
+        ));
+
+        List<String> result = MojoUtils.computeNativeImageArgs(List.of(), "oraclelinux:9", argsFile.toString());
+
+        assertIterableEquals(List.of(
+            "--no-fallback",
+            "\\Q/home/app/libs/demo.jar\\E",
+            "-H:ConfigurationFileDirectories=/home/app/graalvm-reachability-metadata/metadata/io.netty/netty-common/4.1.80.Final,/home/app/graalvm-reachability-metadata/metadata/io.netty/netty-buffer/4.1.80.Final",
+            "-H:ConfigurationFileDirectories=/home/app/generateTestResourceConfig,/home/app/generateResourceConfig"
+        ), result);
     }
 }


### PR DESCRIPTION
## Summary
- normalize nested `@...args` file references before expanding `docker-native` native-image arguments
- keep quoted classpath jars and configuration-directory paths mapped consistently when Windows-style separators are present
- add a focused regression test covering Windows-style nested args expansion without requiring a Windows Docker native-image build

## Verification
- `./mvnw -pl micronaut-maven-plugin -Dtest=MojoUtilsTest test`

## Notes
- Related to #808
- This adds preventive Windows coverage and parser hardening, but it does not close #808 on its own