### PR TITLE
Add a Linux docker-native snapshot preflight

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,6 +27,102 @@ jobs:
       - name: "🛡 Verify workflow pinning"
         run: bash .github/scripts/check-workflow-pinning.sh
 
+  linux-docker-native-preflight:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    needs:
+      - workflow-hardening
+    runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+      DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+      GRAALVM_QUICK_BUILD: true
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 0
+
+      - name: "🔎 Determine preflight scope"
+        id: preflight_scope
+        shell: bash
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=merge_group" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+
+          should_run=false
+          reason=non_sensitive_paths
+          while IFS= read -r file; do
+            case "$file" in
+              .github/workflows/*|.github/scripts/*|.mvn/*|mvnw|mvnw.cmd|pom.xml|micronaut-maven-core/*|micronaut-maven-jib-integration/*|micronaut-maven-plugin/*|micronaut-maven-integration-tests/pom.xml|micronaut-maven-integration-tests/src/it/issue582/*|micronaut-maven-integration-tests/src/it/dockerfile-docker-native-*/*)
+                should_run=true
+                reason="$file"
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "$base_sha" "$head_sha")
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+      - name: "ℹ️ Skip preflight for unrelated changes"
+        if: steps.preflight_scope.outputs.should_run != 'true'
+        run: |
+          echo "Skipping Linux docker-native preflight."
+          echo "Reason: ${{ steps.preflight_scope.outputs.reason }}"
+
+      - name: "🗑 Remove system JDKs"
+        if: steps.preflight_scope.outputs.should_run == 'true'
+        run: |
+          sudo rm -rf /usr/lib/jvm/*
+          unset JAVA_HOME
+          filtered_path=$(echo "$PATH" | tr ':' '\n' | grep -v '/usr/lib/jvm' | paste -sd:)
+          export PATH="$filtered_path"
+
+      - name: "🗑 Free disk space"
+        if: steps.preflight_scope.outputs.should_run == 'true'
+        run: |
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          df -h
+
+      - name: "☕️ Install Java and Maven"
+        if: steps.preflight_scope.outputs.should_run == 'true'
+        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+          cache: 'maven'
+
+      - name: "🔧 Setup GraalVM CE"
+        if: steps.preflight_scope.outputs.should_run == 'true'
+        uses: graalvm/setup-graalvm@2149f395d36ce12ad4ee5d7f334b26bf081fa555
+        with:
+          distribution: 'graalvm'
+          java-version: '25'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "🐳 Run Linux docker-native preflight"
+        if: steps.preflight_scope.outputs.should_run == 'true'
+        run: |
+          ./mvnw -q install -Dinvoker.skip=true
+          ./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=issue582,dockerfile-docker-native-netty-custom-base"
+
+      - name: "📊 Publish Preflight Test Report"
+        if: always() && steps.preflight_scope.outputs.should_run == 'true'
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8
+        with:
+          check_name: Linux Docker Native Preflight / Test Report
+          report_paths: '**/target/invoker-reports/TEST-*.xml'
+          check_retries: 'true'
+
   snapshot:
     needs:
       - workflow-hardening

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Micronaut Maven Plugin monorepo. Core work happens in the Maven plugin module pl
 | Shared compile/dependency logic | `micronaut-maven-plugin/src/main/java/io/micronaut/maven/services` | Used by heavy mojos like `RunMojo` |
 | Enforcer policy checks | `micronaut-maven-enforcer-rules/src/main/java/io/micronaut/maven/enforcer` | Currently centered on `CheckSnakeYaml`; keep cross-module policy here |
 | Cross-module integration behavior | `micronaut-maven-integration-tests/src/it` | Scenario-per-directory invoker tests |
-| CI/release delivery changes | `.github/workflows` | `snapshot.yml`, `windows-ci.yml`, and `release.yml` must stay aligned |
+| CI/release delivery changes | `.github/workflows` | `snapshot.yml` includes the Linux docker-native preflight plus the full snapshot run; keep `windows-ci.yml` and `release.yml` aligned when CI expectations move |
 | Formatting and style rules | `config/checkstyle`, `config/spotless.license.java` | Enforced in compile phase |
 
 ## CODE MAP
@@ -52,7 +52,7 @@ Micronaut Maven Plugin monorepo. Core work happens in the Maven plugin module pl
 - Root POM owns shared plugin and quality configuration; module POMs stay lean.
 - Feature packages under `io.micronaut.maven` are explicit (`openapi`, `aot`, `testresources`, `services`, `jsonschema`).
 - Integration tests are isolated scenarios under `src/it/<scenario>` with per-scenario `invoker.properties` and optional `verify.groovy`.
-- CI matrix is intentional: snapshot on Java 25, windows on Java 25, release workflow handles tagging + publish.
+- CI matrix is intentional: `snapshot.yml` carries a PR/merge-group Linux docker-native preflight plus the full Java 25 snapshot run, `windows-ci.yml` covers Java 25 on Windows, and `release.yml` handles tagging + publish.
 
 ## ANTI-PATTERNS (THIS PROJECT)
 - Do not add new plugin behavior only in examples; behavior must live in real modules and be covered by `src/it` scenarios.


### PR DESCRIPTION
## Summary
- add a selective Linux docker-native preflight job to `snapshot.yml` for pull requests and merge groups
- target the highest-risk docker-native invoker scenarios for branch and tag normalization plus custom Dockerfile regressions
- document the new preflight lane in `AGENTS.md` so CI-sensitive changes use it intentionally

## Testing
- `bash .github/scripts/check-workflow-pinning.sh`
- parse `.github/workflows/snapshot.yml` with `python3` and `yaml.safe_load`

## Notes
- The docker-native invoker scenarios were not run locally in this heartbeat; GitHub Actions should provide the end-to-end lane coverage.