### PR TITLE
Pin CI Docker test images by digest

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: "⏬ Eagerly pull Docker images"
         run: |
-          docker pull postgres:latest
+          docker pull postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 
       - name: "🧪 Run tests"
         run: |

--- a/micronaut-maven-integration-tests/src/it/issue1332/modules/app1/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/issue1332/modules/app1/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-shared
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/issue1332/modules/app2/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/issue1332/modules/app2/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-shared
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-custom-dependency/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-custom-dependency/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-custom-dependency
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-disabled/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-disabled/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-disabled
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-failing-test/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-failing-test/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-failing-test
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-run/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-run/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-run
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-run/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-run/verify.groovy
@@ -2,7 +2,7 @@ File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS") : "Build did not succeed"
 assert log.text.contains("Starting Micronaut Test Resources service") : "Test Resources service was not started"
-assert log.text.contains("Container postgres:latest started") : "postgres container was not started"
+assert log.text.contains("Container postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a started") : "postgres container was not started with the pinned image"
 assert log.text.contains("Startup completed in") : "Startup was not completed"
 
 String port = new File(basedir, "target/test-resources-port.txt").text

--- a/micronaut-maven-integration-tests/src/it/test-resources-shared-namespace/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-shared-namespace/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-shared-namespace
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-shared/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-shared/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-shared
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-start-kill-stop/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-start-kill-stop/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-start-kill-stop
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources-start-stop/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources-start-stop/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources-start-stop
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 netty:
   default:
     allocator:

--- a/micronaut-maven-integration-tests/src/it/test-resources/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/test-resources/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 micronaut:
   application:
     name: test-resources
+test-resources:
+  containers:
+    postgres:
+      image-name: postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
 datasources:
   default:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## Summary
- pin the snapshot workflow's eagerly pulled PostgreSQL image to a reviewed `18.3` digest
- configure the affected test-resources integration scenarios to request the same pinned image instead of relying on a mutable default
- update `test-resources-run` verification to assert the pinned image string

## Verification
- `./mvnw -q -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=issue1332,test-resources,test-resources-shared,test-resources-disabled,test-resources-failing-test,test-resources-run,test-resources-custom-dependency,test-resources-shared-namespace,test-resources-start-stop"`
- `./mvnw -q -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=test-resources*,issue1332"` still reproduces the pre-existing `test-resources-start-kill-stop` harness failure (`Test Resources Service process not found`) seen on `5.0.x` and called out in QA sign-off.