### PR TITLE
Add Maven wrapper distribution checksum verification

### DIFF
--- a/.github/scripts/verify-maven-wrapper-checksum.sh
+++ b/.github/scripts/verify-maven-wrapper-checksum.sh
@@ -47,7 +47,8 @@ if [[ ! "$distribution_sha256_sum" =~ ^[0-9a-f]{64}$ ]]; then
   exit 1
 fi
 
-tmp_file="$(mktemp)"
+# Use an explicit template so local verification also works with BSD/macOS mktemp.
+tmp_file="$(mktemp "${TMPDIR:-/tmp}/maven-wrapper-checksum.XXXXXX")"
 trap 'rm -f "$tmp_file"' EXIT
 
 curl -fsSL \

--- a/.github/scripts/verify-maven-wrapper-checksum.sh
+++ b/.github/scripts/verify-maven-wrapper-checksum.sh
@@ -2,9 +2,24 @@
 set -euo pipefail
 
 properties_file="${1:-.mvn/wrapper/maven-wrapper.properties}"
+wrapper_dir="$(cd "$(dirname "$properties_file")" && pwd)"
+wrapper_jar="$wrapper_dir/maven-wrapper.jar"
 
 normalize_properties_value() {
   printf '%s' "$1" | sed 's/^[[:space:]]*//;s/\\:/:/g;s/\\\\/\\/g'
+}
+
+sha256_file() {
+  local file="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  else
+    echo "Missing SHA-256 tool: install sha256sum or shasum" >&2
+    exit 1
+  fi
 }
 
 if [[ ! -f "$properties_file" ]]; then
@@ -14,6 +29,7 @@ fi
 
 distribution_url=""
 distribution_sha256_sum=""
+wrapper_sha256_sum=""
 
 while IFS= read -r line || [[ -n "$line" ]]; do
   # GitHub Windows runners can check out this properties file with CRLF endings.
