### PR TITLE
Fix AOT resource-filter path traversal cleanup

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AotAnalysisMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AotAnalysisMojo.java
@@ -118,12 +118,18 @@ public class AotAnalysisMojo extends AbstractMicronautAotCliMojo {
     protected void onSuccess(File outputDir) throws MojoExecutionException {
         Path generated = outputDir.toPath().resolve("generated");
         Path generatedClasses = generated.resolve("classes");
+        Path targetOutputDirectory = outputDirectory.toPath().toAbsolutePath().normalize();
         try {
             FileUtils.copyDirectory(generatedClasses.toFile(), outputDirectory);
             try (Stream<String> linesStream = Files.lines(generated.resolve("logs").resolve("resource-filter.txt"))) {
                 linesStream.forEach(toRemove -> {
+                    Path candidate = targetOutputDirectory.resolve(toRemove).normalize();
+                    if (!candidate.startsWith(targetOutputDirectory)) {
+                        getLog().warn("Skipping deletion outside output directory: " + toRemove);
+                        return;
+                    }
                     try {
-                        Files.delete(outputDirectory.toPath().resolve(toRemove));
+                        Files.delete(candidate);
                         getLog().debug("Removed " + toRemove);
                     } catch (IOException e) {
                         if (!(e instanceof NoSuchFileException)) {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AotAnalysisMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/aot/AotAnalysisMojo.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -123,7 +124,17 @@ public class AotAnalysisMojo extends AbstractMicronautAotCliMojo {
             FileUtils.copyDirectory(generatedClasses.toFile(), outputDirectory);
             try (Stream<String> linesStream = Files.lines(generated.resolve("logs").resolve("resource-filter.txt"))) {
                 linesStream.forEach(toRemove -> {
-                    Path candidate = targetOutputDirectory.resolve(toRemove).normalize();
+                    String sanitized = toRemove.strip();
+                    if (sanitized.isEmpty() || ".".equals(sanitized)) {
+                        return;
+                    }
+                    final Path candidate;
+                    try {
+                        candidate = targetOutputDirectory.resolve(Path.of(sanitized)).normalize();
+                    } catch (InvalidPathException e) {
+                        getLog().warn("Skipping invalid deletion entry: " + toRemove, e);
+                        return;
+                    }
                     if (!candidate.startsWith(targetOutputDirectory)) {
                         getLog().warn("Skipping deletion outside output directory: " + toRemove);
                         return;

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/aot/AotAnalysisMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/aot/AotAnalysisMojoTest.java
@@ -1,0 +1,45 @@
+package io.micronaut.maven.aot;
+
+import io.micronaut.maven.services.CompilerService;
+import io.micronaut.maven.services.DependencyResolutionService;
+import io.micronaut.maven.services.ExecutorService;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class AotAnalysisMojoTest {
+
+    @Test
+    void onSuccessDoesNotDeleteFilesOutsideOutputDirectoryWhenResourceFilterContainsTraversal(@TempDir Path tempDir) throws Exception {
+        var mojo = new AotAnalysisMojo(
+            mock(CompilerService.class),
+            mock(ExecutorService.class),
+            mock(MavenProject.class),
+            mock(DependencyResolutionService.class),
+            mock(MavenSession.class),
+            mock(ToolchainManager.class)
+        );
+        Path outputDirectory = tempDir.resolve("target/classes");
+        Path generatedDirectory = tempDir.resolve("aot/jit/generated");
+        Path outsideFile = tempDir.resolve("outside.txt");
+
+        mojo.outputDirectory = outputDirectory.toFile();
+        Files.createDirectories(outputDirectory);
+        Files.createDirectories(generatedDirectory.resolve("classes"));
+        Files.createDirectories(generatedDirectory.resolve("logs"));
+        Files.writeString(generatedDirectory.resolve("logs/resource-filter.txt"), "../../outside.txt");
+        Files.writeString(outsideFile, "outside");
+
+        mojo.onSuccess(tempDir.resolve("aot/jit").toFile());
+
+        assertTrue(Files.exists(outsideFile));
+    }
+}

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/aot/AotAnalysisMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/aot/AotAnalysisMojoTest.java
@@ -19,20 +19,11 @@ class AotAnalysisMojoTest {
 
     @Test
     void onSuccessDoesNotDeleteFilesOutsideOutputDirectoryWhenResourceFilterContainsTraversal(@TempDir Path tempDir) throws Exception {
-        var mojo = new AotAnalysisMojo(
-            mock(CompilerService.class),
-            mock(ExecutorService.class),
-            mock(MavenProject.class),
-            mock(DependencyResolutionService.class),
-            mock(MavenSession.class),
-            mock(ToolchainManager.class)
-        );
         Path outputDirectory = tempDir.resolve("target/classes");
         Path generatedDirectory = tempDir.resolve("aot/jit/generated");
         Path outsideFile = tempDir.resolve("outside.txt");
 
-        mojo.outputDirectory = outputDirectory.toFile();
-        Files.createDirectories(outputDirectory);
+        AotAnalysisMojo mojo = newMojo(outputDirectory);
         Files.createDirectories(generatedDirectory.resolve("classes"));
         Files.createDirectories(generatedDirectory.resolve("logs"));
         Files.writeString(generatedDirectory.resolve("logs/resource-filter.txt"), "../../outside.txt");
@@ -41,5 +32,38 @@ class AotAnalysisMojoTest {
         mojo.onSuccess(tempDir.resolve("aot/jit").toFile());
 
         assertTrue(Files.exists(outsideFile));
+    }
+
+    @Test
+    void onSuccessIgnoresBlankAndSelfDeletionEntries(@TempDir Path tempDir) throws Exception {
+        Path outputDirectory = tempDir.resolve("target/classes");
+        Path generatedDirectory = tempDir.resolve("aot/jit/generated");
+        Path insideFile = outputDirectory.resolve("keep.txt");
+
+        AotAnalysisMojo mojo = newMojo(outputDirectory);
+        Files.createDirectories(generatedDirectory.resolve("classes"));
+        Files.createDirectories(generatedDirectory.resolve("logs"));
+        Files.createDirectories(outputDirectory);
+        Files.writeString(generatedDirectory.resolve("logs/resource-filter.txt"), "\n   \n.\n");
+        Files.writeString(insideFile, "inside");
+
+        mojo.onSuccess(tempDir.resolve("aot/jit").toFile());
+
+        assertTrue(Files.exists(insideFile));
+    }
+
+    private static AotAnalysisMojo newMojo(Path outputDirectory) throws Exception {
+        var mojo = new AotAnalysisMojo(
+            mock(CompilerService.class),
+            mock(ExecutorService.class),
+            mock(MavenProject.class),
+            mock(DependencyResolutionService.class),
+            mock(MavenSession.class),
+            mock(ToolchainManager.class)
+        );
+
+        mojo.outputDirectory = outputDirectory.toFile();
+        Files.createDirectories(outputDirectory);
+        return mojo;
     }
 }


### PR DESCRIPTION
## Summary
- normalize `resource-filter.txt` deletion entries against the build output directory before deleting
- skip and warn on traversal or absolute paths that escape the output directory
- add regression coverage for a `../../outside.txt` traversal entry

## Verification
- `./mvnw -pl micronaut-maven-plugin -Dtest=AotAnalysisMojoTest clean test`
- `./mvnw -pl micronaut-maven-plugin test`

Closes #1611