### PR TITLE
Add native-image agent support to mn:run

### DIFF
--- a/micronaut-maven-integration-tests/src/it/run-native-agent/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -ntp -e mn:run -Dagent=true -Dmn.watch=false -Dmn.appArgs="-v"

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>run-native-agent</artifactId>
+    <version>0.1</version>
+    <packaging>${packaging}</packaging>
+
+    <parent>
+        <groupId>io.micronaut.platform</groupId>
+        <artifactId>micronaut-parent</artifactId>
+        <version>@it.micronaut.version@</version>
+    </parent>
+
+    <properties>
+        <packaging>jar</packaging>
+        <micronaut.version>@it.micronaut.version@</micronaut.version>
+        <exec.mainClass>io.micronaut.build.examples.RunCommand</exec.mainClass>
+        <picocli.version>4.7.7</picocli.version>
+        <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+        <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-inject</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.validation</groupId>
+            <artifactId>micronaut-validation</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-runtime</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.picocli</groupId>
+            <artifactId>micronaut-picocli</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.test</groupId>
+            <artifactId>micronaut-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.micronaut.maven</groupId>
+                <artifactId>micronaut-maven-plugin</artifactId>
+                <version>${micronaut-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Uncomment to enable incremental compilation -->
+                    <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+                    <annotationProcessorPaths combine.children="append">
+                        <path>
+                            <groupId>info.picocli</groupId>
+                            <artifactId>picocli-codegen</artifactId>
+                            <version>${picocli.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Amicronaut.processing.group=com.example</arg>
+                        <arg>-Amicronaut.processing.module=demo</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/selector.groovy
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/selector.groovy
@@ -1,0 +1,15 @@
+return isGraalJVM()
+
+static boolean isGraalJVM() {
+    return isGraal("jvmci.Compiler", "java.vendor.version")
+}
+
+private static boolean isGraal(String... props) {
+    for (String prop : props) {
+        String vv = System.getProperty(prop)
+        if (vv != null && vv.toLowerCase(Locale.ENGLISH).contains("graal")) {
+            return true
+        }
+    }
+    return false
+}

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/src/main/java/io/micronaut/build/examples/RunCommand.java
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/src/main/java/io/micronaut/build/examples/RunCommand.java
@@ -1,0 +1,25 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "run2", description = "...",
+        mixinStandardHelpOptions = true)
+public class RunCommand implements Runnable {
+
+    @Option(names = {"-v", "--verbose"}, description = "...")
+    boolean verbose;
+
+    public static void main(String[] args) throws Exception {
+        PicocliRunner.run(RunCommand.class, args);
+    }
+
+    public void run() {
+        // business logic here
+        if (verbose) {
+            System.out.println("Hi!");
+        }
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: run-native-agent

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/src/test/java/io/micronaut/build/examples/RunCommandTest.java
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/src/test/java/io/micronaut/build/examples/RunCommandTest.java
@@ -1,0 +1,28 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RunCommandTest {
+
+    @Test
+    public void testWithCommandLineOption() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            String[] args = new String[] { "-v" };
+            PicocliRunner.run(RunCommand.class, ctx, args);
+
+            // run2
+            assertTrue(baos.toString().contains("Hi!"));
+        }
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/src/test/java/io/micronaut/build/examples/RunCommandTest.java
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/src/test/java/io/micronaut/build/examples/RunCommandTest.java
@@ -15,14 +15,18 @@ public class RunCommandTest {
     @Test
     public void testWithCommandLineOption() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos));
+        PrintStream originalOut = System.out;
 
-        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+        try (PrintStream output = new PrintStream(baos);
+             ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            System.setOut(output);
             String[] args = new String[] { "-v" };
             PicocliRunner.run(RunCommand.class, ctx, args);
 
             // run2
             assertTrue(baos.toString().contains("Hi!"));
+        } finally {
+            System.setOut(originalOut);
         }
     }
 }

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/verify.groovy
@@ -1,0 +1,14 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("Hi!")
+assert !log.text.contains("Micronaut AOT")
+
+File agentOutputDirectory = new File(basedir, "target/native/agent-output/main")
+assert agentOutputDirectory.exists()
+
+int currentJdkVersion = Integer.parseInt(System.getProperty("java.specification.version"))
+if (currentJdkVersion >= 23) {
+    assert new File(agentOutputDirectory, "reachability-metadata.json").exists()
+} else {
+    assert new File(agentOutputDirectory, "reflect-config.json").exists()
+}

--- a/micronaut-maven-integration-tests/src/it/run-native-agent/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/run-native-agent/verify.groovy
@@ -6,7 +6,16 @@ assert !log.text.contains("Micronaut AOT")
 File agentOutputDirectory = new File(basedir, "target/native/agent-output/main")
 assert agentOutputDirectory.exists()
 