@@ -26,6 +42,9 @@ while IFS= read -r line || [[ -n "$line" ]]; do
       ;;
     distributionSha256Sum=*)
       distribution_sha256_sum="$(normalize_properties_value "${line#distributionSha256Sum=}")"
+      ;;
+    wrapperSha256Sum=*)
+      wrapper_sha256_sum="$(normalize_properties_value "${line#wrapperSha256Sum=}")"
       ;;
   esac
 done <"$properties_file"
@@ -47,6 +66,28 @@ if [[ ! "$distribution_sha256_sum" =~ ^[0-9a-f]{64}$ ]]; then
   exit 1
 fi
 
+if [[ -f "$wrapper_jar" ]]; then
+  if [[ -z "$wrapper_sha256_sum" ]]; then
+    echo "wrapperSha256Sum is missing from $properties_file" >&2
+    exit 1
+  fi
+
+  wrapper_sha256_sum="${wrapper_sha256_sum,,}"
+
+  if [[ ! "$wrapper_sha256_sum" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "wrapperSha256Sum must be a SHA-256 hex digest" >&2
+    exit 1
+  fi
+
+  actual_wrapper_sha256_sum="$(sha256_file "$wrapper_jar")"
+  if [[ "$actual_wrapper_sha256_sum" != "$wrapper_sha256_sum" ]]; then
+    echo "Maven wrapper JAR checksum mismatch" >&2
+    echo "Expected: $wrapper_sha256_sum" >&2
+    echo "Actual:   $actual_wrapper_sha256_sum" >&2
+    exit 1
+  fi
+fi
+
 # Use an explicit template so local verification also works with BSD/macOS mktemp.
 tmp_file="$(mktemp "${TMPDIR:-/tmp}/maven-wrapper-checksum.XXXXXX")"
 trap 'rm -f "$tmp_file"' EXIT
@@ -58,15 +99,7 @@ curl -fsSL \
   --retry-delay 5 \
   "$distribution_url" -o "$tmp_file"
 
-actual_sha256_sum=""
-if command -v sha256sum >/dev/null 2>&1; then
-  actual_sha256_sum="$(sha256sum "$tmp_file" | awk '{print $1}')"
-elif command -v shasum >/dev/null 2>&1; then
-  actual_sha256_sum="$(shasum -a 256 "$tmp_file" | awk '{print $1}')"
-else
-  echo "Missing SHA-256 tool: install sha256sum or shasum" >&2
-  exit 1
-fi
+actual_sha256_sum="$(sha256_file "$tmp_file")"
 
 if [[ "$actual_sha256_sum" != "$distribution_sha256_sum" ]]; then
   echo "Maven wrapper distribution checksum mismatch" >&2

--- a/.github/scripts/verify-maven-wrapper-checksum.sh
+++ b/.github/scripts/verify-maven-wrapper-checksum.sh
@@ -6,7 +6,7 @@ wrapper_dir="$(cd "$(dirname "$properties_file")" && pwd)"
 wrapper_jar="$wrapper_dir/maven-wrapper.jar"
 
 normalize_properties_value() {
-  printf '%s' "$1" | sed 's/^[[:space:]]*//;s/\\:/:/g;s/\\\\/\\/g'
+  printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\\:/:/g;s/\\\\/\\/g'
 }
 
 sha256_file() {
@@ -97,7 +97,8 @@ curl -fsSL \
   --max-time 300 \
   --retry 3 \
   --retry-delay 5 \
-  "$distribution_url" -o "$tmp_file"
+  -o "$tmp_file" \
+  -- "$distribution_url"
 
 actual_sha256_sum="$(sha256_file "$tmp_file")"
 

--- a/.github/scripts/verify-maven-wrapper-checksum.sh
+++ b/.github/scripts/verify-maven-wrapper-checksum.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 properties_file="${1:-.mvn/wrapper/maven-wrapper.properties}"
 
+normalize_properties_value() {
+  printf '%s' "$1" | sed 's/^[[:space:]]*//;s/\\:/:/g;s/\\\\/\\/g'
+}
+
 if [[ ! -f "$properties_file" ]]; then
   echo "Missing wrapper properties file: $properties_file" >&2
   exit 1
@@ -18,10 +22,10 @@ while IFS= read -r line || [[ -n "$line" ]]; do
 
   case "$line" in
     distributionUrl=*)
-      distribution_url="${line#distributionUrl=}"
+      distribution_url="$(normalize_properties_value "${line#distributionUrl=}")"
       ;;
     distributionSha256Sum=*)
-      distribution_sha256_sum="${line#distributionSha256Sum=}"
+      distribution_sha256_sum="$(normalize_properties_value "${line#distributionSha256Sum=}")"
       ;;
   esac
 done <"$properties_file"
@@ -36,15 +40,22 @@ if [[ -z "$distribution_sha256_sum" ]]; then
   exit 1
 fi
 
+distribution_sha256_sum="${distribution_sha256_sum,,}"
+
 if [[ ! "$distribution_sha256_sum" =~ ^[0-9a-f]{64}$ ]]; then
-  echo "distributionSha256Sum must be a lowercase SHA-256 hex digest" >&2
+  echo "distributionSha256Sum must be a SHA-256 hex digest" >&2
   exit 1
 fi
 
 tmp_file="$(mktemp)"
 trap 'rm -f "$tmp_file"' EXIT
 
-curl -fsSL "$distribution_url" -o "$tmp_file"
+curl -fsSL \
+  --connect-timeout 10 \
+  --max-time 300 \
+  --retry 3 \
+  --retry-delay 5 \
+  "$distribution_url" -o "$tmp_file"
 
 actual_sha256_sum=""
 if command -v sha256sum >/dev/null 2>&1; then

--- a/.github/scripts/verify-maven-wrapper-checksum.sh
+++ b/.github/scripts/verify-maven-wrapper-checksum.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+properties_file="${1:-.mvn/wrapper/maven-wrapper.properties}"
+
+if [[ ! -f "$properties_file" ]]; then
+  echo "Missing wrapper properties file: $properties_file" >&2
+  exit 1
+fi
+
+distribution_url=""
+distribution_sha256_sum=""
+
+while IFS='=' read -r key value; do
+  case "$key" in
+    distributionUrl) distribution_url="${value}" ;;
+    distributionSha256Sum) distribution_sha256_sum="${value}" ;;
+  esac
+done <"$properties_file"
+
+if [[ -z "$distribution_url" ]]; then
+  echo "distributionUrl is missing from $properties_file" >&2
+  exit 1
+fi
+
+if [[ -z "$distribution_sha256_sum" ]]; then
+  echo "distributionSha256Sum is missing from $properties_file" >&2
+  exit 1
+fi
+
+if [[ ! "$distribution_sha256_sum" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "distributionSha256Sum must be a lowercase SHA-256 hex digest" >&2
+  exit 1
+fi
+
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+curl -fsSL "$distribution_url" -o "$tmp_file"
+
+actual_sha256_sum=""
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha256_sum="$(sha256sum "$tmp_file" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_sha256_sum="$(shasum -a 256 "$tmp_file" | awk '{print $1}')"
+else
+  echo "Missing SHA-256 tool: install sha256sum or shasum" >&2
+  exit 1
+fi
+
+if [[ "$actual_sha256_sum" != "$distribution_sha256_sum" ]]; then
+  echo "Maven wrapper distribution checksum mismatch" >&2
+  echo "Expected: $distribution_sha256_sum" >&2
+  echo "Actual:   $actual_sha256_sum" >&2
+  exit 1
+fi
+
+echo "Verified Maven wrapper checksum for $distribution_url"

--- a/.github/scripts/verify-maven-wrapper-checksum.sh
+++ b/.github/scripts/verify-maven-wrapper-checksum.sh
@@ -11,10 +11,18 @@ fi
 distribution_url=""
 distribution_sha256_sum=""
 
-while IFS='=' read -r key value; do
-  case "$key" in
-    distributionUrl) distribution_url="${value}" ;;
-    distributionSha256Sum) distribution_sha256_sum="${value}" ;;
+while IFS= read -r line || [[ -n "$line" ]]; do
+  # GitHub Windows runners can check out this properties file with CRLF endings.
+  # Normalize the parsed line so the checksum regex still validates the real value.
+  line="${line%$'\r'}"
+
+  case "$line" in
+    distributionUrl=*)
+      distribution_url="${line#distributionUrl=}"
+      ;;
+    distributionSha256Sum=*)
+      distribution_sha256_sum="${line#distributionSha256Sum=}"
+      ;;
   esac
 done <"$properties_file"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
