### PR TITLE
Add a CI-sensitive local preflight wrapper

### DIFF
--- a/.github/scripts/ci-sensitive-preflight.sh
+++ b/.github/scripts/ci-sensitive-preflight.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
+windows_script_path="$repo_root/.github/scripts/windows-preflight.cmd"
+
+echo "Running workflow pinning preflight..."
+bash "$script_dir/check-workflow-pinning.sh"
+echo "Workflow pinning preflight passed."
+
+if command -v cmd.exe >/dev/null 2>&1 && [[ -f "$windows_script_path" ]]; then
+  echo "Running Windows wrapper preflight..."
+  (
+    cd "$repo_root"
+    cmd.exe //c ".github\\scripts\\windows-preflight.cmd"
+  )
+  echo "Windows wrapper preflight passed."
+else
+  cat <<'EOF'
+Windows wrapper preflight still needs a Windows shell.
+
+- Run `.\.github\scripts\windows-preflight.cmd` in a Windows shell, or
+- trigger the `Windows Preflight` GitHub Actions workflow before review handoff.
+EOF
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ sdk env                    # applies the repo's Java 25 toolchain from .sdkmanrc
 ./mvnw spotless:check checkstyle:check
 ./mvnw -pl micronaut-maven-plugin -am test
 ./mvnw release:prepare -DdryRun=true
+bash .github/scripts/ci-sensitive-preflight.sh
 bash .github/scripts/check-workflow-pinning.sh
 .\.github\scripts\windows-preflight.cmd
 ```
@@ -83,5 +84,5 @@ bash .github/scripts/check-workflow-pinning.sh
 - If touching CI expectations, update `.github/workflows/snapshot.yml`, `.github/workflows/windows-ci.yml`, and/or `.github/workflows/release.yml` consistently.
 - Local shells may still default to Java 21 even though the repo and CI validate on Java 25; apply `.sdkmanrc` with `sdk env` or point `JAVA_HOME` at a Java 25 install before running root `./mvnw ... validate/verify` commands.
 - Paperclip worktrees may surface an untracked `.agents/` directory as local runtime scaffolding; ignore it unless the task is explicitly about agent assets or skills.
-- If a change touches `.github/workflows`, `.github/scripts`, `.mvn/wrapper`, `mvnw`, or `mvnw.cmd`, run the workflow-pinning check and the Windows preflight before handoff. Use the `Windows Preflight` workflow if you do not have local Windows access.
+- If a change touches `.github/workflows`, `.github/scripts`, `.mvn/wrapper`, `mvnw`, or `mvnw.cmd`, start with `bash .github/scripts/ci-sensitive-preflight.sh` before handoff. It always runs workflow pinning and, when `cmd.exe` is available, dispatches the Windows wrapper preflight; otherwise use the `Windows Preflight` workflow for the Windows-only leg.
 - Keep child AGENTS.md files scoped: local rules only, no repeated root-level guidance.

--- a/README.md
+++ b/README.md
@@ -55,21 +55,27 @@ If you want to run individual tests, you can execute `./mvnw verify "-Dinvoker.t
 
 ### Windows-sensitive preflight
 
-If your change touches GitHub Actions workflows, `.github/scripts`, `.mvn/wrapper`, `mvnw`, or `mvnw.cmd`, run the lightweight Windows preflight before review handoff.
+If your change touches GitHub Actions workflows, `.github/scripts`, `.mvn/wrapper`, `mvnw`, or `mvnw.cmd`, start with the repo-owned CI-sensitive preflight wrapper before review handoff:
 
-On Windows, execute:
+```shell
+bash .github/scripts/ci-sensitive-preflight.sh
+```
+
+The wrapper always runs workflow pinning locally. In a Windows shell that exposes `cmd.exe`, it also dispatches the lightweight wrapper/bootstrap validation automatically.
+
+If you want to run the Windows-specific step directly, execute:
 
 ```shell
 .\.github\scripts\windows-preflight.cmd
 ```
 
-On any platform, also verify workflow pinning:
+If you want to run the workflow pinning step directly, execute:
 
 ```shell
 bash .github/scripts/check-workflow-pinning.sh
 ```
 
-If you do not have a Windows shell locally, open a draft PR or run the `Windows Preflight` workflow manually to get the same wrapper/bootstrap check on `windows-latest` without waiting for the full Windows CI job.
+If you do not have a Windows shell locally, the wrapper will remind you to open a draft PR or run the `Windows Preflight` workflow manually to get the same wrapper/bootstrap check on `windows-latest` without waiting for the full Windows CI job.
 
 ### Debugging
 


### PR DESCRIPTION
## Summary
- add a single bash entry point for workflow, wrapper, and bootstrap-sensitive local preflight
- keep workflow pinning as the first local check and dispatch the existing Windows wrapper preflight when `cmd.exe` is available
- update contributor guidance to point to the single wrapper command first

## Verification
- bash .github/scripts/ci-sensitive-preflight.sh
- bash -n .github/scripts/ci-sensitive-preflight.sh
- git diff --check