### PR TITLE
ci: harden privileged GitHub workflows

### DIFF
--- a/.github/scripts/check-workflow-pinning.sh
+++ b/.github/scripts/check-workflow-pinning.sh
@@ -8,9 +8,9 @@ workflow_files=(.github/workflows/*.yml .github/workflows/*.yaml)
 failures=0
 
 for file in "${workflow_files[@]}"; do
-  if rg -n 'raw\.githubusercontent\.com' "$file" >/dev/null; then
+  if grep -nE 'raw\.githubusercontent\.com' "$file" >/dev/null; then
     echo "::error file=$file::Remote raw.githubusercontent.com downloads are not allowed in workflows. Vendor the script into this repository or pin the source to an audited commit outside the workflow."
-    rg -n 'raw\.githubusercontent\.com' "$file"
+    grep -nE 'raw\.githubusercontent\.com' "$file"
     failures=1
   fi
 
@@ -31,7 +31,7 @@ for file in "${workflow_files[@]}"; do
 
     echo "::error file=$file,line=$lineno::GitHub Actions must use a full 40-character commit SHA: $ref"
     failures=1
-  done < <(rg -n '^[[:space:]-]*uses:[[:space:]]*' "$file")
+  done < <(grep -nE '^[[:space:]-]*uses:[[:space:]]*' "$file")
 done
 
 exit "$failures"

--- a/.github/scripts/check-workflow-pinning.sh
+++ b/.github/scripts/check-workflow-pinning.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+shopt -s nullglob
+
+workflow_files=(.github/workflows/*.yml .github/workflows/*.yaml)
+failures=0
+
+for file in "${workflow_files[@]}"; do
+  if rg -n 'raw\.githubusercontent\.com' "$file" >/dev/null; then
+    echo "::error file=$file::Remote raw.githubusercontent.com downloads are not allowed in workflows. Vendor the script into this repository or pin the source to an audited commit outside the workflow."
+    rg -n 'raw\.githubusercontent\.com' "$file"
+    failures=1
+  fi
+
+  while IFS=: read -r lineno line; do
+    ref=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]-]*uses:[[:space:]]*//; s/[[:space:]]+#.*$//; s/[[:space:]]+$//')
+
+    if [[ -z "$ref" ]]; then
+      continue
+    fi
+
+    if [[ "$ref" =~ ^\./ ]] || [[ "$ref" =~ ^docker:// ]]; then
+      continue
+    fi
+
+    if [[ "$ref" =~ ^[^/]+/[^@]+(/[^@]+)*@[0-9a-f]{40}$ ]]; then
+      continue
+    fi
+
+    echo "::error file=$file,line=$lineno::GitHub Actions must use a full 40-character commit SHA: $ref"
+    failures=1
+  done < <(rg -n '^[[:space:]-]*uses:[[:space:]]*' "$file")
+done
+
+exit "$failures"

--- a/.github/scripts/increment_version.sh
+++ b/.github/scripts/increment_version.sh
@@ -1,40 +1,91 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Vendored from micronaut-projects/github-actions at commit
 # 300bf6db7c062dcba77c90bb90e475df31b2acab, path post-release/increment_version.sh.
 # Increment a version string using Semantic Versioning (SemVer) terminology.
 # Source: https://github.com/fmahnke/shell-semver
 
-while getopts ":Mmp" Option
-do
+usage() {
+  echo "Usage: $0 [-M | -m | -p] version" >&2
+}
+
+major=false
+minor=false
+patch=false
+selected=0
+
+while getopts ":Mmp" Option; do
   case $Option in
-    M ) major=true;;
-    m ) minor=true;;
-    p ) patch=true;;
+    M )
+      major=true
+      ((selected++))
+      ;;
+    m )
+      minor=true
+      ((selected++))
+      ;;
+    p )
+      patch=true
+      ((selected++))
+      ;;
+    * )
+      usage
+      exit 1
+      ;;
   esac
 done
 