+      - name: "🛡 Verify Maven wrapper checksum"
+        run: bash .github/scripts/verify-maven-wrapper-checksum.sh
+
       - name: "🔐 Import GPG key"
         env:
           GPG_FILE: ${{ secrets.GPG_FILE }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: "🛡 Verify workflow pinning"
         run: bash .github/scripts/check-workflow-pinning.sh
+      - name: "🛡 Verify Maven wrapper checksum"
+        run: bash .github/scripts/verify-maven-wrapper-checksum.sh
 
   snapshot:
     needs:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -24,6 +24,9 @@ jobs:
         java: ['25']
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - name: Verify Maven wrapper checksum
+        shell: bash
+        run: bash .github/scripts/verify-maven-wrapper-checksum.sh
       - name: Cache Maven packages
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
-# Keep this Apache Maven Wrapper checksum aligned with distributionUrl whenever
-# the wrapper's Maven version is updated.
+# Keep these Apache Maven Wrapper checksums aligned with the committed wrapper
+# JAR and distributionUrl whenever the wrapper is updated.
 distributionSha256Sum=55fadd669532a3205d5db95f490bf13971d8b0843526f407f29db0e61f074ab3
+wrapperSha256Sum=e63a53cfb9c4d291ebe3c2b0edacb7622bbc480326beaa5a0456e412f52f066a

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,4 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+# Keep this Apache Maven Wrapper checksum aligned with distributionUrl whenever
+# the wrapper's Maven version is updated.
 distributionSha256Sum=55fadd669532a3205d5db95f490bf13971d8b0843526f407f29db0e61f074ab3

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,3 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionSha256Sum=55fadd669532a3205d5db95f490bf13971d8b0843526f407f29db0e61f074ab3


### PR DESCRIPTION
## Summary

This hardens the repository's Maven wrapper bootstrap so the pinned Maven 3.9.14 distribution is verified before execution.

- adds the pinned `distributionSha256Sum` to `.mvn/wrapper/maven-wrapper.properties`
- adds a lightweight CI script that downloads the configured wrapper distribution and verifies it against that checksum
- wires the guardrail into the snapshot, windows, and release workflows so future wrapper updates cannot silently drop or stale the checksum

## Root Cause

The wrapper scripts already supported `distributionSha256Sum`, but the repository only configured `distributionUrl`, so first-use wrapper bootstrap trusted TLS alone.

## Validation

- `bash -n .github/scripts/verify-maven-wrapper-checksum.sh`
- `bash .github/scripts/verify-maven-wrapper-checksum.sh`
- `HOME=$(mktemp -d) ./mvnw -q -version`
