### PR TITLE
Harden generated Dockerfile substitutions

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile
@@ -1,3 +1,4 @@
+ARG CHECKPOINT_IMAGE
 FROM ${CHECKPOINT_IMAGE} AS crac-checkpoint
 
 FROM ubuntu:18.04

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
@@ -1,5 +1,8 @@
 FROM ubuntu:18.04
 
+ARG CRAC_ARCH
+ARG CRAC_JDK_VERSION
+ARG CRAC_OS
 WORKDIR /home/app
 
 # Add required libraries

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM gcr.io/distroless/cc-debian12
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM gcr.io/distroless/cc-debian12
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
@@ -13,7 +13,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.function.aws.runtime.MicronautLambdaRuntime' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.function.aws.runtime.MicronautLambdaRuntime" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS graalvm
 ENV LANG=en_US.UTF-8
 RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
-RUN curl -4 -L https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-aarch64_bin.tar.gz -o /tmp/graalvm.tar.gz \
+RUN curl -4 -L 'https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-aarch64_bin.tar.gz' -o /tmp/graalvm.tar.gz \
     && mkdir -p /usr/lib/graalvm \
     && tar -zxf /tmp/graalvm.tar.gz -C /usr/lib/graalvm --strip-components 1 \
     && rm -rf /tmp/*
@@ -13,7 +13,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.function.aws.runtime.MicronautLambdaRuntime' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS graalvm
 ENV LANG=en_US.UTF-8
 RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
-RUN curl -4 -L https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-x64_bin.tar.gz -o /tmp/graalvm.tar.gz \
+RUN curl -4 -L 'https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-x64_bin.tar.gz' -o /tmp/graalvm.tar.gz \
     && mkdir -p /usr/lib/graalvm \
     && tar -zxf /tmp/graalvm.tar.gz -C /usr/lib/graalvm --strip-components 1 \
     && rm -rf /tmp/*
@@ -13,7 +13,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.function.aws.runtime.MicronautLambdaRuntime' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
@@ -13,7 +13,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.function.aws.runtime.MicronautLambdaRuntime' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.function.aws.runtime.MicronautLambdaRuntime" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM ubuntu
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM ubuntu
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
 COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM ubuntu
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
 COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM ubuntu
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM scratch
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM scratch
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
@@ -7,7 +7,7 @@ COPY dependency/snapshot/ /home/app/libs/snapshot/
 COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
-RUN native-image @/home/app/graalvm-native-image.args -H:Class='io.micronaut.build.examples.Application' -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.build.examples.Application" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -537,6 +537,14 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         return quoteShellLiteral(source, validateDockerfileValue(source, value));
     }
 
+    protected static String escapeShellDoubleQuoted(String source, String value) throws MojoExecutionException {
+        return validateDockerfileValue(source, value)
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("$", "\\$")
+            .replace("`", "\\`");
+    }
+
     /**
      * @return Networking mode for the RUN instructions during build (if any).
      */

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.maven;
 
+import com.google.cloud.tools.jib.api.ImageReference;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.common.io.FileWriteMode;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.maven.core.MicronautRuntime;
@@ -26,6 +28,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -33,6 +36,8 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -46,7 +51,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static io.micronaut.maven.services.ApplicationConfigurationService.DEFAULT_PORT;
 
@@ -341,18 +345,18 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     /**
      * @return the Docker CMD command.
      */