-shift $(($OPTIND - 1))
+shift $((OPTIND - 1))
+
+if (( selected != 1 )) || [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
 
 version=$1
+IFS=. read -r major_part minor_part patch_part extra_part <<< "$version"
+prerelease=false
 
-a=( ${version//./ } )
+if [[ -n "${extra_part:-}" ]] || [[ -z "${major_part:-}" ]] || [[ -z "${minor_part:-}" ]] || [[ -z "${patch_part:-}" ]]; then
+  echo "Invalid version: $version" >&2
+  usage
+  exit 1
+fi
 
-if [ ! -z "$major" ]
-then
+if ! [[ "$major_part" =~ ^[0-9]+$ ]] || ! [[ "$minor_part" =~ ^[0-9]+$ ]]; then
+  echo "Invalid version: $version" >&2
+  usage
+  exit 1
+fi
+
+if [[ "$patch_part" =~ ^([0-9]+)$ ]]; then
+  patch_number="${BASH_REMATCH[1]}"
+elif [[ "$patch_part" =~ ^([0-9]+)-((M|RC).+)$ ]]; then
+  patch_number="${BASH_REMATCH[1]}"
+  prerelease=true
+elif [[ "$patch_part" =~ ^((M|RC).+)$ ]]; then
+  patch_number=0
+  prerelease=true
+else
+  echo "Invalid version: $version" >&2
+  usage
+  exit 1
+fi
+
+a=("$major_part" "$minor_part" "$patch_number")
+
+if [[ "$major" == true ]]; then
   ((a[0]++))
   a[1]=0
   a[2]=0
 fi
 
-if [ ! -z "$minor" ]
-then
+if [[ "$minor" == true ]]; then
   ((a[1]++))
   a[2]=0
 fi
 
-if [ ! -z "$patch" ] && ! [[ "${a[2]}" =~ M.*|RC.* ]]
-then
+if [[ "$patch" == true ]] && [[ "$prerelease" == false ]]; then
   ((a[2]++))
 else
   a[2]=0

--- a/.github/scripts/increment_version.sh
+++ b/.github/scripts/increment_version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Vendored from micronaut-projects/github-actions at commit
+# 300bf6db7c062dcba77c90bb90e475df31b2acab, path post-release/increment_version.sh.
+# Increment a version string using Semantic Versioning (SemVer) terminology.
+# Source: https://github.com/fmahnke/shell-semver
+
+while getopts ":Mmp" Option
+do
+  case $Option in
+    M ) major=true;;
+    m ) minor=true;;
+    p ) patch=true;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+
+version=$1
+
+a=( ${version//./ } )
+
+if [ ! -z "$major" ]
+then
+  ((a[0]++))
+  a[1]=0
+  a[2]=0
+fi
+
+if [ ! -z "$minor" ]
+then
+  ((a[1]++))
+  a[2]=0
+fi
+
+if [ ! -z "$patch" ] && ! [[ "${a[2]}" =~ M.*|RC.* ]]
+then
+  ((a[2]++))
+else
+  a[2]=0
+fi
+
+echo "${a[0]}.${a[1]}.${a[2]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         id: next_version
         run: |
           chmod +x .github/scripts/increment_version.sh
-          NV=`.github/scripts/increment_version.sh -p ${{ steps.release_version.outputs.release_version }}`
+          NV="$(.github/scripts/increment_version.sh -p "${{ steps.release_version.outputs.release_version }}")"
           echo "next_version=${NV}-SNAPSHOT" >> $GITHUB_OUTPUT
 
       - name: "⚙️ Prepare release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '/usr/lib/jvm' | paste -sd:)
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: "☕️ Install Java and Maven and set up Apache Maven Central"
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -58,16 +58,15 @@ jobs:
           git push origin :refs/tags/v${{ steps.release_version.outputs.release_version }}
 
       - name: "🔑 Setup SSH key"
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: "❓ Figure out next version"
         id: next_version
         run: |
-          wget -q https://raw.githubusercontent.com/micronaut-projects/github-actions/master/post-release/increment_version.sh -O /tmp/iv.sh
-          chmod +x /tmp/iv.sh
-          NV=`/tmp/iv.sh -p ${{ steps.release_version.outputs.release_version }}`
+          chmod +x .github/scripts/increment_version.sh
+          NV=`.github/scripts/increment_version.sh -p ${{ steps.release_version.outputs.release_version }}`
           echo "next_version=${NV}-SNAPSHOT" >> $GITHUB_OUTPUT
 
       - name: "⚙️ Prepare release"
@@ -76,7 +75,7 @@ jobs:
           cp -R target/site/apidocs/* micronaut-maven-plugin/target/site/apidocs
 
       - name: "📄 Publish docs to Github Pages"
-        uses: micronaut-projects/github-pages-deploy-action@master
+        uses: micronaut-projects/github-pages-deploy-action@76d63aafbab7108d74e83be4e5b3b0501382e829
         env:
           BETA: ${{ contains(steps.release_version.outputs.release_version, 'M') || contains(steps.release_version.outputs.release_version, 'RC') }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -105,7 +104,7 @@ jobs:
 
       - name: "🚪 Close milestone ${{ steps.release_version.outputs.release_version }}"
         if: success()
-        uses: Beakyn/gha-close-milestone@v1.1.1
+        uses: Beakyn/gha-close-milestone@cb86f414f1601acbebdf9339f07ff7ac6ac0f24c
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -19,7 +19,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  workflow-hardening:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: "🛡 Verify workflow pinning"
+        run: bash .github/scripts/check-workflow-pinning.sh
+
   snapshot:
+    needs:
+      - workflow-hardening
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,7 +59,7 @@ jobs:
           df -h
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
@@ -63,7 +73,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: "☕️ Install Java and Maven and set up Apache Maven Central"
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -73,7 +83,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@v1.4.5
+        uses: graalvm/setup-graalvm@54b4f5a65c1a84b2fdfdc2078fe43df32819e4b1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
@@ -96,7 +106,7 @@ jobs:
 
       - name: "📊 Publish Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@v6.2.0
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8
         with:
           check_name: Java CI / Test Report
           report_paths: '**/target/invoker-reports/TEST-*.xml'
@@ -122,7 +132,7 @@ jobs:
 
       - name: "📑 Publish to Github Pages"
         if: success() && github.event_name == 'push' && matrix.java == '25'
-        uses: micronaut-projects/github-pages-deploy-action@master
+        uses: micronaut-projects/github-pages-deploy-action@76d63aafbab7108d74e83be4e5b3b0501382e829
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -23,15 +23,15 @@ jobs:
       matrix:
         java: ['25']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Setup GraalVM
-        uses: graalvm/setup-graalvm@v1.4.5
+        uses: graalvm/setup-graalvm@54b4f5a65c1a84b2fdfdc2078fe43df32819e4b1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
@@ -45,4 +45,3 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-


### PR DESCRIPTION
## What this PR does

- vendors the post-release `increment_version.sh` helper into this repository instead of downloading it from `raw.githubusercontent.com` during the release workflow
- pins the GitHub Actions used by the release, snapshot, and Windows CI workflows to full commit SHAs
- adds a workflow hardening check that fails when workflow files download mutable remote content or use non-SHA `uses:` references

## Verification

- `bash -n .github/scripts/increment_version.sh`
- `bash -n .github/scripts/check-workflow-pinning.sh`
- `bash .github/scripts/check-workflow-pinning.sh`
- `ruby -e 'require "yaml"; %w[.github/workflows/release.yml .github/workflows/snapshot.yml .github/workflows/windows-ci.yml].each { |f| YAML.load_file(f) }'`
- `bash .github/scripts/increment_version.sh -p 1.2.3`
- `bash .github/scripts/increment_version.sh -m 1.2.3`
- `bash .github/scripts/increment_version.sh -M 1.2.3`
- `bash .github/scripts/increment_version.sh -p 1.2.RC1`
- `git diff --check -- .github/scripts/increment_version.sh .github/scripts/check-workflow-pinning.sh .github/workflows/release.yml .github/workflows/snapshot.yml .github/workflows/windows-ci.yml`
