### PR TITLE
test: enable four more Windows-safe invoker scenarios

### DIFF
--- a/micronaut-maven-integration-tests/src/it/issue582/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/issue582/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp -e package -Dpackaging=docker-native -Pgraalvm
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/issue582/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/issue582/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp -e package -Dpackaging=docker-native -Pgraalvm
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-lambda/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp package -Dpackaging=docker
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-lambda/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp package -Dpackaging=docker
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/invoker.properties
@@ -1,4 +1,3 @@
 invoker.goals = -ntp package -Dpackaging=docker-native
 
 invoker.profiles = graalvm
-invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/invoker.properties
@@ -1,3 +1,4 @@
 invoker.goals = -ntp package -Dpackaging=docker-native
 
 invoker.profiles = graalvm
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/invoker.properties
@@ -1,1 +1,2 @@
 invoker.goals = -ntp package -Dpackaging=docker
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/invoker.properties
@@ -1,2 +1,1 @@
 invoker.goals = -ntp package -Dpackaging=docker
-invoker.os.family = !windows


### PR DESCRIPTION
## What this PR does
- removes the Windows invoker skip from `package-docker-lambda`
- removes the Windows invoker skip from `package-docker-oracle-function`
- removes the Windows invoker skip from `package-docker-native-lambda`
- removes the Windows invoker skip from `issue582`

## Why
These four scenarios pass on the current `5.0.x` line on Windows and do not rely on the Linux-only `docker:start` or `docker:stop` expectations that still keep the broader remaining Windows-gated matrix split out for later work.

## Verification
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=package-docker-lambda,package-docker-oracle-function,package-docker-native-lambda,issue582"`