### PR TITLE
Support custom bootstrap arguments for docker-native Lambda

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
@@ -18,7 +18,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function
 RUN dnf update -y && dnf install -y zip && dnf clean all
 COPY --from=graalvm /home/app/application /function/func
-RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd)" >> bootstrap
+RUN printf '%s\n' '#!/bin/sh' 'set -euo pipefail' './func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd) -Dio.netty.noUnsafe=true -Dio.netty.noPreferDirect=false' > bootstrap
 RUN chmod 777 bootstrap
 RUN chmod 777 func
 RUN zip -j function.zip bootstrap func

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
@@ -18,7 +18,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function
 RUN dnf update -y && dnf install -y zip && dnf clean all
 COPY --from=graalvm /home/app/application /function/func
-RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd)" >> bootstrap
+RUN printf '%s\n' '#!/bin/sh' 'set -euo pipefail' './func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd) -Dio.netty.noUnsafe=true -Dio.netty.noPreferDirect=false' > bootstrap
 RUN chmod 777 bootstrap
 RUN chmod 777 func
 RUN zip -j function.zip bootstrap func

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/pom.xml
@@ -88,6 +88,10 @@
         <version>${micronaut-maven-plugin.version}</version>
         <configuration>
           <nativeImageBuildArgs>-Ob</nativeImageBuildArgs>
+          <lambdaBootstrapArguments>
+            <arg>-Dio.netty.noUnsafe=true</arg>
+            <arg>-Dio.netty.noPreferDirect=false</arg>
+          </lambdaBootstrapArguments>
         </configuration>
       </plugin>
       <plugin>

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/pom.xml
@@ -87,6 +87,10 @@
         <artifactId>micronaut-maven-plugin</artifactId>
         <configuration>
           <configFile>aot-${packaging}.properties</configFile>
+          <lambdaBootstrapArguments>
+            <arg>-Dio.netty.noUnsafe=true</arg>
+            <arg>-Dio.netty.noPreferDirect=false</arg>
+          </lambdaBootstrapArguments>
         </configuration>
       </plugin>
       <plugin>

--- a/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native-lambda/verify.groovy
@@ -1,6 +1,19 @@
+import java.util.zip.ZipFile
+
 File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS")
 assert log.text.contains("native:${nativeMavenPluginVersion}:generateTestResourceConfig")
 assert log.text.contains("Successfully built")
 assert log.text.contains("AWS Lambda Custom Runtime ZIP:")
+
+File functionZip = new File(basedir, "target/function.zip")
+assert functionZip.exists()
+
+ZipFile zipFile = new ZipFile(functionZip)
+try {
+    def bootstrap = zipFile.getInputStream(zipFile.getEntry("bootstrap")).getText("UTF-8")
+    assert bootstrap.contains('./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd) -Dio.netty.noUnsafe=true -Dio.netty.noPreferDirect=false')
+} finally {
+    zipFile.close()
+}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -102,6 +102,8 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
 
     /**
      * Additional arguments that will be appended to the generated AWS Lambda native bootstrap command.
+     *
+     * @since 5.0.0
      */
     @Parameter(property = "micronaut.lambda.bootstrap.args")
     protected List<String> lambdaBootstrapArguments;

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +46,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.micronaut.maven.services.ApplicationConfigurationService.DEFAULT_PORT;
 
@@ -64,7 +66,14 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     public static final String X86_64_ARCH = "x64";
     public static final String ORACLE_CLOUD_FUNCTION_DEFAULT_CMD = "CMD [\"io.micronaut.oraclecloud.function.http.HttpFunction::handleRequest\"]";
     public static final String GDS_DOWNLOAD_URL = "https://gds.oracle.com/download/graal/%s/latest-gftc/graalvm-jdk-%s_linux-%s_bin.tar.gz";
+    public static final String LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER = "${LAMBDA_BOOTSTRAP_DOCKER_COMMAND}";
     private static final NavigableSet<Integer> GRAALVM_VERSIONS = new TreeSet<>(Set.of(25));
+    private static final List<String> DEFAULT_LAMBDA_BOOTSTRAP_ARGUMENTS = List.of(
+        "-XX:MaximumHeapSizePercent=80",
+        "-Dio.netty.allocator.numDirectArenas=0",
+        "-Dio.netty.noPreferDirect=true",
+        "-Djava.library.path=$(pwd)"
+    );
 
     protected final MavenProject mavenProject;
     protected final MavenSession mavenSession;
@@ -90,6 +99,12 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      */
     @Parameter(property = RunMojo.MN_APP_ARGS)
     protected List<String> appArguments;
