### PR TITLE
test: enable four Windows-safe invoker scenarios

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-crac
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native -Dmicronaut.native-image.static=true
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-down/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-down/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals = -ntp package -Dpackaging=docker -Djib.dockerClient.environment="DOCKER_HOST=tcp://localhost:65432"
+invoker.goals = -ntp package -Dpackaging=docker -Djib.dockerClient.environment=DOCKER_HOST=tcp://localhost:65432
 invoker.buildResult = failure

--- a/micronaut-maven-integration-tests/src/it/package-docker-down/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-down/invoker.properties
@@ -1,4 +1,2 @@
 invoker.goals = -ntp package -Dpackaging=docker -Djib.dockerClient.environment="DOCKER_HOST=tcp://localhost:65432"
-
-invoker.os.family = !windows
 invoker.buildResult = failure

--- a/micronaut-maven-integration-tests/src/it/package-docker-down/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-down/verify.groovy
@@ -1,3 +1,6 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
-assert log.text.contains("Cannot connect to the Docker daemon at tcp://localhost:65432. Is the docker daemon running?")
+String text = log.text
+assert text.contains("localhost:65432")
+assert text.contains("Cannot connect to the Docker daemon at tcp://localhost:65432. Is the docker daemon running?") ||
+    (text.contains("Failed to read output of 'docker info'") && text.contains("error during connect: Get \"http://localhost:65432/"))

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-docker-down/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-docker-down/invoker.properties
@@ -1,5 +1,4 @@
 invoker.goals = -ntp package -Dpackaging=docker-native -DDOCKER_HOST=tcp://localhost:65432
 
 invoker.profiles = graalvm
-invoker.os.family = !windows
 invoker.buildResult = failure

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-docker-down/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-docker-down/verify.groovy
@@ -1,3 +1,6 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
-assert log.text.contains("Cannot connect to the Docker daemon at tcp://localhost:65432. Is the docker daemon running?")
+String text = log.text
+assert text.contains("localhost:65432")
+assert text.contains("Cannot connect to the Docker daemon at tcp://localhost:65432. Is the docker daemon running?") ||
+    (text.contains("Failed to read output of 'docker info'") && text.contains("error during connect: Get \"http://localhost:65432/"))


### PR DESCRIPTION
## Summary
- remove the Windows invoker skip from `dockerfile-docker-crac`
- remove the Windows invoker skip from `dockerfile-docker-native-static`
- remove the Windows invoker skip from `package-docker-down` and `package-docker-native-docker-down`
- keep the broader Windows-disabled scenarios untouched because they still depend on Linux-container Jib and test-resources coverage

## Verification
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=dockerfile-docker-crac,dockerfile-docker-native-static,package-docker-down,package-docker-native-docker-down"`
