### PR TITLE
Harden test resources keepalive handling

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -38,8 +38,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -157,7 +159,7 @@ public class TestResourcesHelper {
     }
 
     private boolean isKeepAlive() {
-        boolean hasKeepAliveFile = Files.exists(getKeepAliveFile());
+        boolean hasKeepAliveFile = Files.isRegularFile(getKeepAliveFile(), LinkOption.NOFOLLOW_LINKS);
         return hasKeepAliveFile || isStartExplicitlyInvoked();
     }
 
@@ -529,8 +531,13 @@ public class TestResourcesHelper {
 
     private void createKeepAliveFile() throws IOException {
         Path keepalive = getKeepAliveFile();
-        if (!Files.exists(keepalive)) {
-            Files.write(keepalive, "true".getBytes());
+        createKeepAliveDirectory();
+        if (Files.exists(keepalive, LinkOption.NOFOLLOW_LINKS)) {
+            if (!Files.isRegularFile(keepalive, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Keepalive path exists but is not a regular file: " + keepalive);
+            }
+        } else {
+            Files.writeString(keepalive, "true", StandardOpenOption.CREATE_NEW);
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
                     deleteKeepAliveFile();
@@ -539,6 +546,17 @@ public class TestResourcesHelper {
                 }
             }));
         }
+    }
+
+    private void createKeepAliveDirectory() throws IOException {
+        Path keepAliveDirectory = sessionState().keepAliveDirectory;
+        if (Files.exists(keepAliveDirectory, LinkOption.NOFOLLOW_LINKS)) {
+            if (!Files.isDirectory(keepAliveDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("Keepalive directory exists but is not a directory: " + keepAliveDirectory);
+            }
+            return;
+        }
+        Files.createDirectory(keepAliveDirectory);
     }
 
     private static boolean isServerStarted(int port) {
@@ -569,7 +587,7 @@ public class TestResourcesHelper {
     }
 
     private void deleteKeepAliveFile() throws MojoExecutionException {
-        if (Files.exists(getKeepAliveFile())) {
+        if (Files.exists(getKeepAliveFile(), LinkOption.NOFOLLOW_LINKS)) {
             try {
                 Files.delete(getKeepAliveFile());
             } catch (IOException e) {
@@ -586,8 +604,7 @@ public class TestResourcesHelper {
     }
 
     private Path getKeepAliveFile() {
-        var tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
-        return tmpDir.resolve("keepalive-" + mavenSession.getRequest().getBuilderId());
+        return sessionState().keepAliveDirectory.resolve("keepalive-" + mavenSession.getRequest().getBuilderId());
     }
 
     private void cleanupSharedProjectSettings() throws IOException {
@@ -610,6 +627,8 @@ public class TestResourcesHelper {
 
     private static final class SessionState {
         private final String scopePrefix = SCOPE_PREFIX + "-" + UUID.randomUUID();
+        private final Path keepAliveDirectory = Path.of(System.getProperty("java.io.tmpdir"))
+            .resolve("mn-test-resources-" + UUID.randomUUID());
         private final Map<Path, SharedServerState> sharedServers = new LinkedHashMap<>();
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -34,6 +34,8 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 
 import java.io.File;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.FileAlreadyExistsException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -42,6 +44,8 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -549,14 +553,27 @@ public class TestResourcesHelper {
     }
 
     private void createKeepAliveDirectory() throws IOException {
-        Path keepAliveDirectory = sessionState().keepAliveDirectory;
-        if (Files.exists(keepAliveDirectory, LinkOption.NOFOLLOW_LINKS)) {
-            if (!Files.isDirectory(keepAliveDirectory, LinkOption.NOFOLLOW_LINKS)) {
-                throw new IOException("Keepalive directory exists but is not a directory: " + keepAliveDirectory);
+        synchronized (SESSION_STATE_MONITOR) {
+            Path keepAliveDirectory = sessionState().keepAliveDirectory;
+            if (Files.exists(keepAliveDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                if (!Files.isDirectory(keepAliveDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IOException("Keepalive directory exists but is not a directory: " + keepAliveDirectory);
+                }
+                return;
             }
-            return;
+            try {
+                FileAttribute<?>[] attributes = keepAliveDirectoryAttributes(keepAliveDirectory.getParent());
+                if (attributes.length == 0) {
+                    Files.createDirectory(keepAliveDirectory);
+                } else {
+                    Files.createDirectory(keepAliveDirectory, attributes);
+                }
+            } catch (FileAlreadyExistsException e) {
+                if (!Files.isDirectory(keepAliveDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IOException("Keepalive directory exists but is not a directory: " + keepAliveDirectory, e);
+                }
+            }
         }
-        Files.createDirectory(keepAliveDirectory);
     }
 
     private static boolean isServerStarted(int port) {
@@ -594,6 +611,7 @@ public class TestResourcesHelper {
                 throw new MojoExecutionException("Failed to delete keepalive file", e);
             }
         }
+        tryDeleteKeepAliveDirectory();
     }
 
     private Path getServerSettingsDirectory() {
@@ -605,6 +623,31 @@ public class TestResourcesHelper {
 
     private Path getKeepAliveFile() {
         return sessionState().keepAliveDirectory.resolve("keepalive-" + mavenSession.getRequest().getBuilderId());
+    }
+
+    private void tryDeleteKeepAliveDirectory() throws MojoExecutionException {
+        Path keepAliveDirectory = sessionState().keepAliveDirectory;
+        try {
+            Files.deleteIfExists(keepAliveDirectory);
+        } catch (DirectoryNotEmptyException ignored) {
+            // Another keepalive file in the same session still owns the directory.
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to delete keepalive directory", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FileAttribute<?>[] keepAliveDirectoryAttributes(Path directory) {
+        try {
+            if (directory == null || !Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+                return new FileAttribute[0];
+            }
+            return new FileAttribute<?>[]{
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"))
+            };
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            return new FileAttribute[0];
+        }
     }
 
     private void cleanupSharedProjectSettings() throws IOException {

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -188,11 +188,67 @@ class TestResourcesHelperTest {
     }
 
     @Test
+    void createKeepAliveDirectoryRejectsExistingNonDirectoryPath() throws Exception {
+        Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
+
+        String previousTmpDir = System.getProperty("java.io.tmpdir");
+        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
+        try {
+            TestResourcesHelper helper = helper("builder-123");
+            Path keepAliveDirectory = invokeGetKeepAliveFile(helper).getParent();
+            Files.writeString(keepAliveDirectory, "not-a-directory");
+
+            InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> invokeCreateKeepAliveDirectory(helper));
+
+            assertInstanceOf(IOException.class, exception.getCause());
+        } finally {
+            if (previousTmpDir == null) {
+                System.clearProperty("java.io.tmpdir");
+            } else {
+                System.setProperty("java.io.tmpdir", previousTmpDir);
+            }
+        }
+    }
+
+    @Test
+    void deleteKeepAliveFileLeavesDirectoryWhenOtherFilesRemain() throws Exception {
+        Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
+
+        String previousTmpDir = System.getProperty("java.io.tmpdir");
+        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
+        try {
+            TestResourcesHelper helper = helper("builder-123");
+            Path keepAliveFile = invokeGetKeepAliveFile(helper);
+            Path siblingFile = keepAliveFile.getParent().resolve("sibling.txt");
+
+            invokeCreateKeepAliveFile(helper);
+            Files.writeString(siblingFile, "keep");
+
+            invokeDeleteKeepAliveFile(helper);
+
+            assertFalse(Files.exists(keepAliveFile, LinkOption.NOFOLLOW_LINKS));
+            assertTrue(Files.exists(keepAliveFile.getParent(), LinkOption.NOFOLLOW_LINKS));
+            assertTrue(Files.exists(siblingFile, LinkOption.NOFOLLOW_LINKS));
+        } finally {
+            if (previousTmpDir == null) {
+                System.clearProperty("java.io.tmpdir");
+            } else {
+                System.setProperty("java.io.tmpdir", previousTmpDir);
+            }
+        }
+    }
+
+    @Test
     void keepAliveDirectoryAttributesOnlyUsePosixPermissionsWhenSupported() throws Exception {
         FileAttribute<?>[] attributes = invokeKeepAliveDirectoryAttributes(tempDir);
         boolean posixSupported = Files.getFileStore(tempDir).supportsFileAttributeView("posix");
 
         assertEquals(posixSupported ? 1 : 0, attributes.length);
+    }
+
+    @Test
+    void keepAliveDirectoryAttributesReturnsEmptyArrayForNullDirectory() throws Exception {
+        assertEquals(0, invokeKeepAliveDirectoryAttributes(null).length);
     }
 
     private static TestResourcesHelper helper(String builderId) {
@@ -225,6 +281,12 @@ class TestResourcesHelperTest {
 
     private static void invokeDeleteKeepAliveFile(TestResourcesHelper helper) throws Exception {
         Method method = TestResourcesHelper.class.getDeclaredMethod("deleteKeepAliveFile");
+        method.setAccessible(true);
+        method.invoke(helper);
+    }
+
+    private static void invokeCreateKeepAliveDirectory(TestResourcesHelper helper) throws Exception {
+        Method method = TestResourcesHelper.class.getDeclaredMethod("createKeepAliveDirectory");
         method.setAccessible(true);
         method.invoke(helper);
     }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -4,6 +4,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
 
@@ -28,7 +29,9 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ResourceLock("java.io.tmpdir")
 class TestResourcesHelperTest {
+    private static final String JAVA_IO_TMPDIR_PROPERTY = "java.io.tmpdir";
 
     @TempDir
     Path tempDir;
@@ -109,9 +112,7 @@ class TestResourcesHelperTest {
     void keepAliveFileUsesSessionScopedRandomizedDirectory() throws Exception {
         Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
 
-        String previousTmpDir = System.getProperty("java.io.tmpdir");
-        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
-        try {
+        withTmpDir(scopedTmpDir, () -> {
             TestResourcesHelper firstHelper = helper("builder-123");
             TestResourcesHelper secondHelper = helper("builder-123");
 
@@ -125,13 +126,7 @@ class TestResourcesHelperTest {
             assertTrue(firstKeepAlive.getParent().getFileName().toString().startsWith("mn-test-resources-"));
             assertFalse(firstKeepAlive.getParent().equals(scopedTmpDir));
             assertFalse(firstKeepAlive.getParent().equals(secondKeepAlive.getParent()));
-        } finally {
-            if (previousTmpDir == null) {
-                System.clearProperty("java.io.tmpdir");
-            } else {
-                System.setProperty("java.io.tmpdir", previousTmpDir);
-            }
-        }
+        });
     }
 
     @Test
@@ -139,9 +134,7 @@ class TestResourcesHelperTest {
         Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
         Path protectedFile = tempDir.resolve("protected.txt");
 
-        String previousTmpDir = System.getProperty("java.io.tmpdir");
-        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
-        try {
+        withTmpDir(scopedTmpDir, () -> {
             TestResourcesHelper helper = helper("builder-123");
             Path keepAliveFile = invokeGetKeepAliveFile(helper);
             Files.createDirectories(keepAliveFile.getParent());
@@ -154,22 +147,14 @@ class TestResourcesHelperTest {
             assertFalse(Files.exists(protectedFile));
             assertFalse(invokeIsKeepAlive(helper));
             assertTrue(Files.isSymbolicLink(keepAliveFile));
-        } finally {
-            if (previousTmpDir == null) {
-                System.clearProperty("java.io.tmpdir");
-            } else {
-                System.setProperty("java.io.tmpdir", previousTmpDir);
-            }
-        }
+        });
     }
 
     @Test
     void deleteKeepAliveFileRemovesEmptyKeepAliveDirectory() throws Exception {
         Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
 
-        String previousTmpDir = System.getProperty("java.io.tmpdir");
-        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
-        try {
+        withTmpDir(scopedTmpDir, () -> {
             TestResourcesHelper helper = helper("builder-123");
             Path keepAliveFile = invokeGetKeepAliveFile(helper);
 
@@ -178,22 +163,14 @@ class TestResourcesHelperTest {
 
             assertFalse(Files.exists(keepAliveFile, LinkOption.NOFOLLOW_LINKS));
             assertFalse(Files.exists(keepAliveFile.getParent(), LinkOption.NOFOLLOW_LINKS));
-        } finally {
-            if (previousTmpDir == null) {
-                System.clearProperty("java.io.tmpdir");
-            } else {
-                System.setProperty("java.io.tmpdir", previousTmpDir);
-            }
-        }
+        });
     }
 
     @Test
     void createKeepAliveDirectoryRejectsExistingNonDirectoryPath() throws Exception {
         Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
 
-        String previousTmpDir = System.getProperty("java.io.tmpdir");
-        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
-        try {
+        withTmpDir(scopedTmpDir, () -> {
             TestResourcesHelper helper = helper("builder-123");
             Path keepAliveDirectory = invokeGetKeepAliveFile(helper).getParent();
             Files.writeString(keepAliveDirectory, "not-a-directory");
@@ -201,22 +178,14 @@ class TestResourcesHelperTest {
             InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> invokeCreateKeepAliveDirectory(helper));
 
             assertInstanceOf(IOException.class, exception.getCause());
-        } finally {
-            if (previousTmpDir == null) {
-                System.clearProperty("java.io.tmpdir");
-            } else {
-                System.setProperty("java.io.tmpdir", previousTmpDir);
-            }
-        }
+        });
     }
 
     @Test
     void deleteKeepAliveFileLeavesDirectoryWhenOtherFilesRemain() throws Exception {
         Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
 
-        String previousTmpDir = System.getProperty("java.io.tmpdir");
-        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
-        try {
+        withTmpDir(scopedTmpDir, () -> {
             TestResourcesHelper helper = helper("builder-123");
             Path keepAliveFile = invokeGetKeepAliveFile(helper);
             Path siblingFile = keepAliveFile.getParent().resolve("sibling.txt");
@@ -229,13 +198,7 @@ class TestResourcesHelperTest {
             assertFalse(Files.exists(keepAliveFile, LinkOption.NOFOLLOW_LINKS));
             assertTrue(Files.exists(keepAliveFile.getParent(), LinkOption.NOFOLLOW_LINKS));
             assertTrue(Files.exists(siblingFile, LinkOption.NOFOLLOW_LINKS));
-        } finally {
-            if (previousTmpDir == null) {
-                System.clearProperty("java.io.tmpdir");
-            } else {
-                System.setProperty("java.io.tmpdir", previousTmpDir);
-            }
-        }
+        });
     }
 
     @Test
@@ -300,9 +263,32 @@ class TestResourcesHelperTest {
         }
     }
 
+    private static void withTmpDir(Path scopedTmpDir, ThrowingRunnable action) throws Exception {
+        String previousTmpDir = System.getProperty(JAVA_IO_TMPDIR_PROPERTY);
+        System.setProperty(JAVA_IO_TMPDIR_PROPERTY, scopedTmpDir.toString());
+        try {
+            action.run();
+        } finally {
+            restoreSystemProperty(JAVA_IO_TMPDIR_PROPERTY, previousTmpDir);
+        }
+    }
+
+    private static void restoreSystemProperty(String propertyName, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, previousValue);
+        }
+    }
+
     private static FileAttribute<?>[] invokeKeepAliveDirectoryAttributes(Path directory) throws Exception {
         Method method = TestResourcesHelper.class.getDeclaredMethod("keepAliveDirectoryAttributes", Path.class);
         method.setAccessible(true);
         return (FileAttribute<?>[]) method.invoke(null, directory);
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
     }
 }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -9,15 +9,20 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -139,13 +144,16 @@ class TestResourcesHelperTest {
         try {
             TestResourcesHelper helper = helper("builder-123");
             Path keepAliveFile = invokeGetKeepAliveFile(helper);
+            Files.createDirectories(keepAliveFile.getParent());
 
             assumeTrue(createSymlinkIfSupported(keepAliveFile, protectedFile), "Symbolic links are not available");
 
-            invokeCreateKeepAliveFile(helper);
+            InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> invokeCreateKeepAliveFile(helper));
 
+            assertInstanceOf(IOException.class, exception.getCause());
             assertFalse(Files.exists(protectedFile));
             assertFalse(invokeIsKeepAlive(helper));
+            assertTrue(Files.isSymbolicLink(keepAliveFile));
         } finally {
             if (previousTmpDir == null) {
                 System.clearProperty("java.io.tmpdir");
@@ -153,6 +161,38 @@ class TestResourcesHelperTest {
                 System.setProperty("java.io.tmpdir", previousTmpDir);
             }
         }
+    }
+
+    @Test
+    void deleteKeepAliveFileRemovesEmptyKeepAliveDirectory() throws Exception {
+        Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
+
+        String previousTmpDir = System.getProperty("java.io.tmpdir");
+        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
+        try {
+            TestResourcesHelper helper = helper("builder-123");
+            Path keepAliveFile = invokeGetKeepAliveFile(helper);
+
+            invokeCreateKeepAliveFile(helper);
+            invokeDeleteKeepAliveFile(helper);
+
+            assertFalse(Files.exists(keepAliveFile, LinkOption.NOFOLLOW_LINKS));
+            assertFalse(Files.exists(keepAliveFile.getParent(), LinkOption.NOFOLLOW_LINKS));
+        } finally {
+            if (previousTmpDir == null) {
+                System.clearProperty("java.io.tmpdir");
+            } else {
+                System.setProperty("java.io.tmpdir", previousTmpDir);
+            }
+        }
+    }
+
+    @Test
+    void keepAliveDirectoryAttributesOnlyUsePosixPermissionsWhenSupported() throws Exception {
+        FileAttribute<?>[] attributes = invokeKeepAliveDirectoryAttributes(tempDir);
+        boolean posixSupported = Files.getFileStore(tempDir).supportsFileAttributeView("posix");
+
+        assertEquals(posixSupported ? 1 : 0, attributes.length);
     }
 
     private static TestResourcesHelper helper(String builderId) {
@@ -183,6 +223,12 @@ class TestResourcesHelperTest {
         return (boolean) method.invoke(helper);
     }
 
+    private static void invokeDeleteKeepAliveFile(TestResourcesHelper helper) throws Exception {
+        Method method = TestResourcesHelper.class.getDeclaredMethod("deleteKeepAliveFile");
+        method.setAccessible(true);
+        method.invoke(helper);
+    }
+
     private static boolean createSymlinkIfSupported(Path link, Path target) {
         try {
             Files.createSymbolicLink(link, target);
@@ -190,5 +236,11 @@ class TestResourcesHelperTest {
         } catch (UnsupportedOperationException | IOException e) {
             return false;
         }
+    }
+
+    private static FileAttribute<?>[] invokeKeepAliveDirectoryAttributes(Path directory) throws Exception {
+        Method method = TestResourcesHelper.class.getDeclaredMethod("keepAliveDirectoryAttributes", Path.class);
+        method.setAccessible(true);
+        return (FileAttribute<?>[]) method.invoke(null, directory);
     }
 }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -1,5 +1,7 @@
 package io.micronaut.maven.testresources;
 
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.apache.maven.model.Build;
@@ -7,6 +9,7 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -16,6 +19,9 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class TestResourcesHelperTest {
 
@@ -92,5 +98,97 @@ class TestResourcesHelperTest {
         assertTrue(acquired.await(5, TimeUnit.SECONDS));
         worker.join();
         assertEquals(0, TestResourcesHelper.sharedServerLockCount());
+    }
+
+    @Test
+    void keepAliveFileUsesSessionScopedRandomizedDirectory() throws Exception {
+        Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
+
+        String previousTmpDir = System.getProperty("java.io.tmpdir");
+        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
+        try {
+            TestResourcesHelper firstHelper = helper("builder-123");
+            TestResourcesHelper secondHelper = helper("builder-123");
+
+            Path firstKeepAlive = invokeGetKeepAliveFile(firstHelper);
+            Path secondKeepAlive = invokeGetKeepAliveFile(secondHelper);
+            Path firstKeepAliveAgain = invokeGetKeepAliveFile(firstHelper);
+
+            assertEquals(firstKeepAlive, firstKeepAliveAgain);
+            assertTrue(firstKeepAlive.startsWith(scopedTmpDir));
+            assertEquals("keepalive-builder-123", firstKeepAlive.getFileName().toString());
+            assertTrue(firstKeepAlive.getParent().getFileName().toString().startsWith("mn-test-resources-"));
+            assertFalse(firstKeepAlive.getParent().equals(scopedTmpDir));
+            assertFalse(firstKeepAlive.getParent().equals(secondKeepAlive.getParent()));
+        } finally {
+            if (previousTmpDir == null) {
+                System.clearProperty("java.io.tmpdir");
+            } else {
+                System.setProperty("java.io.tmpdir", previousTmpDir);
+            }
+        }
+    }
+
+    @Test
+    void createKeepAliveFileDoesNotWriteThroughExistingSymlink() throws Exception {
+        Path scopedTmpDir = Files.createDirectory(tempDir.resolve("tmp"));
+        Path protectedFile = tempDir.resolve("protected.txt");
+
+        String previousTmpDir = System.getProperty("java.io.tmpdir");
+        System.setProperty("java.io.tmpdir", scopedTmpDir.toString());
+        try {
+            TestResourcesHelper helper = helper("builder-123");
+            Path keepAliveFile = invokeGetKeepAliveFile(helper);
+
+            assumeTrue(createSymlinkIfSupported(keepAliveFile, protectedFile), "Symbolic links are not available");
+
+            invokeCreateKeepAliveFile(helper);
+
+            assertFalse(Files.exists(protectedFile));
+            assertFalse(invokeIsKeepAlive(helper));
+        } finally {
+            if (previousTmpDir == null) {
+                System.clearProperty("java.io.tmpdir");
+            } else {
+                System.setProperty("java.io.tmpdir", previousTmpDir);
+            }
+        }
+    }
+
+    private static TestResourcesHelper helper(String builderId) {
+        MavenExecutionRequest request = mock(MavenExecutionRequest.class);
+        when(request.getBuilderId()).thenReturn(builderId);
+
+        MavenSession mavenSession = mock(MavenSession.class);
+        when(mavenSession.getRequest()).thenReturn(request);
+
+        return new TestResourcesHelper(mavenSession, true, false, new File("."));
+    }
+
+    private static Path invokeGetKeepAliveFile(TestResourcesHelper helper) throws Exception {
+        Method method = TestResourcesHelper.class.getDeclaredMethod("getKeepAliveFile");
+        method.setAccessible(true);
+        return (Path) method.invoke(helper);
+    }
+
+    private static void invokeCreateKeepAliveFile(TestResourcesHelper helper) throws Exception {
+        Method method = TestResourcesHelper.class.getDeclaredMethod("createKeepAliveFile");
+        method.setAccessible(true);
+        method.invoke(helper);
+    }
+
+    private static boolean invokeIsKeepAlive(TestResourcesHelper helper) throws Exception {
+        Method method = TestResourcesHelper.class.getDeclaredMethod("isKeepAlive");
+        method.setAccessible(true);
+        return (boolean) method.invoke(helper);
+    }
+
+    private static boolean createSymlinkIfSupported(Path link, Path target) {
+        try {
+            Files.createSymbolicLink(link, target);
+            return true;
+        } catch (UnsupportedOperationException | IOException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- move shared test resources keepalive files into a randomized per-session directory under `java.io.tmpdir`
- treat only regular files as valid keepalive markers and avoid following symlinks during existence checks
- add regression tests for randomized session-scoped paths and the dangling-symlink write-through case

Fixes #1610

## Verification
- ./mvnw -pl micronaut-maven-plugin -am -Dtest=TestResourcesHelperTest -Dsurefire.failIfNoSpecifiedTests=false test