### PR TITLE
Pin docker-native default base images

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
@@ -9,7 +9,7 @@ COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 COPY --from=builder /home/app/application /app/application
 
 EXPOSE 8080

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -9,7 +9,7 @@ COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 COPY --from=builder /home/app/application /app/application
 
 EXPOSE 8080

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
@@ -9,9 +9,9 @@ COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-elements-at-runtime -H:PageSize=64k -H:Class=com.fnproject.fn.runtime.EntryPoint -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
+FROM fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f AS fnfdk
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 WORKDIR /function
 COPY --from=builder /home/app/application /function/func
 COPY --from=fnfdk /function/runtime/lib/* .

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
@@ -9,9 +9,9 @@ COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-elements-at-runtime -H:PageSize=64k -H:Class=com.fnproject.fn.runtime.EntryPoint -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
+FROM fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f AS fnfdk
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 WORKDIR /function
 COPY --from=builder /home/app/application /function/func
 COPY --from=fnfdk /function/runtime/lib/* .

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-function/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_JAVA_IMAGE=eclipse-temurin:25-jre
 
-FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
+FROM fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f AS fnfdk
 
 FROM ${BASE_JAVA_IMAGE}
 COPY --from=fnfdk /function /function

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-function/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-function/verify.groovy
@@ -7,5 +7,5 @@ assert dockerfile.text == expectedDockerfileText
 
 File log = new File(basedir, 'build.log')
 assert log.exists()
-assert log.text.contains("fnproject/fn-java-fdk:jre17-latest")
+assert log.text.contains("fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f")
 assert log.text.contains("Successfully tagged alvarosanchez/dockerfile-docker-oracle-function:0.1")

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-http-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-http-function/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_JAVA_IMAGE=eclipse-temurin:25-jre
 
-FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
+FROM fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f AS fnfdk
 
 FROM ${BASE_JAVA_IMAGE}
 COPY --from=fnfdk /function /function

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-http-function/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-oracle-http-function/verify.groovy
@@ -7,5 +7,5 @@ assert dockerfile.text == expectedDockerfileText
 
 File log = new File(basedir, 'build.log')
 assert log.exists()
-assert log.text.contains("fnproject/fn-java-fdk:jre17-latest")
+assert log.text.contains("fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f")
 assert log.text.contains("Successfully tagged alvarosanchez/dockerfile-docker-oracle-http-function:0.1")

--- a/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
@@ -9,7 +9,7 @@ COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 COPY --from=builder /home/app/application /app/application
 
 EXPOSE 8080 8081

--- a/micronaut-maven-integration-tests/src/it/package-docker-native/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-native/verify.groovy
@@ -2,6 +2,6 @@ File log = new File(basedir, 'build.log')
 
 assert log.exists()
 assert log.text.contains("native:${nativeMavenPluginVersion}:generateTestResourceConfig")
-assert log.text.contains("Using BASE_IMAGE_RUN: cgr.dev/chainguard/wolfi-base:latest")
+assert log.text.contains("Using BASE_IMAGE_RUN: cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502")
 assert log.text.contains("Successfully tagged alvarosanchez/package-docker-native:0.1")
 assert log.text.contains("io.micronaut.runtime.Micronaut - Startup completed")

--- a/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-oracle-function/verify.groovy
@@ -1,6 +1,6 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
-assert log.text.contains("fnproject/fn-java-fdk:jre17-latest")
+assert log.text.contains("fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f")
 assert log.text.contains("Successfully tagged alvarosanchez/dockerfile-docker-oracle-function:0.1")
 assert log.text.contains("ENTRYPOINT [\"java\", \"-XX:-UsePerfData\", \"-XX:+UseSerialGC\", \"-Xshare:auto\", \"-Djava.awt.headless=true\", \"-Djava.library.path=/function/runtime/lib\", \"-cp\", \"/function/app/classes:/function/app/libs/release/*:/function/app/libs/snapshot/*:/function/app/resources:/function/runtime/*\", \"com.fnproject.fn.runtime.EntryPoint\"]")
 assert log.text.contains("CMD [\"io.micronaut.oraclecloud.function.http.HttpFunction::handleRequest\"]")

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -60,7 +60,7 @@ import static io.micronaut.maven.services.ApplicationConfigurationService.DEFAUL
 public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
 
     public static final String LATEST_TAG = "latest";
-    public static final String DEFAULT_BASE_IMAGE_GRAALVM_RUN = "cgr.dev/chainguard/wolfi-base:latest";
+    public static final String DEFAULT_BASE_IMAGE_GRAALVM_RUN = "cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502";
     public static final String MOSTLY_STATIC_NATIVE_IMAGE_GRAALVM_FLAG = "-H:+StaticExecutableWithDynamicLibC";
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "x64";

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeOracleCloud
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeOracleCloud
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-ARG BASE_IMAGE_RUN=cgr.dev/chainguard/wolfi-base:latest
+ARG BASE_IMAGE_RUN=cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 FROM ${BASE_IMAGE} AS builder
 WORKDIR /home/app
 
@@ -11,7 +11,7 @@ COPY nativ[e]/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-elements-at-runtime -H:PageSize=64k -H:Class=com.fnproject.fn.runtime.EntryPoint -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
+FROM fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f AS fnfdk
 
 FROM ${BASE_IMAGE_RUN}
 WORKDIR /function

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileOracleCloud
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileOracleCloud
@@ -1,6 +1,6 @@
 ARG BASE_JAVA_IMAGE=eclipse-temurin:
 
-FROM fnproject/fn-java-fdk:jre17-latest AS fnfdk
+FROM fnproject/fn-java-fdk:jre17-1.1.7@sha256:50a0b8138fec3dde64aaedbe66406da6c2c17fc88446726c75446cb4c4fc681f AS fnfdk
 
 FROM ${BASE_JAVA_IMAGE}
 COPY --from=fnfdk /function /function

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -243,7 +243,7 @@ If the `<packaging>` is set to `docker-native`, this plugin will use a Docker cl
 images. In this case, the `micronaut.runtime` property will also determine how the image is prepared.
 
 * Default runtime.
-** Default image (dynamic): `mvn package -Dpackaging=docker-native`.
+** Default image (pinned immutable base): `mvn package -Dpackaging=docker-native`.
 ** JDK HTTP server runtime (Starter compatibility alias for the default runtime; same behavior as the default image): `mvn package -Dpackaging=docker-native -Dmicronaut.runtime=http_server_jdk`.
 ** Static image: `mvn package -Dpackaging=docker-native -Dmicronaut.native-image.static=true`. This uses GraalVM's
    `--static --libc=musl` flags and then puts the binary in a `scratch` image.


### PR DESCRIPTION
## Summary
- pin the default `docker-native` runtime image to an immutable Chainguard Wolfi digest
- pin the Oracle Cloud Dockerfile templates to an immutable `fn-java-fdk` digest instead of `jre17-latest`
- update the affected invoker fixtures, assertions, and package docs to reflect the pinned defaults

## Verification
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=package-docker-native,package-docker-oracle-function,dockerfile-docker-native-oracle-function,dockerfile-docker-native-oracle-http-function,dockerfile-docker-oracle-function,dockerfile-docker-oracle-http-function,dockerfile-docker-native-netty,dockerfile-docker-native-netty-custom-ol,issue1218"`

Closes #1612