-    protected String getCmd() {
-        return "CMD [" +
-            appArguments.stream()
-                .map(s -> "\"" + s + "\"")
-                .collect(Collectors.joining(", ")) +
-            "]";
+    protected String getCmd() throws MojoExecutionException {
+        var escapedArguments = new ArrayList<String>(appArguments.size());
+        for (String argument : appArguments) {
+            escapedArguments.add(jsonStringLiteral("mn.app.args", argument));
+        }
+        return "CMD [" + String.join(", ", escapedArguments) + "]";
     }
 
     /**
      * @return the generated AWS Lambda bootstrap command.
      */
-    protected String getLambdaBootstrapCommand() {
+    protected String getLambdaBootstrapCommand() throws MojoExecutionException {
         var command = new StringBuilder("./func");
         for (String bootstrapArgument : DEFAULT_LAMBDA_BOOTSTRAP_ARGUMENTS) {
             command.append(' ').append(bootstrapArgument);
@@ -370,10 +374,11 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      *
      * @param dockerfile the docker file
      */
-    protected void lambdaBootstrapCommand(File dockerfile) throws IOException {
+    protected void lambdaBootstrapCommand(File dockerfile) throws IOException, MojoExecutionException {
         if (dockerfile == null) {
             return;
         }
+        String lambdaBootstrapDockerCommand = getLambdaBootstrapDockerCommand();
         if (lambdaBootstrapArguments != null && !lambdaBootstrapArguments.isEmpty()) {
             getLog().info("Using AWS Lambda bootstrap arguments: " + lambdaBootstrapArguments);
         }
@@ -381,7 +386,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         var result = new ArrayList<String>(allLines.size());
         for (String line : allLines) {
             if (line.contains(LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER)) {
-                result.add(line.replace(LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER, getLambdaBootstrapDockerCommand()));
+                result.add(line.replace(LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER, lambdaBootstrapDockerCommand));
             } else {
                 result.add(line);
             }
@@ -389,19 +394,20 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         Files.write(dockerfile.toPath(), result);
     }
 
-    private String getLambdaBootstrapDockerCommand() {
-        return "printf '%s\\n' "
-            + Stream.of("#!/bin/sh", "set -euo pipefail", getLambdaBootstrapCommand())
-            .map(AbstractDockerMojo::quoteShellLiteral)
-            .collect(Collectors.joining(" "))
-            + " > bootstrap";
+    private String getLambdaBootstrapDockerCommand() throws MojoExecutionException {
+        var quotedLines = new ArrayList<String>();
+        for (String line : List.of("#!/bin/sh", "set -euo pipefail", getLambdaBootstrapCommand())) {
+            quotedLines.add(quoteShellLiteral("AWS Lambda bootstrap command", line));
+        }
+        return "printf '%s\\n' " + String.join(" ", quotedLines) + " > bootstrap";
     }
 
-    private static String escapeBootstrapArgument(String argument) {
-        if (isShellSafe(argument)) {
-            return argument;
+    private static String escapeBootstrapArgument(String argument) throws MojoExecutionException {
+        String sanitized = validateDockerfileValue("micronaut.lambda.bootstrap.args", argument);
+        if (isShellSafe(sanitized)) {
+            return sanitized;
         }
-        return quoteShellLiteral(argument);
+        return quoteShellLiteral("micronaut.lambda.bootstrap.args", sanitized);
     }
 
     private static boolean isShellSafe(String argument) {
@@ -418,8 +424,96 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         return true;
     }
 
-    private static String quoteShellLiteral(String value) {
+    static String quoteShellLiteral(String source, String value) throws MojoExecutionException {
+        validateDockerfileValue(source, value);
         return "'" + value.replace("'", "'\"'\"'") + "'";
+    }
+
+    protected static String validateDockerfileValue(String source, String value) throws MojoExecutionException {
+        if (value == null) {
+            throw new MojoExecutionException(source + " must not be null when generating a Dockerfile");
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (Character.isISOControl(c)) {
+                throw new MojoExecutionException(source + " contains an unsupported control character at index " + i
+                    + " and cannot be written into a generated Dockerfile");
+            }
+        }
+        return value;
+    }
+
+    protected static String validateImageReference(String source, String value) throws MojoExecutionException {
+        String sanitized = validateDockerfileValue(source, value);
+        try {
+            ImageReference.parse(sanitized);
+        } catch (InvalidImageReferenceException e) {
+            throw new MojoExecutionException(source + " is not a valid Docker image reference: " + sanitized, e);
+        }
+        return sanitized;
+    }
+
+    protected static String validateExposedPorts(String source, String value) throws MojoExecutionException {
+        String sanitized = validateDockerfileValue(source, value);
+        for (String token : sanitized.split("\\s+")) {
+            if (token.isEmpty()) {
+                continue;
+            }
+            if (!token.matches("\\d+(/(?:tcp|udp))?")) {
+                throw new MojoExecutionException(source + " contains an invalid exposed port token: " + token);
+            }
+        }
+        return sanitized;
+    }
+
+    protected static String validateDownloadUrl(String source, String value) throws MojoExecutionException {
+        String sanitized = validateDockerfileValue(source, value);
+        try {
+            URI uri = new URI(sanitized);
+            String scheme = uri.getScheme();
+            if (!"https".equalsIgnoreCase(scheme) && !"http".equalsIgnoreCase(scheme)) {
+                throw new MojoExecutionException(source + " must use an http or https URL: " + sanitized);
+            }
+            if (!uri.isAbsolute()) {
+                throw new MojoExecutionException(source + " must be an absolute URL: " + sanitized);
+            }
+        } catch (URISyntaxException e) {
+            throw new MojoExecutionException(source + " is not a valid URL: " + sanitized, e);
+        }
+        return sanitized;
+    }
+
+    protected static String jsonStringLiteral(String source, String value) throws MojoExecutionException {
+        return "\"" + escapeJsonString(source, value) + "\"";
+    }
+
+    protected static String escapeJsonString(String source, String value) throws MojoExecutionException {
+        String sanitized = validateDockerfileValue(source, value);
+        var result = new StringBuilder(sanitized.length() + 8);
+        for (int i = 0; i < sanitized.length(); i++) {
+            char c = sanitized.charAt(i);
+            switch (c) {
+                case '"' -> result.append("\\\"");
+                case '\\' -> result.append("\\\\");
+                case '\b' -> result.append("\\b");
+                case '\f' -> result.append("\\f");
+                case '\n' -> result.append("\\n");
+                case '\r' -> result.append("\\r");
+                case '\t' -> result.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        result.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        result.append(c);
+                    }
+                }
+            }
+        }
+        return result.toString();
+    }
+
+    protected static String shellLiteral(String source, String value) throws MojoExecutionException {
+        return quoteShellLiteral(source, validateDockerfileValue(source, value));
     }
 
     /**
@@ -477,10 +571,11 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      *
      * @param dockerfile the docker file
      */
-    protected void oracleCloudFunctionCmd(File dockerfile) throws IOException {
+    protected void oracleCloudFunctionCmd(File dockerfile) throws IOException, MojoExecutionException {
         if (appArguments != null && !appArguments.isEmpty()) {
             getLog().info("Using application arguments: " + appArguments);
-            com.google.common.io.Files.asCharSink(dockerfile, Charset.defaultCharset(), FileWriteMode.APPEND).write(System.lineSeparator() + getCmd());
+            com.google.common.io.Files.asCharSink(dockerfile, Charset.defaultCharset(), FileWriteMode.APPEND)
+                .write(System.lineSeparator() + getCmd());
         } else {
             com.google.common.io.Files.asCharSink(dockerfile, Charset.defaultCharset(), FileWriteMode.APPEND).write(System.lineSeparator() + ORACLE_CLOUD_FUNCTION_DEFAULT_CMD);
         }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -144,7 +144,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         }
     }
 
-    private void buildDockerNativeLambda() throws IOException {
+    private void buildDockerNativeLambda() throws IOException, MojoExecutionException {
         var buildImageCmdArguments = new HashMap<String, String>();
 
         // Add proxy settings if configured
@@ -165,7 +165,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         getLog().info("AWS Lambda Custom Runtime ZIP: " + functionZip.getPath());
     }
 
-    private void buildDockerNative() throws IOException, InvalidImageReferenceException {
+    private void buildDockerNative() throws IOException, InvalidImageReferenceException, MojoExecutionException {
         String dockerfileName = DockerfileMojo.DOCKERFILE_NATIVE;
         if (Boolean.TRUE.equals(staticNativeImage)) {
             getLog().info("Generating a static native image");
@@ -178,11 +178,11 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         buildDockerfile(dockerfileName, true);
     }
 
-    private void buildOracleCloud() throws IOException, InvalidImageReferenceException {
+    private void buildOracleCloud() throws IOException, InvalidImageReferenceException, MojoExecutionException {
         buildDockerfile(DockerfileMojo.DOCKERFILE_NATIVE_ORACLE_CLOUD, false);
     }
 
-    private void buildDockerfile(String dockerfileName, boolean passClassName) throws IOException, InvalidImageReferenceException {
+    private void buildDockerfile(String dockerfileName, boolean passClassName) throws IOException, InvalidImageReferenceException, MojoExecutionException {
         Set<String> tags = getTags();
         for (String tag : tags) {
             ImageReference.parse(tag);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -159,7 +159,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments, () -> dockerService.buildImageCmd()
             .withDockerfile(dockerfile)
             .withBuildArg("GRAALVM_DOWNLOAD_URL", graalVmDownloadUrl()));
-        buildImageCmd.withBuildArg("CLASS_NAME", mainClass);
+        buildImageCmd.withBuildArg("CLASS_NAME", escapeClassNameBuildArg(mainClass));
         String imageId = dockerService.buildImage(buildImageCmd);
         File functionZip = dockerService.copyFromContainer(imageId, "/function/function.zip");
         getLog().info("AWS Lambda Custom Runtime ZIP: " + functionZip.getPath());
@@ -206,7 +206,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         }
 
         if (passClassName) {
-            buildImageCmdArguments.put("CLASS_NAME", mainClass);
+            buildImageCmdArguments.put("CLASS_NAME", escapeClassNameBuildArg(mainClass));
         }
 
         BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments, () -> dockerService.buildImageCmd()
@@ -239,6 +239,10 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         } else {
             throw new IOException("Unable to convert native image build args to args file");
         }
+    }
+
+    static String escapeClassNameBuildArg(String value) throws MojoExecutionException {
+        return escapeShellDoubleQuoted("exec.mainClass", value);
     }
 
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -58,7 +58,6 @@ import static io.micronaut.maven.DockerNativeMojo.ARGS_FILE_PROPERTY_NAME;
 @Mojo(name = "dockerfile", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 @Execute(phase = LifecyclePhase.PROCESS_CLASSES)
 public class DockerfileMojo extends AbstractDockerMojo {
-
     public static final String DOCKERFILE = "Dockerfile";
     public static final String DOCKERFILE_AWS_CUSTOM_RUNTIME = "DockerfileNativeLambda";
     public static final String DOCKERFILE_AWS = "DockerfileLambda";
@@ -71,6 +70,8 @@ public class DockerfileMojo extends AbstractDockerMojo {
     public static final String DOCKERFILE_NATIVE_STATIC = "DockerfileNativeStatic";
     public static final String DOCKERFILE_NATIVE_ORACLE_CLOUD = "DockerfileNativeOracleCloud";
     public static final String NATIVE_BUILD_TOOLS_MAVEN_PLUGIN = "org.graalvm.buildtools:native-maven-plugin";
+    private static final String CLASS_NAME_PLACEHOLDER = "CLASS_NAME";
+    private static final String EXEC_MAIN_CLASS_SOURCE = "exec.mainClass";
 
     private final ExecutorService executorService;
 
@@ -226,7 +227,7 @@ public class DockerfileMojo extends AbstractDockerMojo {
         if (containsPlaceholder(line, "GRAALVM_DOWNLOAD_URL")) {
             return line.replace("${GRAALVM_DOWNLOAD_URL}", shellLiteral("GraalVM download URL", validateDownloadUrl("GraalVM download URL", graalVmDownloadUrl())));
         }
-        if (containsPlaceholder(line, "CLASS_NAME")) {
+        if (containsPlaceholder(line, CLASS_NAME_PLACEHOLDER)) {
             return replaceClassName(line);
         }
         if (containsPlaceholder(line, "PORTS")) {
@@ -271,30 +272,22 @@ public class DockerfileMojo extends AbstractDockerMojo {
             || "BASE_JAVA_IMAGE".equals(argName)
             || "BASE_IMAGE".equals(argName)
             || "GRAALVM_DOWNLOAD_URL".equals(argName)
-            || "CLASS_NAME".equals(argName)
+            || CLASS_NAME_PLACEHOLDER.equals(argName)
             || "PORTS".equals(argName);
     }
 
     private String replaceClassName(String line) throws MojoExecutionException {
         String className = isJsonArrayClassNameContext(line)
-            ? escapeJsonString("exec.mainClass", mainClass)
+            ? escapeJsonString(EXEC_MAIN_CLASS_SOURCE, mainClass)
             : line.contains("\"${CLASS_NAME}\"")
-                ? escapeShellDoubleQuoted("exec.mainClass", mainClass)
-            : shellLiteral("exec.mainClass", mainClass);
+                ? escapeShellDoubleQuoted(EXEC_MAIN_CLASS_SOURCE, mainClass)
+            : shellLiteral(EXEC_MAIN_CLASS_SOURCE, mainClass);
         return line.replace("${CLASS_NAME}", className);
     }
 
     private static boolean isJsonArrayClassNameContext(String line) {
-        return containsPlaceholder(line, "CLASS_NAME")
+        return containsPlaceholder(line, CLASS_NAME_PLACEHOLDER)
             && (line.contains("ENTRYPOINT [") || line.contains("CMD ["));
-    }
-
-    private static String escapeShellDoubleQuoted(String source, String value) throws MojoExecutionException {
-        return validateDockerfileValue(source, value)
-            .replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("$", "\\$")
-            .replace("`", "\\`");
     }
 
     private String findArgsFile() throws IOException {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -236,12 +236,39 @@ public class DockerfileMojo extends AbstractDockerMojo {
     }
 
     private static boolean shouldInlineArgLine(String line) {
-        return line.contains("BASE_IMAGE_RUN")
-            || line.contains("BASE_JAVA_IMAGE")
-            || line.contains("BASE_IMAGE")
-            || line.contains("GRAALVM_DOWNLOAD_URL")
-            || line.contains("CLASS_NAME")
-            || line.contains("PORTS");
+        String trimmed = line.trim();
+        if (!trimmed.startsWith("ARG")) {
+            return false;
+        }
+        String remainder = trimmed.substring(3).trim();
+        if (remainder.isEmpty()) {
+            return false;
+        }
+
+        int endEquals = remainder.indexOf('=');
+        int endWhitespace = -1;
+        for (int i = 0; i < remainder.length(); i++) {
+            if (Character.isWhitespace(remainder.charAt(i))) {
+                endWhitespace = i;
+                break;
+            }
+        }
+
+        int end = remainder.length();
+        if (endEquals >= 0) {
+            end = Math.min(end, endEquals);
+        }
+        if (endWhitespace >= 0) {
+            end = Math.min(end, endWhitespace);
+        }
+
+        String argName = remainder.substring(0, end);
+        return "BASE_IMAGE_RUN".equals(argName)
+            || "BASE_JAVA_IMAGE".equals(argName)
+            || "BASE_IMAGE".equals(argName)
+            || "GRAALVM_DOWNLOAD_URL".equals(argName)
+            || "CLASS_NAME".equals(argName)
+            || "PORTS".equals(argName);
     }
 
     private String replaceClassName(String line) throws MojoExecutionException {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -247,8 +247,18 @@ public class DockerfileMojo extends AbstractDockerMojo {
     private String replaceClassName(String line) throws MojoExecutionException {
         String className = line.contains("ENTRYPOINT [")
             ? escapeJsonString("exec.mainClass", mainClass)
+            : line.contains("\"${CLASS_NAME}\"")
+                ? escapeShellDoubleQuoted(mainClass)
             : shellLiteral("exec.mainClass", mainClass);
         return line.replace("${CLASS_NAME}", className);
+    }
+
+    private static String escapeShellDoubleQuoted(String value) {
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("$", "\\$")
+            .replace("`", "\\`");
     }
 
     private String findArgsFile() throws IOException {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -214,25 +214,29 @@ public class DockerfileMojo extends AbstractDockerMojo {
         if (line.startsWith("ARG")) {
             return shouldInlineArgLine(line) ? null : line;
         }
-        if (line.contains("BASE_IMAGE_RUN")) {
+        if (containsPlaceholder(line, "BASE_IMAGE_RUN")) {
             return line.replace("${BASE_IMAGE_RUN}", validateImageReference("micronaut.native-image.base-image-run", baseImageRun));
         }
-        if (line.contains("BASE_IMAGE")) {
+        if (containsPlaceholder(line, "BASE_IMAGE")) {
             return line.replace("${BASE_IMAGE}", validateImageReference("jib.from.image", getFrom()));
         }
-        if (line.contains("BASE_JAVA_IMAGE")) {
+        if (containsPlaceholder(line, "BASE_JAVA_IMAGE")) {
             return line.replace("${BASE_JAVA_IMAGE}", validateImageReference("base Java image", getBaseImage()));
         }
-        if (line.contains("GRAALVM_DOWNLOAD_URL")) {
+        if (containsPlaceholder(line, "GRAALVM_DOWNLOAD_URL")) {
             return line.replace("${GRAALVM_DOWNLOAD_URL}", shellLiteral("GraalVM download URL", validateDownloadUrl("GraalVM download URL", graalVmDownloadUrl())));
         }
-        if (line.contains("CLASS_NAME")) {
+        if (containsPlaceholder(line, "CLASS_NAME")) {
             return replaceClassName(line);
         }
-        if (line.contains("PORTS")) {
+        if (containsPlaceholder(line, "PORTS")) {
             return line.replace("${PORTS}", validateExposedPorts("jib.container.ports", getPorts()));
         }
         return line;
+    }
+
+    private static boolean containsPlaceholder(String line, String placeholderName) {
+        return line.contains("${" + placeholderName + "}");
     }
 
     private static boolean shouldInlineArgLine(String line) {
@@ -272,12 +276,17 @@ public class DockerfileMojo extends AbstractDockerMojo {
     }
 
     private String replaceClassName(String line) throws MojoExecutionException {
-        String className = line.contains("ENTRYPOINT [")
+        String className = isJsonArrayClassNameContext(line)
             ? escapeJsonString("exec.mainClass", mainClass)
             : line.contains("\"${CLASS_NAME}\"")
                 ? escapeShellDoubleQuoted("exec.mainClass", mainClass)
             : shellLiteral("exec.mainClass", mainClass);
         return line.replace("${CLASS_NAME}", className);
+    }
+
+    private static boolean isJsonArrayClassNameContext(String line) {
+        return containsPlaceholder(line, "CLASS_NAME")
+            && (line.contains("ENTRYPOINT [") || line.contains("CMD ["));
     }
 
     private static String escapeShellDoubleQuoted(String source, String value) throws MojoExecutionException {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -102,7 +102,7 @@ public class DockerfileMojo extends AbstractDockerMojo {
         }
     }
 
-    private Optional<File> buildDockerfile(MicronautRuntime runtime) throws IOException {
+    private Optional<File> buildDockerfile(MicronautRuntime runtime) throws IOException, MojoExecutionException {
         File dockerfile;
         switch (runtime.getBuildStrategy()) {
             case ORACLE_FUNCTION -> {
@@ -155,7 +155,7 @@ public class DockerfileMojo extends AbstractDockerMojo {
         }
     }
 
-    private Optional<File> buildDockerfileNative(MicronautRuntime runtime) throws IOException, MavenInvocationException {
+    private Optional<File> buildDockerfileNative(MicronautRuntime runtime) throws IOException, MavenInvocationException, MojoExecutionException {
         getLog().info("Generating GraalVM args file");
         executorService.invokeGoal(NATIVE_BUILD_TOOLS_MAVEN_PLUGIN, "write-args-file");
         File dockerfile;
@@ -185,58 +185,98 @@ public class DockerfileMojo extends AbstractDockerMojo {
         return Optional.ofNullable(dockerfile);
     }
 
-    private void processDockerfile(File dockerfile) throws IOException {
+    private void processDockerfile(File dockerfile) throws IOException, MojoExecutionException {
+        if (dockerfile == null) {
+            return;
+        }
 
-        if (dockerfile != null) {
-            var allLines = Files.readAllLines(dockerfile.toPath());
-            var result = new ArrayList<String>();
-            for (String line : allLines) {
-                if (!line.startsWith("ARG")) {
-                    if (line.contains("BASE_IMAGE_RUN")) {
-                        result.add(line.replace("${BASE_IMAGE_RUN}", baseImageRun));
-                    } else if (line.contains("BASE_IMAGE")) {
-                        result.add(line.replace("${BASE_IMAGE}", getFrom()));
-                    } else if (line.contains("BASE_JAVA_IMAGE")) {
-                        result.add(line.replace("${BASE_JAVA_IMAGE}", getBaseImage()));
-                    } else if (line.contains("GRAALVM_DOWNLOAD_URL")) {
-                        result.add(line.replace("${GRAALVM_DOWNLOAD_URL}", graalVmDownloadUrl()));
-                    } else if (line.contains("CLASS_NAME")) {
-                        result.add(line.replace("${CLASS_NAME}", mainClass));
-                    } else if (line.contains("PORTS")) {
-                        result.add(line.replace("${PORTS}", getPorts()));
-                    } else {
-                        result.add(line);
-                    }
-                }
-            }
+        var allLines = Files.readAllLines(dockerfile.toPath());
+        Files.write(dockerfile.toPath(), processDockerfileLines(allLines));
 
-            String argsFile = mavenProject.getProperties().getProperty(ARGS_FILE_PROPERTY_NAME);
-            if (argsFile == null) {
-                Path targetPath = Paths.get(mavenProject.getBuild().getDirectory());
-                try (Stream<Path> listStream = Files.list(targetPath)) {
-                    Path argsFilePath = listStream
-                        .map(path -> path.getFileName().toString())
-                        .filter(f -> f.startsWith("native-image") && f.endsWith("args"))
-                        .map(targetPath::resolve)
-                        .findFirst()
-                        .orElse(null);
-                    if (argsFilePath != null) {
-                        argsFile = argsFilePath.toAbsolutePath().toString();
-                    }
-                }
-            }
-            if (argsFile != null) {
-                List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile);
-                //Remove extra main class argument
-                allNativeImageBuildArgs.remove(mainClass);
-                getLog().info("GraalVM native image build args: " + allNativeImageBuildArgs);
-                List<String> conversionResult = NativeImageUtils.convertToArgsFile(allNativeImageBuildArgs, Paths.get(mavenProject.getBuild().getDirectory()));
-                if (conversionResult.size() == 1) {
-                    Files.delete(Paths.get(argsFile));
-                }
-            }
+        String argsFile = findArgsFile();
+        if (argsFile != null) {
+            processNativeImageArgs(argsFile);
+        }
+    }
 
-            Files.write(dockerfile.toPath(), result);
+    private List<String> processDockerfileLines(List<String> allLines) throws MojoExecutionException {
+        var result = new ArrayList<String>();
+        for (String line : allLines) {
+            String processedLine = processDockerfileLine(line);
+            if (processedLine != null) {
+                result.add(processedLine);
+            }
+        }
+        return result;
+    }
+
+    private String processDockerfileLine(String line) throws MojoExecutionException {
+        if (line.startsWith("ARG")) {
+            return shouldInlineArgLine(line) ? null : line;
+        }
+        if (line.contains("BASE_IMAGE_RUN")) {
+            return line.replace("${BASE_IMAGE_RUN}", validateImageReference("micronaut.native-image.base-image-run", baseImageRun));
+        }
+        if (line.contains("BASE_IMAGE")) {
+            return line.replace("${BASE_IMAGE}", validateImageReference("jib.from.image", getFrom()));
+        }
+        if (line.contains("BASE_JAVA_IMAGE")) {
+            return line.replace("${BASE_JAVA_IMAGE}", validateImageReference("base Java image", getBaseImage()));
+        }
+        if (line.contains("GRAALVM_DOWNLOAD_URL")) {
+            return line.replace("${GRAALVM_DOWNLOAD_URL}", shellLiteral("GraalVM download URL", validateDownloadUrl("GraalVM download URL", graalVmDownloadUrl())));
+        }
+        if (line.contains("CLASS_NAME")) {
+            return replaceClassName(line);
+        }
+        if (line.contains("PORTS")) {
+            return line.replace("${PORTS}", validateExposedPorts("jib.container.ports", getPorts()));
+        }
+        return line;
+    }
+
+    private static boolean shouldInlineArgLine(String line) {
+        return line.contains("BASE_IMAGE_RUN")
+            || line.contains("BASE_JAVA_IMAGE")
+            || line.contains("BASE_IMAGE")
+            || line.contains("GRAALVM_DOWNLOAD_URL")
+            || line.contains("CLASS_NAME")
+            || line.contains("PORTS");
+    }
+
+    private String replaceClassName(String line) throws MojoExecutionException {
+        String className = line.contains("ENTRYPOINT [")
+            ? escapeJsonString("exec.mainClass", mainClass)
+            : shellLiteral("exec.mainClass", mainClass);
+        return line.replace("${CLASS_NAME}", className);
+    }
+
+    private String findArgsFile() throws IOException {
+        String argsFile = mavenProject.getProperties().getProperty(ARGS_FILE_PROPERTY_NAME);
+        if (argsFile != null) {
+            return argsFile;
+        }
+        Path targetPath = Paths.get(mavenProject.getBuild().getDirectory());
+        try (Stream<Path> listStream = Files.list(targetPath)) {
+            return listStream
+                .filter(path -> {
+                    String fileName = path.getFileName().toString();
+                    return fileName.startsWith("native-image") && fileName.endsWith("args");
+                })
+                .findFirst()
+                .map(path -> path.toAbsolutePath().toString())
+                .orElse(null);
+        }
+    }
+
+    private void processNativeImageArgs(String argsFile) throws IOException, MojoExecutionException {
+        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile);
+        //Remove extra main class argument
+        allNativeImageBuildArgs.remove(mainClass);
+        getLog().info("GraalVM native image build args: " + allNativeImageBuildArgs);
+        List<String> conversionResult = NativeImageUtils.convertToArgsFile(allNativeImageBuildArgs, Paths.get(mavenProject.getBuild().getDirectory()));
+        if (conversionResult.size() == 1) {
+            Files.delete(Paths.get(argsFile));
         }
     }
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -248,13 +248,13 @@ public class DockerfileMojo extends AbstractDockerMojo {
         String className = line.contains("ENTRYPOINT [")
             ? escapeJsonString("exec.mainClass", mainClass)
             : line.contains("\"${CLASS_NAME}\"")
-                ? escapeShellDoubleQuoted(mainClass)
+                ? escapeShellDoubleQuoted("exec.mainClass", mainClass)
             : shellLiteral("exec.mainClass", mainClass);
         return line.replace("${CLASS_NAME}", className);
     }
 
-    private static String escapeShellDoubleQuoted(String value) {
-        return value
+    private static String escapeShellDoubleQuoted(String source, String value) throws MojoExecutionException {
+        return validateDockerfileValue(source, value)
             .replace("\\", "\\\\")
             .replace("\"", "\\\"")
             .replace("$", "\\$")

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNative
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNative
@@ -10,7 +10,7 @@ COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="${CLASS_NAME}" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM ${BASE_IMAGE_RUN}
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeDistroless
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeDistroless
@@ -10,7 +10,7 @@ COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="${CLASS_NAME}" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM ${BASE_IMAGE_RUN}
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
@@ -15,7 +15,7 @@ COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
-RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args -H:Class="${CLASS_NAME}" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 WORKDIR /function

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeStatic
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeStatic
@@ -10,7 +10,7 @@ COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
 COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
-RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class="${CLASS_NAME}" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
 FROM scratch
 COPY --from=builder /home/app/application /app/application

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -122,14 +122,19 @@ class AbstractDockerMojoTest {
     private static final class TestDockerMojo extends AbstractDockerMojo {
 
         private TestDockerMojo(MavenProject mavenProject, MavenSession mavenSession) {
+            this(mavenProject, mavenSession, mock(JibConfigurationService.class));
+        }
+
+        private TestDockerMojo(MavenProject mavenProject, MavenSession mavenSession, JibConfigurationService jibConfigurationService) {
             super(
                 mavenProject,
-                mock(JibConfigurationService.class),
+                jibConfigurationService,
                 mock(ApplicationConfigurationService.class),
                 mock(DockerService.class),
                 mavenSession,
                 mock(MojoExecution.class)
             );
+            oracleLinuxVersion = "ol9";
         }
 
         @Override

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -7,10 +7,12 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,6 +21,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -56,6 +59,38 @@ class AbstractDockerMojoTest {
         assertFalse(Files.exists(dependencyDirectory.resolve("snapshot").resolve("release.jar")));
         assertEquals("release", Files.readString(flatReleaseJar));
         assertEquals("snapshot", Files.readString(flatSnapshotJar));
+    }
+
+    @Test
+    void getCmdEscapesJsonArguments() throws MojoExecutionException {
+        var project = mockProject(Path.of(".").toAbsolutePath(), Set.of());
+        var mojo = new TestDockerMojo(project, mockSession(project));
+        mojo.appArguments = java.util.List.of("handler\", \"extra", "path\\segment");
+
+        assertEquals("CMD [\"handler\\\", \\\"extra\", \"path\\\\segment\"]", mojo.getCmd());
+    }
+
+    @Test
+    void getCmdRejectsControlCharacters() {
+        var project = mockProject(Path.of(".").toAbsolutePath(), Set.of());
+        var mojo = new TestDockerMojo(project, mockSession(project));
+        mojo.appArguments = java.util.List.of("handler\nRUN echo injected");
+
+        var exception = assertThrows(MojoExecutionException.class, mojo::getCmd);
+
+        assertTrue(exception.getMessage().contains("mn.app.args contains an unsupported control character"));
+    }
+
+    @Test
+    void lambdaBootstrapCommandRejectsControlCharacters(@TempDir Path tempDir) throws IOException {
+        var project = mockProject(tempDir, Set.of());
+        var mojo = new TestDockerMojo(project, mockSession(project));
+        mojo.lambdaBootstrapArguments = java.util.List.of("-Dsafe=true", "-Dmessage=hello\nRUN echo injected");
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "RUN ${LAMBDA_BOOTSTRAP_DOCKER_COMMAND}");
+
+        var exception = assertThrows(MojoExecutionException.class, () -> mojo.applyLambdaBootstrapCommand(dockerfile.toFile()));
+
+        assertTrue(exception.getMessage().contains("micronaut.lambda.bootstrap.args contains an unsupported control character"));
     }
 
     private static Artifact mockDependency(String scope, boolean snapshot, Path file) {
@@ -100,6 +135,10 @@ class AbstractDockerMojoTest {
         @Override
         public void execute() {
             throw new UnsupportedOperationException("not used in test");
+        }
+
+        private void applyLambdaBootstrapCommand(File dockerfile) throws IOException, MojoExecutionException {
+            lambdaBootstrapCommand(dockerfile);
         }
     }
 }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 
 import static io.micronaut.maven.AbstractDockerMojo.X86_64_ARCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -283,6 +284,16 @@ class DockerNativeMojoTest {
         var command = mojo.getLambdaBootstrapCommand();
 
         assertEquals("./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd) -Dio.netty.noUnsafe=true '-Dcustom.message=hello world'", command);
+    }
+
+    @Test
+    void escapeClassNameBuildArgEscapesShellExpansionCharacters() throws MojoExecutionException {
+        assertEquals("example.Outer\\$Inner", DockerNativeMojo.escapeClassNameBuildArg("example.Outer$Inner"));
+    }
+
+    @Test
+    void escapeClassNameBuildArgRejectsControlCharacters() {
+        assertThrows(MojoExecutionException.class, () -> DockerNativeMojo.escapeClassNameBuildArg("example.App\nRUN echo injected"));
     }
 
 }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
@@ -5,6 +5,7 @@ import io.micronaut.maven.services.ApplicationConfigurationService;
 import io.micronaut.maven.services.DockerService;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -268,7 +269,7 @@ class DockerNativeMojoTest {
     }
 
     @Test
-    void testLambdaBootstrapCommandAppendsCustomArguments() {
+    void testLambdaBootstrapCommandAppendsCustomArguments() throws MojoExecutionException {
         var project = mock(MavenProject.class);
         var session = mock(MavenSession.class);
         var execution = mock(MojoExecution.class);

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
@@ -151,6 +151,35 @@ class DockerfileMojoTest {
     }
 
     @Test
+    void processDockerfileTreatsCmdArrayClassNameAsJsonContext(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+        mojo.mainClass = "example.App$USER `quoted` \"Slash\\\\\"";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "CMD [\"${CLASS_NAME}\"]");
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertEquals(
+            "CMD [\"" + AbstractDockerMojo.escapeJsonString("exec.mainClass", mojo.mainClass) + "\"]",
+            Files.readAllLines(dockerfile).get(0)
+        );
+    }
+
+    @Test
     void processDockerfileRejectsInvalidBaseImageReference(@TempDir Path tempDir) throws IOException {
         var project = mockProject(tempDir);
         var jibConfigurationService = mock(JibConfigurationService.class);
@@ -302,6 +331,41 @@ class DockerfileMojoTest {
                 "ARG PORTS_FILE=/tmp/ports",
                 "ARG CLASS_NAME_SUFFIX=Application",
                 "FROM ghcr.io/example/builder:1.0"
+            ),
+            Files.readAllLines(dockerfile)
+        );
+    }
+
+    @Test
+    void processDockerfileDoesNotValidateSimilarlyNamedPlaceholders(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("invalid image"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+        mojo.mainClass = "example.App\nRUN echo injected";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), String.join(System.lineSeparator(),
+            "FROM ${BASE_IMAGE_TAG}",
+            "CMD [\"${CLASS_NAME_SUFFIX}\"]"
+        ));
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertEquals(
+            java.util.List.of(
+                "FROM ${BASE_IMAGE_TAG}",
+                "CMD [\"${CLASS_NAME_SUFFIX}\"]"
             ),
             Files.readAllLines(dockerfile)
         );

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
@@ -268,6 +268,45 @@ class DockerfileMojoTest {
         );
     }
 
+    @Test
+    void processDockerfilePreservesSimilarlyNamedArgLines(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), String.join(System.lineSeparator(),
+            "ARG BASE_IMAGE_TAG=latest",
+            "ARG PORTS_FILE=/tmp/ports",
+            "ARG CLASS_NAME_SUFFIX=Application",
+            "ARG BASE_IMAGE",
+            "FROM ${BASE_IMAGE}"
+        ));
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertEquals(
+            java.util.List.of(
+                "ARG BASE_IMAGE_TAG=latest",
+                "ARG PORTS_FILE=/tmp/ports",
+                "ARG CLASS_NAME_SUFFIX=Application",
+                "FROM ghcr.io/example/builder:1.0"
+            ),
+            Files.readAllLines(dockerfile)
+        );
+    }
+
     private static MavenProject mockProject(Path tempDir) {
         var project = mock(MavenProject.class);
         var build = mock(Build.class);

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
@@ -1,0 +1,258 @@
+package io.micronaut.maven;
+
+import io.micronaut.maven.jib.JibConfigurationService;
+import io.micronaut.maven.services.ApplicationConfigurationService;
+import io.micronaut.maven.services.DockerService;
+import io.micronaut.maven.services.ExecutorService;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DockerfileMojoTest {
+
+    @Test
+    void processDockerfileEscapesJsonAndShellContexts(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080 8443/tcp"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+        mojo.mainClass = "example.App\"Quoted";
+        mojo.baseImageRun = "cgr.dev/chainguard/wolfi-base:latest";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), String.join(System.lineSeparator(),
+            "FROM ${BASE_IMAGE}",
+            "EXPOSE ${PORTS}",
+            "ENTRYPOINT [\"java\", \"-cp\", \"/app\", \"${CLASS_NAME}\"]",
+            "RUN native-image -H:Class=${CLASS_NAME}"
+        ));
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertEquals(
+            java.util.List.of(
+                "FROM ghcr.io/example/builder:1.0",
+                "EXPOSE 8080 8443/tcp",
+                "ENTRYPOINT [\"java\", \"-cp\", \"/app\", \"example.App\\\"Quoted\"]",
+                "RUN native-image -H:Class='example.App\"Quoted'"
+            ),
+            Files.readAllLines(dockerfile)
+        );
+    }
+
+    @Test
+    void processDockerfileRejectsInjectedMainClass(@TempDir Path tempDir) throws IOException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+        mojo.mainClass = "example.App\"\nRUN echo injected";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "ENTRYPOINT [\"java\", \"${CLASS_NAME}\"]");
+
+        var exception = assertThrows(MojoExecutionException.class, () -> invokeProcessDockerfile(mojo, dockerfile));
+
+        assertTrue(exception.getMessage().contains("exec.mainClass contains an unsupported control character"));
+    }
+
+    @Test
+    void processDockerfileRejectsInvalidBaseImageReference(@TempDir Path tempDir) throws IOException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+        mojo.baseImageRun = "invalid image";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "FROM ${BASE_IMAGE_RUN}");
+
+        var exception = assertThrows(MojoExecutionException.class, () -> invokeProcessDockerfile(mojo, dockerfile));
+
+        assertTrue(exception.getMessage().contains("micronaut.native-image.base-image-run is not a valid Docker image reference"));
+    }
+
+    @Test
+    void processDockerfileRejectsInvalidPortTokens(@TempDir Path tempDir) throws IOException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080 RUN"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "EXPOSE ${PORTS}");
+
+        var exception = assertThrows(MojoExecutionException.class, () -> invokeProcessDockerfile(mojo, dockerfile));
+
+        assertTrue(exception.getMessage().contains("jib.container.ports contains an invalid exposed port token"));
+    }
+
+    @Test
+    void processDockerfileQuotesDownloadUrlInRunInstruction(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        project.getProperties().setProperty("maven.compiler.release", "25");
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "RUN curl -4 -L ${GRAALVM_DOWNLOAD_URL} -o /tmp/graalvm.tar.gz");
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertTrue(Files.readString(dockerfile).contains("-L " + AbstractDockerMojo.shellLiteral("GraalVM download URL", mojo.graalVmDownloadUrl()) + " -o"));
+    }
+
+    @Test
+    void processDockerfilePreservesUnknownArgLines(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), String.join(System.lineSeparator(),
+            "ARG BASE_IMAGE",
+            "ARG CHECKPOINT_IMAGE",
+            "ARG CRAC_ARCH",
+            "FROM ${BASE_IMAGE}",
+            "FROM ${CHECKPOINT_IMAGE} AS crac-checkpoint",
+            "RUN echo $CRAC_ARCH"
+        ));
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertEquals(
+            java.util.List.of(
+                "ARG CHECKPOINT_IMAGE",
+                "ARG CRAC_ARCH",
+                "FROM ghcr.io/example/builder:1.0",
+                "FROM ${CHECKPOINT_IMAGE} AS crac-checkpoint",
+                "RUN echo $CRAC_ARCH"
+            ),
+            Files.readAllLines(dockerfile)
+        );
+    }
+
+    private static MavenProject mockProject(Path tempDir) {
+        var project = mock(MavenProject.class);
+        var build = mock(Build.class);
+        var properties = new Properties();
+        tempDir.resolve("target").toFile().mkdirs();
+        when(project.getBuild()).thenReturn(build);
+        when(project.getProperties()).thenReturn(properties);
+        when(project.getArtifacts()).thenReturn(Set.<Artifact>of());
+        when(build.getDirectory()).thenReturn(tempDir.resolve("target").toString());
+        return project;
+    }
+
+    private static MavenSession mockSession(MavenProject project) {
+        var session = mock(MavenSession.class);
+        when(session.getCurrentProject()).thenReturn(project);
+        when(session.getSystemProperties()).thenReturn(new Properties());
+        when(session.getUserProperties()).thenReturn(new Properties());
+        return session;
+    }
+
+    private static void invokeProcessDockerfile(DockerfileMojo mojo, Path dockerfile) throws IOException, MojoExecutionException {
+        try {
+            Method method = DockerfileMojo.class.getDeclaredMethod("processDockerfile", java.io.File.class);
+            method.setAccessible(true);
+            method.invoke(mojo, dockerfile.toFile());
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof MojoExecutionException mojoExecutionException) {
+                throw mojoExecutionException;
+            }
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new AssertionError(cause);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
@@ -12,6 +12,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -23,6 +25,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -47,27 +50,52 @@ class DockerfileMojoTest {
             mock(MojoExecution.class)
         );
         mojo.micronautRuntime = "netty";
-        mojo.mainClass = "example.App\"Quoted";
+        mojo.mainClass = "example.App$USER `touch /tmp/pwned` \"Quoted\" \\\\";
         mojo.baseImageRun = "cgr.dev/chainguard/wolfi-base:latest";
 
         var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), String.join(System.lineSeparator(),
             "FROM ${BASE_IMAGE}",
             "EXPOSE ${PORTS}",
             "ENTRYPOINT [\"java\", \"-cp\", \"/app\", \"${CLASS_NAME}\"]",
-            "RUN native-image -H:Class=${CLASS_NAME}"
+            "RUN echo ${CLASS_NAME}",
+            "RUN native-image -H:Class=\"${CLASS_NAME}\""
         ));
 
         invokeProcessDockerfile(mojo, dockerfile);
+
+        var jsonClassName = AbstractDockerMojo.escapeJsonString("exec.mainClass", mojo.mainClass);
+        var shellLiteralClassName = AbstractDockerMojo.shellLiteral("exec.mainClass", mojo.mainClass);
+        var doubleQuotedClassName = mojo.mainClass
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("$", "\\$")
+            .replace("`", "\\`");
 
         assertEquals(
             java.util.List.of(
                 "FROM ghcr.io/example/builder:1.0",
                 "EXPOSE 8080 8443/tcp",
-                "ENTRYPOINT [\"java\", \"-cp\", \"/app\", \"example.App\\\"Quoted\"]",
-                "RUN native-image -H:Class='example.App\"Quoted'"
+                "ENTRYPOINT [\"java\", \"-cp\", \"/app\", \"" + jsonClassName + "\"]",
+                "RUN echo " + shellLiteralClassName,
+                "RUN native-image -H:Class=\"" + doubleQuotedClassName + "\""
             ),
             Files.readAllLines(dockerfile)
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "DockerfileNative",
+        "DockerfileNativeDistroless",
+        "DockerfileNativeStatic",
+        "DockerfileNativeLambda"
+    })
+    void nativeDockerfileTemplatesQuoteClassNameExpansion(String dockerfileName) throws IOException {
+        var dockerfile = Path.of("src", "main", "resources", "dockerfiles", dockerfileName);
+        var content = Files.readString(dockerfile);
+
+        assertEquals(1, content.lines().filter(line -> line.contains("-H:Class=\"${CLASS_NAME}\"")).count());
+        assertFalse(content.contains("-H:Class=${CLASS_NAME}"));
     }
 
     @Test

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
@@ -125,6 +125,32 @@ class DockerfileMojoTest {
     }
 
     @Test
+    void processDockerfileRejectsInjectedMainClassInDoubleQuotedNativeImageBranch(@TempDir Path tempDir) throws IOException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+        mojo.mainClass = "example.App\nRUN echo injected";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "RUN native-image -H:Class=\"${CLASS_NAME}\"");
+
+        var exception = assertThrows(MojoExecutionException.class, () -> invokeProcessDockerfile(mojo, dockerfile));
+
+        assertTrue(exception.getMessage().contains("exec.mainClass contains an unsupported control character"));
+    }
+
+    @Test
     void processDockerfileRejectsInvalidBaseImageReference(@TempDir Path tempDir) throws IOException {
         var project = mockProject(tempDir);
         var jibConfigurationService = mock(JibConfigurationService.class);


### PR DESCRIPTION
## Summary
- validate generated Dockerfile placeholder values before writing executable instructions
- JSON-escape Oracle Function `CMD` arguments and `ENTRYPOINT` class names, and shell-quote shell-context substitutions
- add regression tests for hostile main class, app arguments, image references, exposed ports, and download URLs

## Verification
- `./mvnw -q -pl micronaut-maven-plugin -am -Dtest=AbstractDockerMojoTest,DockerfileMojoTest test -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -q -pl micronaut-maven-plugin -am test`

## SemVer
- patch