### PR TITLE
Add a Windows preflight workflow for wrapper changes

### DIFF
--- a/.github/scripts/windows-preflight.cmd
+++ b/.github/scripts/windows-preflight.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+
+echo Running Windows wrapper preflight...
+call .\mvnw.cmd --version
+if errorlevel 1 exit /b 1
+
+echo Running lightweight Maven validation...
+call .\mvnw.cmd --batch-mode -q -Dinvoker.skip=true -DskipTests -DskipITs validate
+if errorlevel 1 exit /b 1

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -36,6 +36,9 @@ jobs:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Windows wrapper preflight
+        shell: cmd
+        run: .github\scripts\windows-preflight.cmd
       - name: Build with Maven
         shell: cmd
         run: |

--- a/.github/workflows/windows-preflight.yml
+++ b/.github/workflows/windows-preflight.yml
@@ -1,0 +1,55 @@
+name: Windows Preflight
+
+on:
+  pull_request:
+    branches:
+      - master
+      - '[1-9]+.[0-9]+.x'
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+      - '.mvn/wrapper/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+  merge_group:
+    types: [checks_requested]
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+      - '.mvn/wrapper/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workflow-hardening:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - name: "🛡 Verify workflow pinning"
+        run: bash .github/scripts/check-workflow-pinning.sh
+
+  windows-wrapper:
+    needs:
+      - workflow-hardening
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: ['25']
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - name: "☕️ Install Java"
+        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: "🔎 Run Windows wrapper preflight"
+        shell: cmd
+        run: .github\scripts\windows-preflight.cmd

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,12 @@ Micronaut Maven Plugin monorepo. Core work happens in the Maven plugin module pl
 ./mvnw spotless:check checkstyle:check
 ./mvnw -pl micronaut-maven-plugin -am test
 ./mvnw release:prepare -DdryRun=true
+bash .github/scripts/check-workflow-pinning.sh
+.\.github\scripts\windows-preflight.cmd
 ```
 
 ## NOTES
 - If touching CI expectations, update `.github/workflows/snapshot.yml`, `.github/workflows/windows-ci.yml`, and/or `.github/workflows/release.yml` consistently.
 - Paperclip worktrees may surface an untracked `.agents/` directory as local runtime scaffolding; ignore it unless the task is explicitly about agent assets or skills.
+- If a change touches `.github/workflows`, `.github/scripts`, `.mvn/wrapper`, `mvnw`, or `mvnw.cmd`, run the workflow-pinning check and the Windows preflight before handoff. Use the `Windows Preflight` workflow if you do not have local Windows access.
 - Keep child AGENTS.md files scoped: local rules only, no repeated root-level guidance.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ You can run integration tests by executing `mvn verify`
 If you want to run individual tests, you can execute `mvn verify "-Dinvoker.test=dockerfile*"`. In this case,
 `dockerfile*` will match all test projects under `src/it` folder with a name that starts with "dockerfile".
 
+### Windows-sensitive preflight
+
+If your change touches GitHub Actions workflows, `.github/scripts`, `.mvn/wrapper`, `mvnw`, or `mvnw.cmd`, run the lightweight Windows preflight before review handoff.
+
+On Windows, execute:
+
+```shell
+.\.github\scripts\windows-preflight.cmd
+```
+
+On any platform, also verify workflow pinning:
+
+```shell
+bash .github/scripts/check-workflow-pinning.sh
+```
+
+If you do not have a Windows shell locally, open a draft PR or run the `Windows Preflight` workflow manually to get the same wrapper/bootstrap check on `windows-latest` without waiting for the full Windows CI job.
+
 ### Debugging
 
 To debug the plugin, you first need to publish a snapshot to your Maven local:


### PR DESCRIPTION
## Summary
- add a lightweight `windows-preflight.cmd` check for Maven wrapper bootstrap and a fast `validate` pass
- add a targeted `Windows Preflight` workflow for wrapper- and workflow-sensitive pull requests
- run the preflight earlier in `windows-ci.yml` and document when maintainers should use it

## Testing
- `bash .github/scripts/check-workflow-pinning.sh`
- `JAVA_HOME=/home/ubuntu/.sdkman/candidates/java/25.0.2-graal ./mvnw --batch-mode -q -Dinvoker.skip=true -DskipTests -DskipITs validate`