### PR TITLE
build: restore explicit GitHub Actions permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release
 on:
   release:
     types: [published]
+
+# Release mutations are performed with the dedicated GH_TOKEN secret, not the default workflow token.
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -99,7 +103,7 @@ jobs:
         run: |
           release_url=`cat $GITHUB_EVENT_PATH | jq '.release.url' | sed -e 's/^"\(.*\)"$/\1/g'`
           echo $release_url
-          curl -s --request PATCH -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" $release_url --data "{\"draft\": false}"
+          curl -s --request PATCH -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Content-Type: application/json" $release_url --data "{\"draft\": false}"
 
       - name: "↩️ Rollback release"
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,14 @@ jobs:
       - name: "🚪 Close release"
         if: success()
         run: |
-          release_url=`cat $GITHUB_EVENT_PATH | jq '.release.url' | sed -e 's/^"\(.*\)"$/\1/g'`
-          echo $release_url
-          curl -s --request PATCH -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Content-Type: application/json" $release_url --data "{\"draft\": false}"
+          release_url="$(jq -er '.release.url' "$GITHUB_EVENT_PATH")"
+          echo "$release_url"
+          curl --fail-with-body --silent --show-error \
+            --request PATCH \
+            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "$release_url" \
+            --data '{"draft": false}'
 
       - name: "↩️ Rollback release"
         if: failure()

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Keep the default workflow token read-only; individual jobs opt into writes when needed.
+permissions:
+  contents: read
+
 jobs:
   workflow-hardening:
     runs-on: ubuntu-latest
@@ -34,6 +38,9 @@ jobs:
     needs:
       - workflow-hardening
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -129,6 +136,9 @@ jobs:
     needs:
       - workflow-hardening
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: ['25']

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Windows CI only needs repository read access for checkout and setup actions.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- restore explicit top-level `permissions` blocks for the snapshot and Windows workflows
- scope write access down to the two snapshot jobs that publish JUnit checks
- keep the release workflow on an empty default token permission set and use the dedicated `GH_TOKEN` secret for the release-closing API call

## Verification
- `bash .github/scripts/ci-sensitive-preflight.sh`

## Notes
- Windows wrapper preflight still requires either a local Windows shell or the `Windows Preflight` GitHub Actions workflow before merge.