### PR TITLE
Add native builder image override property

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol9 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-distroless/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
@@ -10,8 +10,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
@@ -10,8 +10,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol9 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-base/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/graalvm/native-image-community:25-muslib-ol9 AS builder
+WORKDIR /home/app
+
+COPY classes /home/app/classes
+COPY dependency/release/ /home/app/libs/release/
+COPY dependency/snapshot/ /home/app/libs/snapshot/
+COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
+COPY nativ[e]/generated /home/app/
+COPY *.args /home/app/graalvm-native-image.args
+RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+
+FROM ubuntu
+COPY --from=builder /home/app/application /app/application
+
+EXPOSE 8080
+ENTRYPOINT ["/app/application"]

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native -Djib.from.image=ghcr.io/graalvm/native-image-community:25-muslib-ol9 compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/pom.xml
@@ -1,0 +1,153 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>dockerfile-docker-native-netty-custom-builder-base-jib-precedence</artifactId>
+  <version>0.1</version>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.platform</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>@it.micronaut.version@</version>
+  </parent>
+
+  <properties>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+    <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
+    <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+    <packaging>jar</packaging>
+    <micronaut.runtime>netty</micronaut.runtime>
+    <maven.compiler.release>${java.specification.version}</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.serde</groupId>
+      <artifactId>micronaut-serde-jackson</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <version>${micronaut-maven-plugin.version}</version>
+        <configuration>
+          <baseImage>container-registry.oracle.com/graalvm/native-image:21-ol8</baseImage>
+          <baseImageRun>ubuntu</baseImageRun>
+          <nativeImageBuildArgs>-Ob</nativeImageBuildArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+            <path>
+              <groupId>io.micronaut.serde</groupId>
+              <artifactId>micronaut-serde-processor</artifactId>
+              <version>${micronaut.serialization.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=${project.artifactId}</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>alvarosanchez/${project.artifactId}:${project.version}</image>
+          </to>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.48.1</version>
+        <configuration>
+          <showLogs>true</showLogs>
+          <outputDirectory>${java.io.tmpdir}</outputDirectory>
+          <verbose>true</verbose>
+          <images>
+            <image>
+              <name>alvarosanchez/${project.artifactId}:${project.version}</name>
+              <build>
+                <dockerFileDir>${project.build.directory}</dockerFileDir>
+              </build>
+              <run>
+                <wait>
+                  <log>Startup completed in</log>
+                  <time>20000</time>
+                </wait>
+              </run>
+            </image>
+          </images>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: dockerfile-docker-native-netty-custom-base

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/test/java/io/micronaut/build/examples/ApplicationTest.java
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/src/test/java/io/micronaut/build/examples/ApplicationTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+public class ApplicationTest {
+
+    @Inject
+    EmbeddedApplication application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/verify.groovy
@@ -1,0 +1,9 @@
+File dockerfile = new File("$basedir/target", "Dockerfile")
+File expectedDockerfile = new File(basedir, "Dockerfile")
+String expectedDockerfileText = expectedDockerfile.text
+
+assert dockerfile.text == expectedDockerfileText
+
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD SUCCESS")

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/Dockerfile
@@ -1,0 +1,16 @@
+FROM container-registry.oracle.com/graalvm/native-image:21-ol8 AS builder
+WORKDIR /home/app
+
+COPY classes /home/app/classes
+COPY dependency/release/ /home/app/libs/release/
+COPY dependency/snapshot/ /home/app/libs/snapshot/
+COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
+COPY nativ[e]/generated /home/app/
+COPY *.args /home/app/graalvm-native-image.args
+RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
+
+FROM ubuntu
+COPY --from=builder /home/app/application /app/application
+
+EXPOSE 8080
+ENTRYPOINT ["/app/application"]

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = -ntp mn:dockerfile -Dpackaging=docker-native compile
+invoker.os.family = !windows

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/pom.xml
@@ -1,0 +1,153 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>dockerfile-docker-native-netty-custom-builder-base</artifactId>
+  <version>0.1</version>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.platform</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>@it.micronaut.version@</version>
+  </parent>
+
+  <properties>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+    <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
+    <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+    <packaging>jar</packaging>
+    <micronaut.runtime>netty</micronaut.runtime>
+    <maven.compiler.release>${java.specification.version}</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.serde</groupId>
+      <artifactId>micronaut-serde-jackson</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <version>${micronaut-maven-plugin.version}</version>
+        <configuration>
+          <baseImage>container-registry.oracle.com/graalvm/native-image:21-ol8</baseImage>
+          <baseImageRun>ubuntu</baseImageRun>
+          <nativeImageBuildArgs>-Ob</nativeImageBuildArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.core.version}</version>
+            </path>
+            <path>
+              <groupId>io.micronaut.serde</groupId>
+              <artifactId>micronaut-serde-processor</artifactId>
+              <version>${micronaut.serialization.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+            <arg>-Amicronaut.processing.module=${project.artifactId}</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <configuration>
+          <to>
+            <image>alvarosanchez/${project.artifactId}:${project.version}</image>
+          </to>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.48.1</version>
+        <configuration>
+          <showLogs>true</showLogs>
+          <outputDirectory>${java.io.tmpdir}</outputDirectory>
+          <verbose>true</verbose>
+          <images>
+            <image>
+              <name>alvarosanchez/${project.artifactId}:${project.version}</name>
+              <build>
+                <dockerFileDir>${project.build.directory}</dockerFileDir>
+              </build>
+              <run>
+                <wait>
+                  <log>Startup completed in</log>
+                  <time>20000</time>
+                </wait>
+              </run>
+            </image>
+          </images>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,10 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: dockerfile-docker-native-netty-custom-base

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/test/java/io/micronaut/build/examples/ApplicationTest.java
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/src/test/java/io/micronaut/build/examples/ApplicationTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+public class ApplicationTest {
+
+    @Inject
+    EmbeddedApplication application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/verify.groovy
@@ -1,0 +1,9 @@
+File dockerfile = new File("$basedir/target", "Dockerfile")
+File expectedDockerfile = new File(basedir, "Dockerfile")
+String expectedDockerfileText = expectedDockerfile.text
+
+assert dockerfile.text == expectedDockerfileText
+
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("BUILD SUCCESS")

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol8 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol8 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-ol/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol9 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-elements-at-runtime -H:PageSize=64k -H:Class=com.fnproject.fn.runtime.EntryPoint -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-function/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol9 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-elements-at-runtime -H:PageSize=64k -H:Class=com.fnproject.fn.runtime.EntryPoint -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-oracle-http-function/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol9 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-static/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-muslib-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-muslib-ol9 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:25-ol9 AS builder
+FROM container-registry.oracle.com/graalvm/native-image:25-ol9 AS builder
 WORKDIR /home/app
 
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
+++ b/micronaut-maven-integration-tests/src/it/issue1218/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=io.micronaut.build.examples.Application -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -61,6 +61,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
 
     public static final String LATEST_TAG = "latest";
     public static final String DEFAULT_BASE_IMAGE_GRAALVM_RUN = "cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502";
+    public static final String DEFAULT_BASE_IMAGE_GRAALVM_BUILD = "container-registry.oracle.com/graalvm/native-image";
     public static final String MOSTLY_STATIC_NATIVE_IMAGE_GRAALVM_FLAG = "-H:+StaticExecutableWithDynamicLibC";
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "x64";
@@ -242,7 +243,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         return getJibFromImageSystemProperty()
             .or(() -> Optional.ofNullable(baseImage).filter(StringUtils::hasText))
             .or(() -> getFromImage().filter(StringUtils::hasText))
-            .orElse("ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
+            .orElse(DEFAULT_BASE_IMAGE_GRAALVM_BUILD + ":" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
     }
 
     /**

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -241,7 +241,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     protected String getFrom() {
         return getJibFromImageSystemProperty()
             .or(() -> Optional.ofNullable(baseImage).filter(StringUtils::hasText))
-            .or(this::getFromImage)
+            .or(() -> getFromImage().filter(StringUtils::hasText))
             .orElse("ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -141,7 +141,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     protected String baseImageRun;
 
     /**
-     * The Docker image used to build the native image for the standard docker-native path.
+     * The builder-stage base image used to build the native image for docker-native packaging variants.
      *
      * @since 5.1.0
      */

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -143,7 +143,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     /**
      * The builder-stage base image used to build the native image for docker-native packaging variants.
      *
-     * @since 5.1.0
+     * @since 5.0.0
      */
     @Parameter(property = "micronaut.native-image.base-image")
     protected String baseImage;

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -67,6 +67,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     public static final String ORACLE_CLOUD_FUNCTION_DEFAULT_CMD = "CMD [\"io.micronaut.oraclecloud.function.http.HttpFunction::handleRequest\"]";
     public static final String GDS_DOWNLOAD_URL = "https://gds.oracle.com/download/graal/%s/latest-gftc/graalvm-jdk-%s_linux-%s_bin.tar.gz";
     public static final String LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER = "${LAMBDA_BOOTSTRAP_DOCKER_COMMAND}";
+    static final String JIB_FROM_IMAGE_PROPERTY = "jib.from.image";
     private static final String DEPENDENCY_DIRECTORY = "dependency";
     private static final String RELEASE_DEPENDENCY_DIRECTORY = "release";
     private static final String SNAPSHOT_DEPENDENCY_DIRECTORY = "snapshot";
@@ -137,6 +138,14 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      */
     @Parameter(property = "micronaut.native-image.base-image-run", defaultValue = DEFAULT_BASE_IMAGE_GRAALVM_RUN)
     protected String baseImageRun;
+
+    /**
+     * The Docker image used to build the native image for the standard docker-native path.
+     *
+     * @since 5.1.0
+     */
+    @Parameter(property = "micronaut.native-image.base-image")
+    protected String baseImage;
 
     /**
      * The version of Oracle Linux to use as a native-compile base when building a native image inside a Docker container.
@@ -230,7 +239,10 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      * @return the base FROM image for the native image.
      */
     protected String getFrom() {
-        return getFromImage().orElse("ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
+        return getJibFromImageSystemProperty()
+            .or(() -> Optional.ofNullable(baseImage).filter(StringUtils::hasText))
+            .or(this::getFromImage)
+            .orElse("ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
     }
 
     /**
@@ -263,6 +275,14 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      */
     protected Optional<String> getFromImage() {
         return jibConfigurationService.getFromImage();
+    }
+
+    /**
+     * @return the base image from the Jib system property override, if any.
+     */
+    protected Optional<String> getJibFromImageSystemProperty() {
+        return Optional.ofNullable(System.getProperty(JIB_FROM_IMAGE_PROPERTY))
+            .filter(StringUtils::hasText);
     }
 
     /**

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNative
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNative
@@ -6,8 +6,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeDistroless
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeDistroless
@@ -6,8 +6,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
@@ -11,8 +11,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
 RUN native-image @/home/app/graalvm-native-image.args -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeOracleCloud
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeOracleCloud
@@ -6,8 +6,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args --report-unsupported-elements-at-runtime -H:PageSize=64k -H:Class=com.fnproject.fn.runtime.EntryPoint -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeStatic
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeStatic
@@ -6,8 +6,8 @@ WORKDIR /home/app
 COPY classes /home/app/classes
 COPY dependency/release/ /home/app/libs/release/
 COPY dependency/snapshot/ /home/app/libs/snapshot/
-COPY graalvm-reachability-metadat[a] /home/app/graalvm-reachability-metadata
-COPY nativ[e]/generated /home/app/
+COPY graalvm-reachability-metadata /home/app/graalvm-reachability-metadata
+COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
 RUN native-image @/home/app/graalvm-native-image.args --static --target=linux-amd64 --libc=musl -H:Class=${CLASS_NAME} -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -322,6 +322,8 @@ deployments, either omit `jib.buildGoal` or set it to `dockerBuild`.
 Note that changing the builder image to a totally different one than the default might break image building, since the rest
 of the build steps expect a certain builder-stage base image. By default, that builder-stage base image comes from
 `container-registry.oracle.com/graalvm/native-image`.
+If you need a stricter reproducibility guarantee than a moving image tag provides, override the builder-stage image with a
+digest-pinned reference via `micronaut.native-image.base-image` or `jib.from.image`.
 If the selected builder image requires authentication, continue using Jib auth configuration such as
 `jib.from.auth.username` and `jib.from.auth.password`.
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -291,8 +291,15 @@ $ mvn package -Dpackaging=docker-native \
 ----
 
 Use `micronaut.native-image.base-image` for the native builder stage and `micronaut.native-image.base-image-run` for
-the final runtime image. If both `jib.from.image` and `micronaut.native-image.base-image` are configured, the Jib
-system property wins so existing automation keeps working unchanged.
+the final runtime image. The native builder-stage image is resolved in this order:
+
+* `jib.from.image`.
+* `micronaut.native-image.base-image`.
+* Jib `<from><image>`.
+* The plugin-computed default Oracle GraalVM GFTC builder image.
+
+That keeps `jib.from.image` as the highest-precedence override so existing automation keeps working unchanged, while
+still letting Micronaut-specific configuration win over the Jib POM builder image.
 
 You can also use some
 https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#system-properties[system properties] from the

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -313,7 +313,8 @@ result, `mvn deploy -Dpackaging=docker -Djib.buildGoal=buildTar` and `... -Djib.
 deployments, either omit `jib.buildGoal` or set it to `dockerBuild`.
 
 Note that changing the builder image to a totally different one than the default might break image building, since the rest
-of the build steps expect a certain base image. By default, the native images are built from a `ghcr.io/graalvm/native-image-community` image.
+of the build steps expect a certain builder-stage base image. By default, that builder-stage base image is
+`ghcr.io/graalvm/native-image-community`.
 If the selected builder image requires authentication, continue using Jib auth configuration such as
 `jib.from.auth.username` and `jib.from.auth.password`.
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -313,7 +313,7 @@ result, `mvn deploy -Dpackaging=docker -Djib.buildGoal=buildTar` and `... -Djib.
 deployments, either omit `jib.buildGoal` or set it to `dockerBuild`.
 
 Note that changing the builder image to a totally different one than the default might break image building, since the rest
-of the build steps expect a certain base image. By default, the native images are built from an `ghcr.io/graalvm/native-image-community` image.
+of the build steps expect a certain base image. By default, the native images are built from a `ghcr.io/graalvm/native-image-community` image.
 If the selected builder image requires authentication, continue using Jib auth configuration such as
 `jib.from.auth.username` and `jib.from.auth.password`.
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -313,8 +313,8 @@ result, `mvn deploy -Dpackaging=docker -Djib.buildGoal=buildTar` and `... -Djib.
 deployments, either omit `jib.buildGoal` or set it to `dockerBuild`.
 
 Note that changing the builder image to a totally different one than the default might break image building, since the rest
-of the build steps expect a certain builder-stage base image. By default, that builder-stage base image is
-`ghcr.io/graalvm/native-image-community`.
+of the build steps expect a certain builder-stage base image. By default, that builder-stage base image comes from
+`container-registry.oracle.com/graalvm/native-image`.
 If the selected builder image requires authentication, continue using Jib auth configuration such as
 `jib.from.auth.username` and `jib.from.auth.password`.
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -249,7 +249,7 @@ images. In this case, the `micronaut.runtime` property will also determine how t
    `--static --libc=musl` flags and then puts the binary in a `scratch` image.
 ** Mostly static image: `mvn package -Dpackaging=docker-native -Dmicronaut.native-image.base-image-run=gcr.io/distroless/cc-debian12 -Pgraalvm`.
    This will create a "mostly" static native image and adds automatically `-H:+StaticExecutableWithDynamicLibC` flag.
-** Custom image: `mvn package -Dpackaging=docker-native -Dmicronaut.native-image.base-image-run=your-own-image-for-run-the-native-image`
+** Custom runtime image: `mvn package -Dpackaging=docker-native -Dmicronaut.native-image.base-image-run=your-own-image-for-run-the-native-image`
 * Oracle Cloud Function: `mvn package -Dpackaging=docker-native -Dmicronaut.runtime=oracle_function`.
 * AWS Lambda (custom runtime): `mvn package -Dpackaging=docker-native -Dmicronaut.runtime=lambda`.
 
@@ -274,16 +274,31 @@ the project POM.
 The image built can be customised using
 https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#configuration[Jib]. In particular, you can set:
 
-* The base image, using `<from><image>`. If the base image comes from a registry that requires authentication, you can
-  use `<from><auth><username>` and `<from><auth><password>`. Chek the
+* The builder image, using `<from><image>`. If the builder image comes from a registry that requires authentication, you can
+  use `<from><auth><username>` and `<from><auth><password>`. Check the
   https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md#using-specific-credentials[Jib documentation]
   for more details.
 * The image name/tags that will be used for building, using either `<to><image>` and/or `<to><tags>`.
+
+You can also override the native build-stage image with the Micronaut-specific `micronaut.native-image.base-image`
+property. This is the preferred override when you want to stay within Micronaut Maven Plugin configuration instead of
+using Jib-specific `<from><image>` or `jib.from.image`.
+
+[source,shell]
+----
+$ mvn package -Dpackaging=docker-native \
+    -Dmicronaut.native-image.base-image=container-registry.oracle.com/graalvm/native-image:21-ol8
+----
+
+Use `micronaut.native-image.base-image` for the native builder stage and `micronaut.native-image.base-image-run` for
+the final runtime image. If both `jib.from.image` and `micronaut.native-image.base-image` are configured, the Jib
+system property wins so existing automation keeps working unchanged.
 
 You can also use some
 https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#system-properties[system properties] from the
 command line:
 
+* `jib.from.image`.
 * `jib.from.auth.username`.
 * `jib.from.auth.password`.
 * `jib.to.image`.
@@ -297,8 +312,10 @@ When using `jib.buildGoal=buildTar` or `jib.buildGoal=build`, only the `package`
 result, `mvn deploy -Dpackaging=docker -Djib.buildGoal=buildTar` and `... -Djib.buildGoal=build` are not supported; for
 deployments, either omit `jib.buildGoal` or set it to `dockerBuild`.
 
-Note that changing the base image to a totally different one than the default might break image building, since the rest
+Note that changing the builder image to a totally different one than the default might break image building, since the rest
 of the build steps expect a certain base image. By default, the native images are built from an `ghcr.io/graalvm/native-image-community` image.
+If the selected builder image requires authentication, continue using Jib auth configuration such as
+`jib.from.auth.username` and `jib.from.auth.password`.
 
 In the case of AWS custom runtime, it starts from `amazonlinux:2023`, and this cannot be changed. Also, in this case the
 result is not a tagged Docker image, but a `function.zip` archive that contains the bootstrap launch script and the native binary.

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 class AbstractDockerMojoTest {
 
     @Test
-    void getFromUsesDefaultCommunityImageWhenNoOverridesExist(@TempDir Path tempDir) {
+    void getFromUsesDefaultOracleImageWhenNoOverridesExist(@TempDir Path tempDir) {
         var project = mockProject(tempDir, Set.of());
         var jibConfigurationService = mock(JibConfigurationService.class);
         when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
@@ -154,7 +154,7 @@ class AbstractDockerMojoTest {
         }
 
         private String defaultBuilderImage() {
-            return "ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion);
+            return DEFAULT_BASE_IMAGE_GRAALVM_BUILD + ":" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion);
         }
 
         @Override

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -36,7 +36,18 @@ class AbstractDockerMojoTest {
 
         var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
 
-        assertEquals(mojo.defaultBuilderImage(), mojo.from());
+        assertEquals("ghcr.io/graalvm/native-image-community:25-ol9", mojo.from());
+    }
+
+    @Test
+    void getFromIgnoresBlankJibPomConfiguration(@TempDir Path tempDir) {
+        var project = mockProject(tempDir, Set.of());
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of(""));
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+
+        assertEquals("ghcr.io/graalvm/native-image-community:25-ol9", mojo.from());
     }
 
     @Test
@@ -135,14 +146,11 @@ class AbstractDockerMojoTest {
                 mavenSession,
                 mock(MojoExecution.class)
             );
+            oracleLinuxVersion = "ol9";
         }
 
         private String from() {
             return getFrom();
-        }
-
-        private String defaultBuilderImage() {
-            return "ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion);
         }
 
         @Override

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -36,7 +36,7 @@ class AbstractDockerMojoTest {
 
         var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
 
-        assertEquals("ghcr.io/graalvm/native-image-community:25-ol9", mojo.from());
+        assertEquals(mojo.defaultBuilderImage(), mojo.from());
     }
 
     @Test
@@ -47,7 +47,7 @@ class AbstractDockerMojoTest {
 
         var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
 
-        assertEquals("ghcr.io/graalvm/native-image-community:25-ol9", mojo.from());
+        assertEquals(mojo.defaultBuilderImage(), mojo.from());
     }
 
     @Test
@@ -151,6 +151,10 @@ class AbstractDockerMojoTest {
 
         private String from() {
             return getFrom();
+        }
+
+        private String defaultBuilderImage() {
+            return "ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion);
         }
 
         @Override

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -10,10 +10,12 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.RestoreSystemProperties;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -23,7 +25,45 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@RestoreSystemProperties
 class AbstractDockerMojoTest {
+
+    @Test
+    void getFromUsesDefaultCommunityImageWhenNoOverridesExist(@TempDir Path tempDir) {
+        var project = mockProject(tempDir, Set.of());
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+
+        assertEquals(mojo.defaultBuilderImage(), mojo.from());
+    }
+
+    @Test
+    void getFromUsesMicronautBaseImageBeforeJibPomConfiguration(@TempDir Path tempDir) {
+        var project = mockProject(tempDir, Set.of());
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/graalvm/native-image-community:25-ol9"));
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+        mojo.baseImage = "container-registry.oracle.com/graalvm/native-image:21-ol8";
+
+        assertEquals("container-registry.oracle.com/graalvm/native-image:21-ol8", mojo.from());
+    }
+
+    @Test
+    void getFromKeepsJibSystemPropertyAsHighestPrecedence(@TempDir Path tempDir) {
+        System.setProperty(AbstractDockerMojo.JIB_FROM_IMAGE_PROPERTY, "container-registry.oracle.com/graalvm/native-image-ee:latest");
+
+        var project = mockProject(tempDir, Set.of());
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/graalvm/native-image-community:25-ol9"));
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+        mojo.baseImage = "container-registry.oracle.com/graalvm/native-image:21-ol8";
+
+        assertEquals("container-registry.oracle.com/graalvm/native-image-ee:latest", mojo.from());
+    }
 
     @Test
     void copyDependenciesKeepsFlatLayoutAndAddsReleaseAndSnapshotLayers(@TempDir Path tempDir) throws IOException {
@@ -36,7 +76,7 @@ class AbstractDockerMojoTest {
         var testDependency = mockDependency(Artifact.SCOPE_TEST, false, testJar);
         var project = mockProject(tempDir, Set.of(releaseDependency, snapshotDependency, testDependency));
 
-        var mojo = new TestDockerMojo(project, mockSession(project));
+        var mojo = new TestDockerMojo(project, mockSession(project), mock(JibConfigurationService.class));
 
         mojo.copyDependencies();
 
@@ -86,15 +126,23 @@ class AbstractDockerMojoTest {
 
     private static final class TestDockerMojo extends AbstractDockerMojo {
 
-        private TestDockerMojo(MavenProject mavenProject, MavenSession mavenSession) {
+        private TestDockerMojo(MavenProject mavenProject, MavenSession mavenSession, JibConfigurationService jibConfigurationService) {
             super(
                 mavenProject,
-                mock(JibConfigurationService.class),
+                jibConfigurationService,
                 mock(ApplicationConfigurationService.class),
                 mock(DockerService.class),
                 mavenSession,
                 mock(MojoExecution.class)
             );
+        }
+
+        private String from() {
+            return getFrom();
+        }
+
+        private String defaultBuilderImage() {
+            return "ghcr.io/graalvm/native-image-community:" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion);
         }
 
         @Override


### PR DESCRIPTION
## Summary
- switch the computed `docker-native` builder image default from GraalVM Community Edition to Oracle GraalVM GFTC so the out-of-the-box builder matches issue #931
- keep precedence `jib.from.image` > `micronaut.native-image.base-image` > Jib `<from><image>` > computed default so existing Jib automation keeps working
- update builder-image docs plus unit and invoker coverage for the new default builder image

## Verification
- `./mvnw -pl micronaut-maven-plugin -am -Dtest=AbstractDockerMojoTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-plugin -am spotless:check checkstyle:check -DskipTests`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=dockerfile-docker-native*"`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=issue1218"`

Fixes #931
