### PR TITLE
Document Java 25 bootstrap for local validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Micronaut Maven Plugin monorepo. Core work happens in the Maven plugin module pl
 
 ## COMMANDS
 ```bash
+sdk env                    # applies the repo's Java 25 toolchain from .sdkmanrc when using SDKMAN!
 ./mvnw clean verify
 ./mvnw verify "-Dinvoker.test=dockerfile*"
 ./mvnw -pl micronaut-maven-integration-tests -am verify
@@ -78,5 +79,6 @@ Micronaut Maven Plugin monorepo. Core work happens in the Maven plugin module pl
 
 ## NOTES
 - If touching CI expectations, update `.github/workflows/snapshot.yml`, `.github/workflows/windows-ci.yml`, and/or `.github/workflows/release.yml` consistently.
+- Local shells may still default to Java 21 even though the repo and CI validate on Java 25; apply `.sdkmanrc` with `sdk env` or point `JAVA_HOME` at a Java 25 install before running root `./mvnw ... validate/verify` commands.
 - Paperclip worktrees may surface an untracked `.agents/` directory as local runtime scaffolding; ignore it unless the task is explicitly about agent assets or skills.
 - Keep child AGENTS.md files scoped: local rules only, no repeated root-level guidance.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,29 @@ A release is performed with the following steps:
 
 ## Contributing tips and tricks
 
+### Bootstrapping the toolchain
+
+This repository's root validation and verify commands expect Java 25. The repo includes a
+`.sdkmanrc`, but shared shells may still start on an older JDK until you apply it.
+
+If you use SDKMAN!, run this from the repository root before `./mvnw ...` commands:
+
+```shell
+sdk env
+java -version
+```
+
+If you do not use SDKMAN!, set `JAVA_HOME` to a Java 25 installation before running the same commands.
+
 ### Running integration tests
 
-You can run integration tests by executing `mvn verify`
+Run the wrapper so you inherit the repo's Maven configuration:
 
-If you want to run individual tests, you can execute `mvn verify "-Dinvoker.test=dockerfile*"`. In this case,
+```shell
+./mvnw verify
+```
+
+If you want to run individual tests, you can execute `./mvnw verify "-Dinvoker.test=dockerfile*"`. In this case,
 `dockerfile*` will match all test projects under `src/it` folder with a name that starts with "dockerfile".
 
 ### Debugging
@@ -40,7 +58,7 @@ If you want to run individual tests, you can execute `mvn verify "-Dinvoker.test
 To debug the plugin, you first need to publish a snapshot to your Maven local:
 
 ```shell
-$ mvn install
+./mvnw install
 ```
 
 You can skip execution of integration tests by adding `-Dinvoker.skip=true` to the command line.
@@ -67,5 +85,5 @@ Then in your IDE, attach a remote debugger to port 8000.
 ### Preparing for a new minor/major version
 
 ```shell
-mvn release:update-versions -DautoVersionSubmodules=true -DdevelopmentVersion=X.Y.Z-SNAPSHOT
+./mvnw release:update-versions -DautoVersionSubmodules=true -DdevelopmentVersion=X.Y.Z-SNAPSHOT
 ```


### PR DESCRIPTION
## Summary
- add a contributor bootstrap note explaining that root validation commands require Java 25
- point contributors at `.sdkmanrc` via `sdk env` and note the `JAVA_HOME` fallback
- switch the README root command examples to `./mvnw` and mirror the guidance in `AGENTS.md`

## Validation
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env && java -version && ./mvnw -q -DskipTests -Dinvoker.skip=true validate`