### PR TITLE
Validate and document sibling-module custom Test Resources resolvers

### DIFF
--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/app/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/app/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.micronaut.build.examples</groupId>
+        <artifactId>test-resources-custom-reactor-dependency-parent</artifactId>
+        <version>0.1</version>
+    </parent>
+
+    <artifactId>custom-reactor-consumer-app</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-server-netty</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.serde</groupId>
+            <artifactId>micronaut-serde-jackson</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.test</groupId>
+            <artifactId>micronaut-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.micronaut.maven</groupId>
+                <artifactId>micronaut-maven-plugin</artifactId>
+                <configuration>
+                    <classpathInference>false</classpathInference>
+                    <testResourcesDependencies>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>custom-reactor-resolver</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </testResourcesDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+                        <arg>-Amicronaut.processing.module=custom-reactor-consumer-app</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/app/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/app/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,9 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/app/src/test/java/io/micronaut/build/examples/ReactorResolverTest.java
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/app/src/test/java/io/micronaut/build/examples/ReactorResolverTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+class ReactorResolverTest {
+
+    @Value("${test.resource.from.reactor}")
+    String message;
+
+    @Test
+    @DisplayName("A sibling module custom resolver can be used through testResourcesDependencies")
+    void resolvesPropertyFromSiblingModule() {
+        assertEquals("hello-from-reactor", message);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -ntp -e test
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>test-resources-custom-reactor-dependency-parent</artifactId>
+    <version>0.1</version>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>io.micronaut.platform</groupId>
+        <artifactId>micronaut-parent</artifactId>
+        <version>@it.micronaut.version@</version>
+    </parent>
+
+    <properties>
+        <micronaut.version>@it.micronaut.version@</micronaut.version>
+        <micronaut.runtime>netty</micronaut.runtime>
+        <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+        <micronaut.test.resources.version>@micronaut.test.resources.version@</micronaut.test.resources.version>
+        <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
+    </properties>
+
+    <modules>
+        <module>resolver</module>
+        <module>app</module>
+    </modules>
+</project>

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.micronaut.testresources</groupId>
             <artifactId>micronaut-test-resources-core</artifactId>
-            <version>${micronaut.test.resources.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.micronaut.build.examples</groupId>
+        <artifactId>test-resources-custom-reactor-dependency-parent</artifactId>
+        <version>0.1</version>
+    </parent>
+
+    <artifactId>custom-reactor-resolver</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-core</artifactId>
+            <version>${micronaut.test.resources.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/src/main/java/io/micronaut/build/examples/resolver/ReactorMessageTestResourcesResolver.java
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/src/main/java/io/micronaut/build/examples/resolver/ReactorMessageTestResourcesResolver.java
@@ -1,0 +1,29 @@
+package io.micronaut.build.examples.resolver;
+
+import io.micronaut.testresources.core.TestResourcesResolver;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public final class ReactorMessageTestResourcesResolver implements TestResourcesResolver {
+    static final String PROPERTY = "test.resource.from.reactor";
+    static final String VALUE = "hello-from-reactor";
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries,
+                                                Map<String, Object> testResourcesConfig) {
+        return List.of(PROPERTY);
+    }
+
+    @Override
+    public Optional<String> resolve(String propertyName,
+                                    Map<String, Object> properties,
+                                    Map<String, Object> testResourcesConfig) {
+        if (PROPERTY.equals(propertyName)) {
+            return Optional.of(VALUE);
+        }
+        return Optional.empty();
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/resolver/src/main/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+io.micronaut.build.examples.resolver.ReactorMessageTestResourcesResolver

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/verify.groovy
@@ -1,0 +1,7 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
+assert log.text.contains("ReactorMessageTestResourcesResolver") : "Custom reactor resolver was not loaded"
+
+File portFile = new File(basedir, "app/target/test-resources-port.txt")
+assert portFile.exists() : "Test Resources port file was not created for the app module"

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-reactor-dependency/verify.groovy
@@ -1,7 +1,12 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
-assert log.text.contains("ReactorMessageTestResourcesResolver") : "Custom reactor resolver was not loaded"
+assert log.text.contains("Starting Micronaut Test Resources service") : "Test Resources service was not started"
+
+File surefireReport = new File(basedir, "app/target/surefire-reports/TEST-io.micronaut.build.examples.ReactorResolverTest.xml")
+assert surefireReport.exists() : "Surefire report for ReactorResolverTest was not created in the app module"
+assert surefireReport.text.contains('failures="0"') : "ReactorResolverTest did not pass successfully"
+assert surefireReport.text.contains('name="resolvesPropertyFromSiblingModule"') : "ReactorResolverTest did not execute the expected test method"
 
 File portFile = new File(basedir, "app/target/test-resources-port.txt")
 assert portFile.exists() : "Test Resources port file was not created for the app module"

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/test-resources.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/test-resources.adoc
@@ -141,6 +141,81 @@ it like this:
 
 The versions of those dependencies will be resolved against the Micronaut BOM.
 
+==== Using a sibling reactor module for custom resolvers
+
+If you want to implement a custom `TestResourcesResolver` in the same multi-module Maven build as the application which
+uses it, put the resolver in a dedicated sibling module and add that module to `<testResourcesDependencies>` in the
+consumer module.
+
+This is the Maven-native equivalent of Gradle's `src/testResources/**` convenience source set: the resolver stays in a
+normal Java module, participates in the same reactor build, and is added explicitly to the Test Resources service
+classpath.
+
+The dedicated resolver module should include:
+
+* The custom `TestResourcesResolver` implementation.
+* A `META-INF/services/io.micronaut.testresources.core.TestResourcesResolver` file listing the implementation class.
+* A dependency on `micronaut-test-resources-core`.
+
+For example, the parent POM can define separate `resolver` and `app` modules:
+
+[source,xml]
+----
+<modules>
+    <module>resolver</module>
+    <module>app</module>
+</modules>
+----
+
+The resolver module can package the implementation and service loader metadata as a normal JAR:
+
+[source,xml]
+----
+<project>
+    <parent>
+        <groupId>io.micronaut.build.examples</groupId>
+        <artifactId>test-resources-custom-reactor-dependency-parent</artifactId>
+        <version>0.1</version>
+    </parent>
+
+    <artifactId>custom-reactor-resolver</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut.testresources</groupId>
+            <artifactId>micronaut-test-resources-core</artifactId>
+            <version>${micronaut.test.resources.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+----
+
+Then the consuming module can expose that sibling artifact to the Test Resources service:
+
+[source,xml]
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.micronaut.maven</groupId>
+            <artifactId>micronaut-maven-plugin</artifactId>
+            <configuration>
+                <testResourcesDependencies>
+                    <dependency>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>custom-reactor-resolver</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </testResourcesDependencies>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+----
+
+When you run `mvn test` or `mvn verify` from the parent project, Maven builds the sibling resolver module in the same
+reactor and the plugin adds that artifact to the Test Resources service classpath for the consuming module.
+
 The list of supported modules is described in the
 https://micronaut-projects.github.io/micronaut-test-resources/latest/guide/#modules[Micronaut Test Resources documentation].
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/test-resources.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/test-resources.adoc
@@ -184,7 +184,6 @@ The resolver module can package the implementation and service loader metadata a
         <dependency>
             <groupId>io.micronaut.testresources</groupId>
             <artifactId>micronaut-test-resources-core</artifactId>
-            <version>${micronaut.test.resources.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- add an invoker scenario proving a sibling reactor module custom `TestResourcesResolver` is loaded when the consumer declares it in `<testResourcesDependencies>`
- document the Maven-first workflow for keeping a custom `TestResourcesResolver` in a sibling reactor module
- explain that this is the Maven-native alternative to Gradle's `src/testResources/**` convenience

Closes #548