+
+    /**
+     * Additional arguments that will be appended to the generated AWS Lambda native bootstrap command.
+     */
+    @Parameter(property = "micronaut.lambda.bootstrap.args")
+    protected List<String> lambdaBootstrapArguments;
 
     /**
      * The main class of the application, as defined in the
@@ -318,6 +333,79 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
                 .map(s -> "\"" + s + "\"")
                 .collect(Collectors.joining(", ")) +
             "]";
+    }
+
+    /**
+     * @return the generated AWS Lambda bootstrap command.
+     */
+    protected String getLambdaBootstrapCommand() {
+        var command = new StringBuilder("./func");
+        for (String bootstrapArgument : DEFAULT_LAMBDA_BOOTSTRAP_ARGUMENTS) {
+            command.append(' ').append(bootstrapArgument);
+        }
+        if (lambdaBootstrapArguments != null && !lambdaBootstrapArguments.isEmpty()) {
+            for (String lambdaBootstrapArgument : lambdaBootstrapArguments) {
+                command.append(' ').append(escapeBootstrapArgument(lambdaBootstrapArgument));
+            }
+        }
+        return command.toString();
+    }
+
+    /**
+     * Applies the generated AWS Lambda bootstrap script to a dockerfile template.
+     *
+     * @param dockerfile the docker file
+     */
+    protected void lambdaBootstrapCommand(File dockerfile) throws IOException {
+        if (dockerfile == null) {
+            return;
+        }
+        if (lambdaBootstrapArguments != null && !lambdaBootstrapArguments.isEmpty()) {
+            getLog().info("Using AWS Lambda bootstrap arguments: " + lambdaBootstrapArguments);
+        }
+        var allLines = Files.readAllLines(dockerfile.toPath());
+        var result = new ArrayList<String>(allLines.size());
+        for (String line : allLines) {
+            if (line.contains(LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER)) {
+                result.add(line.replace(LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER, getLambdaBootstrapDockerCommand()));
+            } else {
+                result.add(line);
+            }
+        }
+        Files.write(dockerfile.toPath(), result);
+    }
+
+    private String getLambdaBootstrapDockerCommand() {
+        return "printf '%s\\n' "
+            + Stream.of("#!/bin/sh", "set -euo pipefail", getLambdaBootstrapCommand())
+            .map(AbstractDockerMojo::quoteShellLiteral)
+            .collect(Collectors.joining(" "))
+            + " > bootstrap";
+    }
+
+    private static String escapeBootstrapArgument(String argument) {
+        if (isShellSafe(argument)) {
+            return argument;
+        }
+        return quoteShellLiteral(argument);
+    }
+
+    private static boolean isShellSafe(String argument) {
+        if (argument == null || argument.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < argument.length(); i++) {
+            char c = argument.charAt(i);
+            if (!Character.isLetterOrDigit(c)
+                && "_@%+=:,./-".indexOf(c) == -1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String quoteShellLiteral(String value) {
+        return "'" + value.replace("'", "'\"'\"'") + "'";
     }
 
     /**

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -16,7 +16,6 @@
 package io.micronaut.maven;
 
 import com.github.dockerjava.api.command.BuildImageCmd;
-import com.github.dockerjava.api.exception.DockerClientException;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import io.micronaut.core.util.StringUtils;
@@ -151,17 +150,15 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         // Add proxy settings if configured
         buildImageCmdArguments.putAll(getProxyBuildArgs());
 
+        File dockerfile = dockerService.loadDockerfileAsResource(DockerfileMojo.DOCKERFILE_AWS_CUSTOM_RUNTIME);
+        lambdaBootstrapCommand(dockerfile);
+
         // Starter sets the right class in pom.xml:
         //   - For applications: io.micronaut.function.aws.runtime.MicronautLambdaRuntime
         //   - For function apps: com.example.BookLambdaRuntime
-        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments, () -> {
-            try {
-                return dockerService.buildImageCmd(DockerfileMojo.DOCKERFILE_AWS_CUSTOM_RUNTIME)
-                    .withBuildArg("GRAALVM_DOWNLOAD_URL", graalVmDownloadUrl());
-            } catch (IOException e) {
-                throw new DockerClientException(e.getMessage(), e);
-            }
-        });
+        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments, () -> dockerService.buildImageCmd()
+            .withDockerfile(dockerfile)
+            .withBuildArg("GRAALVM_DOWNLOAD_URL", graalVmDownloadUrl()));
         buildImageCmd.withBuildArg("CLASS_NAME", mainClass);
         String imageId = dockerService.buildImage(buildImageCmd);
         File functionZip = dockerService.copyFromContainer(imageId, "/function/function.zip");

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -160,7 +160,10 @@ public class DockerfileMojo extends AbstractDockerMojo {
         executorService.invokeGoal(NATIVE_BUILD_TOOLS_MAVEN_PLUGIN, "write-args-file");
         File dockerfile;
         switch (runtime.getBuildStrategy()) {
-            case LAMBDA -> dockerfile = dockerService.loadDockerfileAsResource(DOCKERFILE_AWS_CUSTOM_RUNTIME);
+            case LAMBDA -> {
+                dockerfile = dockerService.loadDockerfileAsResource(DOCKERFILE_AWS_CUSTOM_RUNTIME);
+                lambdaBootstrapCommand(dockerfile);
+            }
             case ORACLE_FUNCTION -> {
                 dockerfile = dockerService.loadDockerfileAsResource(DOCKERFILE_NATIVE_ORACLE_CLOUD);
                 oracleCloudFunctionCmd(dockerfile);

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
@@ -20,7 +20,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function
 RUN dnf update -y && dnf install -y zip && dnf clean all
 COPY --from=graalvm /home/app/application /function/func
-RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd)" >> bootstrap
+RUN ${LAMBDA_BOOTSTRAP_DOCKER_COMMAND}
 RUN chmod 777 bootstrap
 RUN chmod 777 func
 RUN zip -j function.zip bootstrap func

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -274,14 +274,15 @@ Note that changing the base image to a totally different one than the default mi
 of the build steps expect a certain base image. By default, the native images are built from an `ghcr.io/graalvm/native-image-community` image.
 
 In the case of AWS custom runtime, it starts from `amazonlinux:2023`, and this cannot be changed. Also, in this case the
-result is not a tagged Docker image, but a `function.zip` archive that contains the launch script and the native binary.
+result is not a tagged Docker image, but a `function.zip` archive that contains the bootstrap launch script and the native binary.
 Essentially, what you need to upload to AWS Lambda. Also in this case, the Micronaut Maven Plugin will detect the host
 operating system architecture (based on the `os.arch` Java system property) and will install the corresponding GraalVM
 binary distribution inside the Docker image. This means that when running packaging from an X86_64 (Intel/AMD) machine,
 the produced native image will be an `amd64` binary, whilst on an ARM host (such as the new Mac M1) it will be an
 `aarch64` binary.
 
-You can pass additional arguments to the executable in the following way:
+For AWS Lambda custom runtimes, use `lambdaBootstrapArguments` to append extra native bootstrap flags after the plugin's
+default flags. This is different from `appArguments`, which apply to the Oracle Cloud Function Dockerfile path.
 
 [source,xml]
 ----
@@ -289,18 +290,19 @@ You can pass additional arguments to the executable in the following way:
   <groupId>io.micronaut.maven</groupId>
   <artifactId>micronaut-maven-plugin</artifactId>
   <configuration>
-    <appArguments>
-      <appArgument>foo</appArgument>
-      <appArgument>bar</appArgument>
-    </appArguments>
+    <lambdaBootstrapArguments>
+      <arg>-Dio.netty.noUnsafe=true</arg>
+      <arg>-Dio.netty.noPreferDirect=false</arg>
+    </lambdaBootstrapArguments>
   </configuration>
 </plugin>
 ----
 
-Or when packaging:
+Or from the command line:
 
 ----
-$ mvn package -Dpackaging=docker-native -Dmn.appArgs="foo,bar"
+$ mvn package -Dpackaging=docker-native -Dmicronaut.runtime=lambda \
+    -Dmicronaut.lambda.bootstrap.args="-Dio.netty.noUnsafe=true,-Dio.netty.noPreferDirect=false"
 ----
 
 Also, to pass additional arguments to the `native-image` process:

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
@@ -19,6 +19,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -264,6 +265,23 @@ class DockerNativeMojoTest {
         var actualTag = mojo.graalVmTag(jvmVersion, staticNativeImage, oracleLinuxVersion);
 
         assertEquals(expectedTag, actualTag);
+    }
+
+    @Test
+    void testLambdaBootstrapCommandAppendsCustomArguments() {
+        var project = mock(MavenProject.class);
+        var session = mock(MavenSession.class);
+        var execution = mock(MojoExecution.class);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getSystemProperties()).thenReturn(new Properties());
+        when(project.getProperties()).thenReturn(new Properties());
+
+        var mojo = new DockerNativeMojo(project, null, null, null, session, execution);
+        mojo.lambdaBootstrapArguments = List.of("-Dio.netty.noUnsafe=true", "-Dcustom.message=hello world");
+
+        var command = mojo.getLambdaBootstrapCommand();
+
+        assertEquals("./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd) -Dio.netty.noUnsafe=true '-Dcustom.message=hello world'", command);
     }
 
 }


### PR DESCRIPTION
## What this does
- adds `lambdaBootstrapArguments` / `micronaut.lambda.bootstrap.args` for native AWS Lambda packaging
- generates the Lambda bootstrap command in Java so `mn:dockerfile` and `package -Dpackaging=docker-native` share the same behavior
- updates unit coverage, invoker scenarios, and package docs for the new Lambda-specific option

## Verification
- `./mvnw -pl micronaut-maven-plugin -am '-Dtest=DockerNativeMojoTest#testLambdaBootstrapCommandAppendsCustomArguments' -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=dockerfile-docker-native-lambda,package-docker-native-lambda"`

Fixes #245