-int currentJdkVersion = Integer.parseInt(System.getProperty("java.specification.version"))
+String javaSpecVersion = System.getProperty("java.specification.version")
+int currentJdkVersion
+if (javaSpecVersion.startsWith("1.")) {
+    currentJdkVersion = Integer.parseInt(javaSpecVersion.substring(2))
+} else {
+    int dotIndex = javaSpecVersion.indexOf('.')
+    String majorVersion = dotIndex == -1 ? javaSpecVersion : javaSpecVersion.substring(0, dotIndex)
+    currentJdkVersion = Integer.parseInt(majorVersion)
+}
+
 if (currentJdkVersion >= 23) {
     assert new File(agentOutputDirectory, "reachability-metadata.json").exists()
 } else {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 final class NativeImageAgentSupport {
 
     static final String AGENT_PROPERTY = "agent";
+    static final String IMAGECODE_PROPERTY = "org.graalvm.nativeimage.imagecode";
     static final String NATIVE_IMAGE_AGENTLIB = "-agentlib:native-image-agent";
     static final String NATIVE_IMAGE_IMAGECODE = "-Dorg.graalvm.nativeimage.imagecode=agent";
     static final String NATIVE_MAVEN_PLUGIN = DockerfileMojo.NATIVE_BUILD_TOOLS_MAVEN_PLUGIN;
@@ -50,6 +51,9 @@ final class NativeImageAgentSupport {
         }
         if (containsNativeImageAgent(existingJvmArguments)) {
             throw new MojoExecutionException("Native image agent support is enabled through native-build-tools, so mn.jvmArgs must not define -agentlib:native-image-agent manually");
+        }
+        if (containsNativeImageImagecode(session, existingJvmArguments)) {
+            throw new MojoExecutionException("Native image agent support is enabled through native-build-tools, so mn.jvmArgs and Maven properties must not define org.graalvm.nativeimage.imagecode manually");
         }
         String outputDirectory = new File(targetDirectory, SharedConstants.AGENT_OUTPUT_FOLDER + File.separator + "main").getAbsolutePath();
         String agentArgument = NATIVE_IMAGE_AGENTLIB + "=" + configuration.getAgentCommandLine().stream()
@@ -162,5 +166,19 @@ final class NativeImageAgentSupport {
 
     private static boolean containsNativeImageAgent(List<String> jvmArguments) {
         return jvmArguments.stream().anyMatch(argument -> argument.startsWith(NATIVE_IMAGE_AGENTLIB));
+    }
+
+    private static boolean containsNativeImageImagecode(MavenSession session, List<String> jvmArguments) {
+        return jvmArguments.stream().anyMatch(NativeImageAgentSupport::isNativeImageImagecodeArgument)
+            || hasProperty(session.getUserProperties(), IMAGECODE_PROPERTY)
+            || hasProperty(session.getSystemProperties(), IMAGECODE_PROPERTY);
+    }
+
+    private static boolean isNativeImageImagecodeArgument(String argument) {
+        return argument.startsWith("-D" + IMAGECODE_PROPERTY + "=");
+    }
+
+    private static boolean hasProperty(Properties properties, String key) {
+        return properties != null && properties.containsKey(key);
     }
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.graalvm.buildtools.agent.AgentConfiguration;
+import org.graalvm.buildtools.agent.StandardAgentMode;
+import org.graalvm.buildtools.utils.SharedConstants;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+final class NativeImageAgentSupport {
+
+    static final String AGENT_PROPERTY = "agent";
+    static final String NATIVE_IMAGE_AGENTLIB = "-agentlib:native-image-agent";
+    static final String NATIVE_IMAGE_IMAGECODE = "-Dorg.graalvm.nativeimage.imagecode=agent";
+    static final String NATIVE_MAVEN_PLUGIN = DockerfileMojo.NATIVE_BUILD_TOOLS_MAVEN_PLUGIN;
+
+    private NativeImageAgentSupport() {
+    }
+
+    static List<String> computeJvmArguments(MavenSession session,
+                                            MavenProject project,
+                                            File targetDirectory,
+                                            List<String> existingJvmArguments) throws MojoExecutionException {
+        AgentConfiguration configuration = resolveAgentConfiguration(session, project);
+        if (!configuration.isEnabled()) {
+            return List.of();
+        }
+        if (containsNativeImageAgent(existingJvmArguments)) {
+            throw new MojoExecutionException("Native image agent support is enabled through native-build-tools, so mn.jvmArgs must not define -agentlib:native-image-agent manually");
+        }
+        String outputDirectory = new File(targetDirectory, SharedConstants.AGENT_OUTPUT_FOLDER + File.separator + "main").getAbsolutePath();
+        String agentArgument = NATIVE_IMAGE_AGENTLIB + "=" + configuration.getAgentCommandLine().stream()
+            .map(option -> option.replace(SharedConstants.AGENT_OUTPUT_DIRECTORY_MARKER, outputDirectory))
+            .reduce((left, right) -> left + "," + right)
+            .orElse("");
+        return List.of(agentArgument, NATIVE_IMAGE_IMAGECODE);
+    }
+
+    private static AgentConfiguration resolveAgentConfiguration(MavenSession session, MavenProject project) throws MojoExecutionException {
+        Plugin plugin = project.getPlugin(NATIVE_MAVEN_PLUGIN);
+        Xpp3Dom configurationRoot = plugin != null && plugin.getConfiguration() instanceof Xpp3Dom dom ? dom : null;
+        Xpp3Dom agentNode = child(configurationRoot, "agent");
+        Boolean commandLineOverride = readAgentOverride(session);
+        if (commandLineOverride != null) {
+            if (!commandLineOverride) {
+                return new AgentConfiguration();
+            }
+            if (agentNode == null) {
+                return new AgentConfiguration(new StandardAgentMode());
+            }
+        } else if (!isEnabledInPom(agentNode)) {
+            return new AgentConfiguration();
+        }
+        if (agentNode == null) {
+            return new AgentConfiguration(new StandardAgentMode());
+        }
+        return parseAgentConfiguration(project, agentNode);
+    }
+
+    private static AgentConfiguration parseAgentConfiguration(MavenProject project, Xpp3Dom agentNode) throws MojoExecutionException {
+        String mode = value(agentNode, "defaultMode").orElse("standard");
+        if (!"standard".equalsIgnoreCase(mode)) {
+            throw new MojoExecutionException("mn:run supports native-image agent configuration only in standard mode. Configured mode [" + mode + "] must use the upstream native-maven-plugin exec workflow instead");
+        }
+        Xpp3Dom options = child(agentNode, "options");
+        return new AgentConfiguration(
+            filterFiles(project, options, "callerFilterFiles"),
+            filterFiles(project, options, "accessFilterFiles"),
+            parseBoolean(options, "builtinCallerFilter"),
+            parseBoolean(options, "builtinHeuristicFilter"),
+            parseBoolean(options, "enableExperimentalPredefinedClasses"),
+            parseBoolean(options, "enableExperimentalUnsafeAllocationTracing"),
+            parseBoolean(options, "trackReflectionMetadata"),
+            new StandardAgentMode()
+        );
+    }
+
+    private static ArrayList<String> filterFiles(MavenProject project, Xpp3Dom options, String name) {
+        ArrayList<String> files = new ArrayList<>();
+        Xpp3Dom parent = child(options, name);
+        if (parent == null) {
+            return files;
+        }
+        for (Xpp3Dom filterFile : parent.getChildren("filterFile")) {
+            String value = filterFile.getValue();
+            if (value != null && !value.isBlank()) {
+                File file = new File(value);
+                files.add(file.isAbsolute() ? file.getPath() : new File(project.getBasedir(), value).getAbsolutePath());
+            }
+        }
+        return files;
+    }
+
+    private static boolean isEnabledInPom(Xpp3Dom agentNode) throws MojoExecutionException {
+        if (agentNode == null) {
+            return false;
+        }
+        Boolean enabled = parseBoolean(agentNode, "enabled");
+        return Boolean.TRUE.equals(enabled);
+    }
+
+    private static Boolean readAgentOverride(MavenSession session) throws MojoExecutionException {
+        String value = readProperty(session.getUserProperties(), AGENT_PROPERTY)
+            .or(() -> readProperty(session.getSystemProperties(), AGENT_PROPERTY))
+            .orElse(null);
+        if (value == null) {
+            return null;
+        }
+        return parseBoolean(AGENT_PROPERTY, value);
+    }
+
+    private static Optional<String> readProperty(Properties properties, String key) {
+        if (properties == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(properties.getProperty(key));
+    }
+
+    private static Boolean parseBoolean(Xpp3Dom parent, String childName) throws MojoExecutionException {
+        Xpp3Dom child = child(parent, childName);
+        if (child == null || child.getValue() == null) {
+            return null;
+        }
+        return parseBoolean("<" + childName + ">", child.getValue());
+    }
+
+    private static Boolean parseBoolean(String name, String value) throws MojoExecutionException {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw new MojoExecutionException("Invalid boolean value [" + value + "] for " + name + ". Use true or false");
+    }
+
+    private static Optional<String> value(Xpp3Dom parent, String childName) {
+        Xpp3Dom child = child(parent, childName);
+        return child == null ? Optional.empty() : Optional.ofNullable(child.getValue());
+    }
+
+    private static Xpp3Dom child(Xpp3Dom parent, String childName) {
+        return parent == null ? null : parent.getChild(childName);
+    }
+
+    private static boolean containsNativeImageAgent(List<String> jvmArguments) {
+        return jvmArguments.stream().anyMatch(argument -> argument.startsWith(NATIVE_IMAGE_AGENTLIB));
+    }
+}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
@@ -68,14 +68,10 @@ final class NativeImageAgentSupport {
             if (!commandLineOverride.get()) {
                 return new AgentConfiguration();
             }
-            if (agentNode == null) {
-                return new AgentConfiguration(new StandardAgentMode());
-            }
-        } else if (!isEnabledInPom(agentNode)) {
-            return new AgentConfiguration();
+            return agentNode == null ? new AgentConfiguration(new StandardAgentMode()) : parseAgentConfiguration(project, agentNode);
         }
-        if (agentNode == null) {
-            return new AgentConfiguration(new StandardAgentMode());
+        if (!isEnabledInPom(agentNode)) {
+            return new AgentConfiguration();
         }
         return parseAgentConfiguration(project, agentNode);
     }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/NativeImageAgentSupport.java
@@ -62,10 +62,10 @@ final class NativeImageAgentSupport {
     private static AgentConfiguration resolveAgentConfiguration(MavenSession session, MavenProject project) throws MojoExecutionException {
         Plugin plugin = project.getPlugin(NATIVE_MAVEN_PLUGIN);
         Xpp3Dom configurationRoot = plugin != null && plugin.getConfiguration() instanceof Xpp3Dom dom ? dom : null;
-        Xpp3Dom agentNode = child(configurationRoot, "agent");
-        Boolean commandLineOverride = readAgentOverride(session);
-        if (commandLineOverride != null) {
-            if (!commandLineOverride) {
+        Xpp3Dom agentNode = child(configurationRoot, AGENT_PROPERTY);
+        Optional<Boolean> commandLineOverride = readAgentOverride(session);
+        if (commandLineOverride.isPresent()) {
+            if (!commandLineOverride.get()) {
                 return new AgentConfiguration();
             }
             if (agentNode == null) {
@@ -89,11 +89,11 @@ final class NativeImageAgentSupport {
         return new AgentConfiguration(
             filterFiles(project, options, "callerFilterFiles"),
             filterFiles(project, options, "accessFilterFiles"),
-            parseBoolean(options, "builtinCallerFilter"),
-            parseBoolean(options, "builtinHeuristicFilter"),
-            parseBoolean(options, "enableExperimentalPredefinedClasses"),
-            parseBoolean(options, "enableExperimentalUnsafeAllocationTracing"),
-            parseBoolean(options, "trackReflectionMetadata"),
+            parseBoolean(options, "builtinCallerFilter").orElse(null),
+            parseBoolean(options, "builtinHeuristicFilter").orElse(null),
+            parseBoolean(options, "enableExperimentalPredefinedClasses").orElse(null),
+            parseBoolean(options, "enableExperimentalUnsafeAllocationTracing").orElse(null),
+            parseBoolean(options, "trackReflectionMetadata").orElse(null),
             new StandardAgentMode()
         );
     }
@@ -118,18 +118,16 @@ final class NativeImageAgentSupport {
         if (agentNode == null) {
             return false;
         }
-        Boolean enabled = parseBoolean(agentNode, "enabled");
-        return Boolean.TRUE.equals(enabled);
+        return parseBoolean(agentNode, "enabled").orElse(false);
     }
 
-    private static Boolean readAgentOverride(MavenSession session) throws MojoExecutionException {
-        String value = readProperty(session.getUserProperties(), AGENT_PROPERTY)
-            .or(() -> readProperty(session.getSystemProperties(), AGENT_PROPERTY))
-            .orElse(null);
-        if (value == null) {
-            return null;
+    private static Optional<Boolean> readAgentOverride(MavenSession session) throws MojoExecutionException {
+        Optional<String> value = readProperty(session.getUserProperties(), AGENT_PROPERTY)
+            .or(() -> readProperty(session.getSystemProperties(), AGENT_PROPERTY));
+        if (value.isEmpty()) {
+            return Optional.empty();
         }
-        return parseBoolean(AGENT_PROPERTY, value);
+        return Optional.of(parseBoolean(AGENT_PROPERTY, value.get()));
     }
 
     private static Optional<String> readProperty(Properties properties, String key) {
@@ -139,12 +137,12 @@ final class NativeImageAgentSupport {
         return Optional.ofNullable(properties.getProperty(key));
     }
 
-    private static Boolean parseBoolean(Xpp3Dom parent, String childName) throws MojoExecutionException {
+    private static Optional<Boolean> parseBoolean(Xpp3Dom parent, String childName) throws MojoExecutionException {
         Xpp3Dom child = child(parent, childName);
         if (child == null || child.getValue() == null) {
-            return null;
+            return Optional.empty();
         }
-        return parseBoolean("<" + childName + ">", child.getValue());
+        return Optional.of(parseBoolean("<" + childName + ">", child.getValue()));
     }
 
     private static Boolean parseBoolean(String name, String value) throws MojoExecutionException {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -518,62 +518,7 @@ public class RunMojo extends AbstractTestResourcesMojo {
             // Validate Micronaut configuration for the dev environment before starting.
             executorService.executeGoal(runnableProject, THIS_PLUGIN, ValidateDevConfigurationMojo.MOJO_NAME, configurationValidationConfiguration());
             runAotIfNeeded();
-            final String reactorClasses = mavenSession.getAllProjects().stream()
-                    .filter(this::isDependencyOfRunnableProject)
-                    .map(MavenProject::getBuild)
-                    .map(Build::getOutputDirectory)
-                    .collect(Collectors.joining(File.pathSeparator));
-            String classpathArgument = String.join(File.pathSeparator, reactorClasses, this.classpath);
-
-            var args = new ArrayList<String>();
-            args.add(javaExecutable);
-
-            if (debug) {
-                String suspend = debugSuspend ? "y" : "n";
-                args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=" + suspend + ",address=" + debugHost + ":" + debugPort);
-            }
-
-            if (testResourcesEnabled) {
-                Path testResourcesSettingsDirectory = shared ? ServerUtils.getDefaultSharedSettingsPath(sharedServerNamespace) :
-                    AbstractTestResourcesMojo.serverSettingsDirectoryOf(targetDirectory.toPath());
-                Optional<ServerSettings> serverSettings = ServerUtils.readServerSettings(testResourcesSettingsDirectory);
-                serverSettings.ifPresent(settings -> testResourcesHelper.computeSystemProperties(settings)
-                    .forEach((k, v) -> args.add("-D" + k + "=" + v)));
-            }
-
-            List<String> translatedJvmArguments = List.of();
-            if (jvmArguments != null && !jvmArguments.isEmpty()) {
-                final String[] strings = CommandLineUtils.translateCommandline(jvmArguments);
-                translatedJvmArguments = Arrays.asList(strings);
-            }
-
-            List<String> nativeImageAgentArguments = NativeImageAgentSupport.computeJvmArguments(mavenSession, runnableProject, targetDirectory, translatedJvmArguments);
-            if (!nativeImageAgentArguments.isEmpty()) {
-                if (watchForChanges) {
-                    getLog().warn("Native image agent metadata collection is intended for one-shot runs. Prefer mn:run -Dagent=true -Dmn.watch=false");
-                }
-                args.addAll(nativeImageAgentArguments);
-            }
-            args.addAll(translatedJvmArguments);
-
-            if (!mavenSession.getUserProperties().isEmpty()) {
-                mavenSession.getUserProperties().forEach((k, v) -> args.add("-D" + k + "=" + v));
-            }
-
-            if (mainClass == null) {
-                mainClass = runnableProject.getProperties().getProperty("exec.mainClass");
-            }
-
-            args.add("-classpath");
-            args.add(classpathArgument);
-            args.add("-XX:TieredStopAtLevel=1");
-            args.add("-Dcom.sun.management.jmxremote");
-            args.add(mainClass);
-
-            if (appArguments != null && !appArguments.isEmpty()) {
-                final String[] strings = CommandLineUtils.translateCommandline(appArguments);
-                args.addAll(Arrays.asList(strings));
-            }
+            List<String> args = buildRunArguments();
 
             if (getLog().isDebugEnabled()) {
                 getLog().debug("Running " + String.join(" ", args));
@@ -587,6 +532,78 @@ public class RunMojo extends AbstractTestResourcesMojo {
         } finally {
             restartLock.unlock();
         }
+    }
+
+    private List<String> buildRunArguments() throws Exception {
+        final String reactorClasses = mavenSession.getAllProjects().stream()
+            .filter(this::isDependencyOfRunnableProject)
+            .map(MavenProject::getBuild)
+            .map(Build::getOutputDirectory)
+            .collect(Collectors.joining(File.pathSeparator));
+        String classpathArgument = String.join(File.pathSeparator, reactorClasses, this.classpath);
+        List<String> translatedJvmArguments = translateArguments(jvmArguments);
+
+        var args = new ArrayList<String>();
+        args.add(javaExecutable);
+        addDebugArguments(args);
+        addTestResourcesArguments(args);
+        addNativeImageAgentArguments(args, translatedJvmArguments);
+        args.addAll(translatedJvmArguments);
+        addUserProperties(args);
+        args.add("-classpath");
+        args.add(classpathArgument);
+        args.add("-XX:TieredStopAtLevel=1");
+        args.add("-Dcom.sun.management.jmxremote");
+        args.add(resolveMainClass());
+        args.addAll(translateArguments(appArguments));
+        return args;
+    }
+
+    private void addDebugArguments(List<String> args) {
+        if (debug) {
+            String suspend = debugSuspend ? "y" : "n";
+            args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=" + suspend + ",address=" + debugHost + ":" + debugPort);
+        }
+    }
+
+    private void addTestResourcesArguments(List<String> args) {
+        if (testResourcesEnabled) {
+            Path testResourcesSettingsDirectory = shared ? ServerUtils.getDefaultSharedSettingsPath(sharedServerNamespace) :
+                AbstractTestResourcesMojo.serverSettingsDirectoryOf(targetDirectory.toPath());
+            Optional<ServerSettings> serverSettings = ServerUtils.readServerSettings(testResourcesSettingsDirectory);
+            serverSettings.ifPresent(settings -> testResourcesHelper.computeSystemProperties(settings)
+                .forEach((k, v) -> args.add("-D" + k + "=" + v)));
+        }
+    }
+
+    private void addNativeImageAgentArguments(List<String> args, List<String> translatedJvmArguments) throws MojoExecutionException {
+        List<String> nativeImageAgentArguments = NativeImageAgentSupport.computeJvmArguments(mavenSession, runnableProject, targetDirectory, translatedJvmArguments);
+        if (!nativeImageAgentArguments.isEmpty()) {
+            if (watchForChanges) {
+                getLog().warn("Native image agent metadata collection is intended for one-shot runs. Prefer mn:run -Dagent=true -Dmn.watch=false");
+            }
+            args.addAll(nativeImageAgentArguments);
+        }
+    }
+
+    private void addUserProperties(List<String> args) {
+        if (!mavenSession.getUserProperties().isEmpty()) {
+            mavenSession.getUserProperties().forEach((k, v) -> args.add("-D" + k + "=" + v));
+        }
+    }
+
+    private String resolveMainClass() {
+        if (mainClass == null) {
+            mainClass = runnableProject.getProperties().getProperty("exec.mainClass");
+        }
+        return mainClass;
+    }
+
+    private List<String> translateArguments(String arguments) throws Exception {
+        if (arguments == null || arguments.isEmpty()) {
+            return List.of();
+        }
+        return Arrays.asList(CommandLineUtils.translateCommandline(arguments));
     }
 
     private void runAotIfNeeded() {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -541,10 +541,20 @@ public class RunMojo extends AbstractTestResourcesMojo {
                     .forEach((k, v) -> args.add("-D" + k + "=" + v)));
             }
 
+            List<String> translatedJvmArguments = List.of();
             if (jvmArguments != null && !jvmArguments.isEmpty()) {
                 final String[] strings = CommandLineUtils.translateCommandline(jvmArguments);
-                args.addAll(Arrays.asList(strings));
+                translatedJvmArguments = Arrays.asList(strings);
             }
+
+            List<String> nativeImageAgentArguments = NativeImageAgentSupport.computeJvmArguments(mavenSession, runnableProject, targetDirectory, translatedJvmArguments);
+            if (!nativeImageAgentArguments.isEmpty()) {
+                if (watchForChanges) {
+                    getLog().warn("Native image agent metadata collection is intended for one-shot runs. Prefer mn:run -Dagent=true -Dmn.watch=false");
+                }
+                args.addAll(nativeImageAgentArguments);
+            }
+            args.addAll(translatedJvmArguments);
 
             if (!mavenSession.getUserProperties().isEmpty()) {
                 mavenSession.getUserProperties().forEach((k, v) -> args.add("-D" + k + "=" + v));

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/RunMojo.java
@@ -547,9 +547,9 @@ public class RunMojo extends AbstractTestResourcesMojo {
         args.add(javaExecutable);
         addDebugArguments(args);
         addTestResourcesArguments(args);
-        addNativeImageAgentArguments(args, translatedJvmArguments);
         args.addAll(translatedJvmArguments);
         addUserProperties(args);
+        addNativeImageAgentArguments(args, translatedJvmArguments);
         args.add("-classpath");
         args.add(classpathArgument);
         args.add("-XX:TieredStopAtLevel=1");

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -88,6 +88,11 @@ Refer to the
 https://graalvm.github.io/native-build-tools/latest/[Native Maven Plugin documentation]
 for more information about how to customize the generated native image.
 
+If you want to collect native-image metadata before packaging, you can run the application with
+`mvn mn:run -Dagent=true -Dmn.watch=false`. That generates tracing output in `target/native/agent-output/main`, which
+you can then review or process with the upstream native-build-tools workflow before running
+`mvn package -Dpackaging=native-image`.
+
 For example, to add `--verbose` to the native image args, you should define:
 
 [source,xml]

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/run.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/run.adoc
@@ -97,3 +97,23 @@ Debugging options can be specified on the command line directly:
 ==== Other options
 
 For a full list of configuration options, check the link:../run-mojo.html[mn:run] goal documentation.
+
+==== Collecting native-image metadata during `mn:run`
+
+`mn:run` can launch the application with the GraalVM native-image tracing agent by using the same `-Dagent=true`
+switch that `org.graalvm.buildtools:native-maven-plugin` understands:
+
+[source,bash]
+----
+$ mvn mn:run -Dagent=true -Dmn.watch=false
+----
+
+This generates metadata under `target/native/agent-output/main`.
+
+Use this when you want to exercise the application on the JVM and then feed the collected metadata back into the
+upstream native-image workflow. Micronaut still delegates native-image packaging to
+`org.graalvm.buildtools:native-maven-plugin`; `mn:run` only covers the application-run tracing step.
+
+The initial `mn:run` integration supports the upstream standard agent mode. Advanced workflows such as direct mode,
+conditional mode, and metadata copy orchestration should continue to use the upstream native-build-tools Maven plugin
+workflow directly.

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
@@ -56,6 +56,36 @@ class NativeImageAgentSupportTest {
     }
 
     @Test
+    void rejectsManualImagecodeJvmArgumentWhenNativeBuildToolsAgentIsEnabled() {
+        var userProperties = new Properties();
+        userProperties.setProperty(NativeImageAgentSupport.AGENT_PROPERTY, "true");
+
+        var exception = assertThrows(MojoExecutionException.class, () ->
+            NativeImageAgentSupport.computeJvmArguments(
+                session(userProperties, new Properties()),
+                project(null),
+                targetDirectory(),
+                List.of("-Dorg.graalvm.nativeimage.imagecode=buildtime")
+            )
+        );
+
+        assertTrue(exception.getMessage().contains(NativeImageAgentSupport.IMAGECODE_PROPERTY));
+    }
+
+    @Test
+    void rejectsManualImagecodeUserPropertyWhenNativeBuildToolsAgentIsEnabled() {
+        var userProperties = new Properties();
+        userProperties.setProperty(NativeImageAgentSupport.AGENT_PROPERTY, "true");
+        userProperties.setProperty(NativeImageAgentSupport.IMAGECODE_PROPERTY, "buildtime");
+
+        var exception = assertThrows(MojoExecutionException.class, () ->
+            NativeImageAgentSupport.computeJvmArguments(session(userProperties, new Properties()), project(null), targetDirectory(), List.of())
+        );
+
+        assertTrue(exception.getMessage().contains(NativeImageAgentSupport.IMAGECODE_PROPERTY));
+    }
+
+    @Test
     void addsAgentArgumentsWhenEnabledInPomConfiguration() throws MojoExecutionException {
         var arguments = NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfiguration("true", "standard")), targetDirectory(), List.of());
 

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
@@ -84,6 +84,16 @@ class NativeImageAgentSupportTest {
     }
 
     @Test
+    void commandLineTrueOverridesDisabledPomConfiguration() throws MojoExecutionException {
+        var userProperties = new Properties();
+        userProperties.setProperty(NativeImageAgentSupport.AGENT_PROPERTY, "true");
+
+        var arguments = NativeImageAgentSupport.computeJvmArguments(session(userProperties, new Properties()), project(agentConfiguration("false", "standard")), targetDirectory(), List.of());
+
+        assertEquals(2, arguments.size());
+    }
+
+    @Test
     void resolvesConfiguredFilterFilesToAbsolutePaths() throws MojoExecutionException {
         File absoluteAccessFilter = tempDir.resolve("filters/access-filter.json").toFile();
         var arguments = NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfigurationWithFilterFiles(absoluteAccessFilter)), targetDirectory(), List.of());

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
@@ -34,7 +34,7 @@ class NativeImageAgentSupportTest {
     @Test
     void addsDefaultAgentArgumentsWhenEnabledFromCommandLine() throws MojoExecutionException {
         var userProperties = new Properties();
-        userProperties.setProperty("agent", "true");
+        userProperties.setProperty(NativeImageAgentSupport.AGENT_PROPERTY, "true");
 
         var arguments = NativeImageAgentSupport.computeJvmArguments(session(userProperties, new Properties()), project(null), targetDirectory(), List.of());
 
@@ -46,7 +46,7 @@ class NativeImageAgentSupportTest {
     @Test
     void rejectsManualNativeImageAgentWhenNativeBuildToolsAgentIsEnabled() {
         var userProperties = new Properties();
-        userProperties.setProperty("agent", "true");
+        userProperties.setProperty(NativeImageAgentSupport.AGENT_PROPERTY, "true");
 
         var exception = assertThrows(MojoExecutionException.class, () ->
             NativeImageAgentSupport.computeJvmArguments(session(userProperties, new Properties()), project(null), targetDirectory(), List.of("-agentlib:native-image-agent=config-output-dir=custom"))
@@ -56,12 +56,58 @@ class NativeImageAgentSupportTest {
     }
 
     @Test
+    void addsAgentArgumentsWhenEnabledInPomConfiguration() throws MojoExecutionException {
+        var arguments = NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfiguration("true", "standard")), targetDirectory(), List.of());
+
+        assertEquals(2, arguments.size());
+        assertTrue(arguments.get(0).startsWith("-agentlib:native-image-agent=config-output-dir=" + targetDirectory().getAbsolutePath() + File.separator + "native" + File.separator + "agent-output" + File.separator + "main"));
+    }
+
+    @Test
+    void commandLineFalseOverridesPomConfiguration() throws MojoExecutionException {
+        var userProperties = new Properties();
+        userProperties.setProperty(NativeImageAgentSupport.AGENT_PROPERTY, "false");
+
+        var arguments = NativeImageAgentSupport.computeJvmArguments(session(userProperties, new Properties()), project(agentConfiguration("true", "standard")), targetDirectory(), List.of());
+
+        assertEquals(List.of(), arguments);
+    }
+
+    @Test
+    void readsAgentOverrideFromSystemProperties() throws MojoExecutionException {
+        var systemProperties = new Properties();
+        systemProperties.setProperty(NativeImageAgentSupport.AGENT_PROPERTY, "true");
+
+        var arguments = NativeImageAgentSupport.computeJvmArguments(session(new Properties(), systemProperties), project(null), targetDirectory(), List.of());
+
+        assertEquals(2, arguments.size());
+    }
+
+    @Test
+    void resolvesConfiguredFilterFilesToAbsolutePaths() throws MojoExecutionException {
+        File absoluteAccessFilter = tempDir.resolve("filters/access-filter.json").toFile();
+        var arguments = NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfigurationWithFilterFiles(absoluteAccessFilter)), targetDirectory(), List.of());
+
+        assertTrue(arguments.get(0).contains(tempDir.resolve("filters/caller-filter.json").toAbsolutePath().toString()));
+        assertTrue(arguments.get(0).contains(absoluteAccessFilter.getAbsolutePath()));
+    }
+
+    @Test
     void rejectsUnsupportedDirectModeConfiguration() {
         var exception = assertThrows(MojoExecutionException.class, () ->
-            NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfiguration("direct")), targetDirectory(), List.of())
+            NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfiguration("true", "direct")), targetDirectory(), List.of())
         );
 
         assertTrue(exception.getMessage().contains("standard mode"));
+    }
+
+    @Test
+    void rejectsInvalidPomBooleanConfiguration() {
+        var exception = assertThrows(MojoExecutionException.class, () ->
+            NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfiguration("maybe", "standard")), targetDirectory(), List.of())
+        );
+
+        assertTrue(exception.getMessage().contains("<enabled>"));
     }
 
     private MavenSession session(Properties userProperties, Properties systemProperties) {
@@ -88,13 +134,13 @@ class NativeImageAgentSupportTest {
         return tempDir.resolve("target").toFile();
     }
 
-    private Xpp3Dom agentConfiguration(String mode) {
+    private Xpp3Dom agentConfiguration(String enabledValue, String mode) {
         var configuration = new Xpp3Dom("configuration");
         var agent = new Xpp3Dom("agent");
         configuration.addChild(agent);
 
         var enabled = new Xpp3Dom("enabled");
-        enabled.setValue("true");
+        enabled.setValue(enabledValue);
         agent.addChild(enabled);
 
         var defaultMode = new Xpp3Dom("defaultMode");
@@ -107,5 +153,22 @@ class NativeImageAgentSupportTest {
         direct.setValue("config-output-dir={output_dir}");
         modes.addChild(direct);
         return configuration;
+    }
+
+    private Xpp3Dom agentConfigurationWithFilterFiles(File absoluteAccessFilter) {
+        var configuration = agentConfiguration("true", "standard");
+        var options = new Xpp3Dom("options");
+        childWithValue(options, "callerFilterFiles", "filterFile", "filters/caller-filter.json");
+        childWithValue(options, "accessFilterFiles", "filterFile", absoluteAccessFilter.getAbsolutePath());
+        configuration.getChild("agent").addChild(options);
+        return configuration;
+    }
+
+    private void childWithValue(Xpp3Dom parent, String childName, String nestedChildName, String value) {
+        var child = new Xpp3Dom(childName);
+        var nestedChild = new Xpp3Dom(nestedChildName);
+        nestedChild.setValue(value);
+        child.addChild(nestedChild);
+        parent.addChild(child);
     }
 }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/NativeImageAgentSupportTest.java
@@ -1,0 +1,111 @@
+package io.micronaut.maven;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NativeImageAgentSupportTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void doesNotAddAgentArgumentsWhenAgentIsDisabled() throws MojoExecutionException {
+        var arguments = NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(null), targetDirectory(), List.of());
+
+        assertEquals(List.of(), arguments);
+    }
+
+    @Test
+    void addsDefaultAgentArgumentsWhenEnabledFromCommandLine() throws MojoExecutionException {
+        var userProperties = new Properties();
+        userProperties.setProperty("agent", "true");
+
+        var arguments = NativeImageAgentSupport.computeJvmArguments(session(userProperties, new Properties()), project(null), targetDirectory(), List.of());
+
+        assertEquals(2, arguments.size());
+        assertEquals("-Dorg.graalvm.nativeimage.imagecode=agent", arguments.get(1));
+        assertTrue(arguments.get(0).startsWith("-agentlib:native-image-agent=config-output-dir=" + targetDirectory().getAbsolutePath() + File.separator + "native" + File.separator + "agent-output" + File.separator + "main"));
+    }
+
+    @Test
+    void rejectsManualNativeImageAgentWhenNativeBuildToolsAgentIsEnabled() {
+        var userProperties = new Properties();
+        userProperties.setProperty("agent", "true");
+
+        var exception = assertThrows(MojoExecutionException.class, () ->
+            NativeImageAgentSupport.computeJvmArguments(session(userProperties, new Properties()), project(null), targetDirectory(), List.of("-agentlib:native-image-agent=config-output-dir=custom"))
+        );
+
+        assertTrue(exception.getMessage().contains("mn.jvmArgs"));
+    }
+
+    @Test
+    void rejectsUnsupportedDirectModeConfiguration() {
+        var exception = assertThrows(MojoExecutionException.class, () ->
+            NativeImageAgentSupport.computeJvmArguments(session(new Properties(), new Properties()), project(agentConfiguration("direct")), targetDirectory(), List.of())
+        );
+
+        assertTrue(exception.getMessage().contains("standard mode"));
+    }
+
+    private MavenSession session(Properties userProperties, Properties systemProperties) {
+        var session = mock(MavenSession.class);
+        when(session.getUserProperties()).thenReturn(userProperties);
+        when(session.getSystemProperties()).thenReturn(systemProperties);
+        return session;
+    }
+
+    private MavenProject project(Xpp3Dom configuration) {
+        var project = mock(MavenProject.class);
+        when(project.getBasedir()).thenReturn(tempDir.toFile());
+        if (configuration != null) {
+            var plugin = new Plugin();
+            plugin.setGroupId("org.graalvm.buildtools");
+            plugin.setArtifactId("native-maven-plugin");
+            plugin.setConfiguration(configuration);
+            when(project.getPlugin(NativeImageAgentSupport.NATIVE_MAVEN_PLUGIN)).thenReturn(plugin);
+        }
+        return project;
+    }
+
+    private File targetDirectory() {
+        return tempDir.resolve("target").toFile();
+    }
+
+    private Xpp3Dom agentConfiguration(String mode) {
+        var configuration = new Xpp3Dom("configuration");
+        var agent = new Xpp3Dom("agent");
+        configuration.addChild(agent);
+
+        var enabled = new Xpp3Dom("enabled");
+        enabled.setValue("true");
+        agent.addChild(enabled);
+
+        var defaultMode = new Xpp3Dom("defaultMode");
+        defaultMode.setValue(mode);
+        agent.addChild(defaultMode);
+
+        var modes = new Xpp3Dom("modes");
+        agent.addChild(modes);
+        var direct = new Xpp3Dom("direct");
+        direct.setValue("config-output-dir={output_dir}");
+        modes.addChild(direct);
+        return configuration;
+    }
+}


### PR DESCRIPTION
## Summary
- add `mn:run` support for GraalVM native-image tracing when upstream `-Dagent=true` is enabled
- default agent output to `target/native/agent-output/main`, reject manual `-agentlib:native-image-agent` conflicts, and limit `mn:run` support to standard agent mode
- document the `mn:run` workflow and cover it with focused unit tests plus a GraalVM-gated invoker scenario

Closes #1077

## Verification
- `./mvnw -pl micronaut-maven-plugin -am -Dtest=NativeImageAgentSupportTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-integration-tests -am -Dinvoker.test=run-native-agent verify`