### PR TITLE
Harden Lambda Dockerfile inputs on 5.0.x

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.aarch64
@@ -1,7 +1,9 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS graalvm
+# Pin the amazonlinux:2023-minimal builder digest so the Lambda native-image build starts from an explicit base image.
+FROM public.ecr.aws/amazonlinux/amazonlinux@sha256:45c6144a8aedb7e7981ffd953d3af02998d5248f963305b869c820e1d30353de AS graalvm
 ENV LANG=en_US.UTF-8
-RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
-RUN curl -4 -L 'https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-aarch64_bin.tar.gz' -o /tmp/graalvm.tar.gz \
+RUN dnf update -y && dnf install -y coreutils-single gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
+RUN curl -4 -fsSL "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-aarch64_bin.tar.gz" -o "/tmp/graalvm.tar.gz" \
+    && echo "b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71  /tmp/graalvm.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/lib/graalvm \
     && tar -zxf /tmp/graalvm.tar.gz -C /usr/lib/graalvm --strip-components 1 \
     && rm -rf /tmp/*
@@ -15,12 +17,13 @@ COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.function.aws.runtime.MicronautLambdaRuntime" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+# Keep the runtime stage on the same pinned amazonlinux:2023-minimal digest as the builder base image.
+FROM public.ecr.aws/amazonlinux/amazonlinux@sha256:45c6144a8aedb7e7981ffd953d3af02998d5248f963305b869c820e1d30353de
 WORKDIR /function
 RUN dnf update -y && dnf install -y zip && dnf clean all
 COPY --from=graalvm /home/app/application /function/func
 RUN printf '%s\n' '#!/bin/sh' 'set -euo pipefail' './func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd) -Dio.netty.noUnsafe=true -Dio.netty.noPreferDirect=false' > bootstrap
-RUN chmod 777 bootstrap
-RUN chmod 777 func
+RUN chmod 555 bootstrap
+RUN chmod 555 func
 RUN zip -j function.zip bootstrap func
 ENTRYPOINT ["/function/func"]

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-lambda/Dockerfile.25.amd64
@@ -1,7 +1,9 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS graalvm
+# Pin the amazonlinux:2023-minimal builder digest so the Lambda native-image build starts from an explicit base image.
+FROM public.ecr.aws/amazonlinux/amazonlinux@sha256:45c6144a8aedb7e7981ffd953d3af02998d5248f963305b869c820e1d30353de AS graalvm
 ENV LANG=en_US.UTF-8
-RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
-RUN curl -4 -L 'https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-x64_bin.tar.gz' -o /tmp/graalvm.tar.gz \
+RUN dnf update -y && dnf install -y coreutils-single gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
+RUN curl -4 -fsSL "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz" -o "/tmp/graalvm.tar.gz" \
+    && echo "e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0  /tmp/graalvm.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/lib/graalvm \
     && tar -zxf /tmp/graalvm.tar.gz -C /usr/lib/graalvm --strip-components 1 \
     && rm -rf /tmp/*
@@ -15,12 +17,13 @@ COPY native/generated /home/app/
 COPY *.args /home/app/graalvm-native-image.args
 RUN native-image @/home/app/graalvm-native-image.args -H:Class="io.micronaut.function.aws.runtime.MicronautLambdaRuntime" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+# Keep the runtime stage on the same pinned amazonlinux:2023-minimal digest as the builder base image.
+FROM public.ecr.aws/amazonlinux/amazonlinux@sha256:45c6144a8aedb7e7981ffd953d3af02998d5248f963305b869c820e1d30353de
 WORKDIR /function
 RUN dnf update -y && dnf install -y zip && dnf clean all
 COPY --from=graalvm /home/app/application /function/func
 RUN printf '%s\n' '#!/bin/sh' 'set -euo pipefail' './func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd) -Dio.netty.noUnsafe=true -Dio.netty.noPreferDirect=false' > bootstrap
-RUN chmod 777 bootstrap
-RUN chmod 777 func
+RUN chmod 555 bootstrap
+RUN chmod 555 func
 RUN zip -j function.zip bootstrap func
 ENTRYPOINT ["/function/func"]

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -70,13 +70,22 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "x64";
     public static final String ORACLE_CLOUD_FUNCTION_DEFAULT_CMD = "CMD [\"io.micronaut.oraclecloud.function.http.HttpFunction::handleRequest\"]";
-    public static final String GDS_DOWNLOAD_URL = "https://gds.oracle.com/download/graal/%s/latest-gftc/graalvm-jdk-%s_linux-%s_bin.tar.gz";
+    public static final String GRAALVM_DOWNLOAD_URL = "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-%s/graalvm-community-jdk-%s_linux-%s_bin.tar.gz";
     public static final String LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER = "${LAMBDA_BOOTSTRAP_DOCKER_COMMAND}";
     static final String JIB_FROM_IMAGE_PROPERTY = "jib.from.image";
     private static final String DEPENDENCY_DIRECTORY = "dependency";
     private static final String RELEASE_DEPENDENCY_DIRECTORY = "release";
     private static final String SNAPSHOT_DEPENDENCY_DIRECTORY = "snapshot";
-    private static final NavigableSet<Integer> GRAALVM_VERSIONS = new TreeSet<>(Set.of(25));
+    private static final Map<Integer, GraalVmRelease> GRAALVM_RELEASES = Map.of(
+        25, new GraalVmRelease(
+            "25.0.2",
+            Map.of(
+                X86_64_ARCH, "e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0",
+                ARM_ARCH, "b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71"
+            )
+        )
+    );
+    private static final NavigableSet<Integer> GRAALVM_VERSIONS = new TreeSet<>(GRAALVM_RELEASES.keySet());
     private static final List<String> DEFAULT_LAMBDA_BOOTSTRAP_ARGUMENTS = List.of(
         "-XX:MaximumHeapSizePercent=80",
         "-Dio.netty.allocator.numDirectArenas=0",
@@ -221,9 +230,19 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
      * @return the GraalVM download URL depending on the Java version.
      */
     protected String graalVmDownloadUrl() {
-        Integer version = resolveGraalVersion();
+        var release = resolveGraalVmRelease();
+        return GRAALVM_DOWNLOAD_URL.formatted(release.version(), release.version(), graalVmArch());
+    }
 
-        return GDS_DOWNLOAD_URL.formatted(version, version, graalVmArch());
+    /**
+     * @return the expected SHA-256 checksum for the pinned GraalVM download.
+     */
+    protected String graalVmDownloadSha256() {
+        var checksum = resolveGraalVmRelease().checksumsByArch().get(graalVmArch());
+        if (checksum == null) {
+            throw new IllegalStateException("Unsupported GraalVM architecture: " + graalVmArch());
+        }
+        return checksum;
     }
 
     private Integer resolveGraalVersion() {
@@ -231,6 +250,15 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         Integer version = GRAALVM_VERSIONS.floor(target);
 
         return version != null ? version : GRAALVM_VERSIONS.first();
+    }
+
+    private GraalVmRelease resolveGraalVmRelease() {
+        Integer graalVersion = resolveGraalVersion();
+        GraalVmRelease release = GRAALVM_RELEASES.get(graalVersion);
+        if (release == null) {
+            throw new IllegalStateException("Unsupported GraalVM version: " + graalVersion + ". Supported versions are: " + GRAALVM_VERSIONS);
+        }
+        return release;
     }
 
     /**
@@ -608,6 +636,9 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         } else {
             com.google.common.io.Files.asCharSink(dockerfile, Charset.defaultCharset(), FileWriteMode.APPEND).write(System.lineSeparator() + ORACLE_CLOUD_FUNCTION_DEFAULT_CMD);
         }
+    }
+
+    private record GraalVmRelease(String version, Map<String, String> checksumsByArch) {
     }
 
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -160,7 +160,8 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         //   - For function apps: com.example.BookLambdaRuntime
         BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments, () -> dockerService.buildImageCmd()
             .withDockerfile(dockerfile)
-            .withBuildArg("GRAALVM_DOWNLOAD_URL", graalVmDownloadUrl()));
+            .withBuildArg("GRAALVM_DOWNLOAD_URL", graalVmDownloadUrl())
+            .withBuildArg("GRAALVM_DOWNLOAD_SHA256", graalVmDownloadSha256()));
         buildImageCmd.withBuildArg("CLASS_NAME", escapeClassNameBuildArg(mainClass));
         String imageId = dockerService.buildImage(buildImageCmd);
         File functionZip = dockerService.copyFromContainer(imageId, "/function/function.zip");

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -225,8 +225,11 @@ public class DockerfileMojo extends AbstractDockerMojo {
         if (containsPlaceholder(line, "BASE_JAVA_IMAGE")) {
             return line.replace("${BASE_JAVA_IMAGE}", validateImageReference("base Java image", getBaseImage()));
         }
+        if (containsPlaceholder(line, "GRAALVM_DOWNLOAD_SHA256")) {
+            return line.replace("${GRAALVM_DOWNLOAD_SHA256}", validateDockerfileValue("GraalVM download SHA-256", graalVmDownloadSha256()));
+        }
         if (containsPlaceholder(line, "GRAALVM_DOWNLOAD_URL")) {
-            return line.replace("${GRAALVM_DOWNLOAD_URL}", shellLiteral("GraalVM download URL", validateDownloadUrl("GraalVM download URL", graalVmDownloadUrl())));
+            return line.replace("${GRAALVM_DOWNLOAD_URL}", validateDownloadUrl("GraalVM download URL", graalVmDownloadUrl()));
         }
         if (containsPlaceholder(line, CLASS_NAME_PLACEHOLDER)) {
             return replaceClassName(line);
@@ -272,6 +275,7 @@ public class DockerfileMojo extends AbstractDockerMojo {
         return "BASE_IMAGE_RUN".equals(argName)
             || "BASE_JAVA_IMAGE".equals(argName)
             || "BASE_IMAGE".equals(argName)
+            || "GRAALVM_DOWNLOAD_SHA256".equals(argName)
             || "GRAALVM_DOWNLOAD_URL".equals(argName)
             || CLASS_NAME_PLACEHOLDER.equals(argName)
             || "PORTS".equals(argName);

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileNativeLambda
@@ -1,8 +1,11 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS graalvm
+# Pin the amazonlinux:2023-minimal builder digest so the Lambda native-image build starts from an explicit base image.
+FROM public.ecr.aws/amazonlinux/amazonlinux@sha256:45c6144a8aedb7e7981ffd953d3af02998d5248f963305b869c820e1d30353de AS graalvm
 ENV LANG=en_US.UTF-8
-RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
+RUN dnf update -y && dnf install -y coreutils-single gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
 ARG GRAALVM_DOWNLOAD_URL
-RUN curl -4 -L ${GRAALVM_DOWNLOAD_URL} -o /tmp/graalvm.tar.gz \
+ARG GRAALVM_DOWNLOAD_SHA256
+RUN curl -4 -fsSL "${GRAALVM_DOWNLOAD_URL}" -o "/tmp/graalvm.tar.gz" \
+    && echo "${GRAALVM_DOWNLOAD_SHA256}  /tmp/graalvm.tar.gz" | sha256sum -c - \
     && mkdir -p /usr/lib/graalvm \
     && tar -zxf /tmp/graalvm.tar.gz -C /usr/lib/graalvm --strip-components 1 \
     && rm -rf /tmp/*
@@ -17,12 +20,13 @@ COPY *.args /home/app/graalvm-native-image.args
 ARG CLASS_NAME
 RUN native-image @/home/app/graalvm-native-image.args -H:Class="${CLASS_NAME}" -H:Name=application -cp "/home/app/libs/release/*:/home/app/libs/snapshot/*:/home/app/classes/"
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+# Keep the runtime stage on the same pinned amazonlinux:2023-minimal digest as the builder base image.
+FROM public.ecr.aws/amazonlinux/amazonlinux@sha256:45c6144a8aedb7e7981ffd953d3af02998d5248f963305b869c820e1d30353de
 WORKDIR /function
 RUN dnf update -y && dnf install -y zip && dnf clean all
 COPY --from=graalvm /home/app/application /function/func
 RUN ${LAMBDA_BOOTSTRAP_DOCKER_COMMAND}
-RUN chmod 777 bootstrap
-RUN chmod 777 func
+RUN chmod 555 bootstrap
+RUN chmod 555 func
 RUN zip -j function.zip bootstrap func
 ENTRYPOINT ["/function/func"]

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
+import static io.micronaut.maven.AbstractDockerMojo.ARM_ARCH;
 import static io.micronaut.maven.AbstractDockerMojo.X86_64_ARCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -48,12 +49,12 @@ class DockerNativeMojoTest {
 
     @ParameterizedTest
     @CsvSource({
-            "24,https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-x64_bin.tar.gz",
-            "25,https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-x64_bin.tar.gz",
-            "26,https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-x64_bin.tar.gz"
+            "24,https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz,e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0",
+            "25,https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz,e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0",
+            "26,https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz,e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0"
     })
     @SetSystemProperty(key = "os.arch", value = X86_64_ARCH)
-    void testGraalVmDownloadUrl(String javaVersion, String expectedUrl) throws URISyntaxException, IOException, InterruptedException {
+    void testGraalVmDownloadUrl(String javaVersion, String expectedUrl, String expectedSha256) throws URISyntaxException, IOException, InterruptedException {
         var project = mock(MavenProject.class);
         var session = mock(MavenSession.class);
         var execution = mock(MojoExecution.class);
@@ -68,8 +69,10 @@ class DockerNativeMojoTest {
         var mojo = new DockerNativeMojo(project, null, null, null, session, execution);
 
         var actualUrl = mojo.graalVmDownloadUrl();
+        var actualSha256 = mojo.graalVmDownloadSha256();
 
         assertEquals(expectedUrl, actualUrl);
+        assertEquals(expectedSha256, actualSha256);
 
         var client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.NORMAL)
@@ -100,9 +103,54 @@ class DockerNativeMojoTest {
         var mojo = new DockerNativeMojo(project, null, null, null, session, execution);
 
         var actualUrl = mojo.graalVmDownloadUrl();
+        var actualSha256 = mojo.graalVmDownloadSha256();
 
-        var expectedUrl = "https://gds.oracle.com/download/graal/25/latest-gftc/graalvm-jdk-25_linux-x64_bin.tar.gz";
+        var expectedUrl = "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz";
+        var expectedSha256 = "e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0";
         assertEquals(expectedUrl, actualUrl);
+        assertEquals(expectedSha256, actualSha256);
+    }
+
+    @Test
+    @SetSystemProperty(key = "os.arch", value = ARM_ARCH)
+    void testGraalVmDownloadUrlForArm() {
+        var project = mock(MavenProject.class);
+        var session = mock(MavenSession.class);
+        var execution = mock(MojoExecution.class);
+        when(session.getCurrentProject()).thenReturn(project);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getSystemProperties()).thenReturn(new Properties());
+        when(project.getProperties()).thenReturn(new Properties());
+
+        var mojo = new DockerNativeMojo(project, null, null, null, session, execution);
+
+        var actualUrl = mojo.graalVmDownloadUrl();
+        var actualSha256 = mojo.graalVmDownloadSha256();
+
+        assertEquals("https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-aarch64_bin.tar.gz", actualUrl);
+        assertEquals("b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71", actualSha256);
+    }
+
+    @Test
+    void testGraalVmDownloadSha256RejectsUnsupportedResolvedArch() {
+        var project = mock(MavenProject.class);
+        var session = mock(MavenSession.class);
+        var execution = mock(MojoExecution.class);
+        when(session.getCurrentProject()).thenReturn(project);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getSystemProperties()).thenReturn(new Properties());
+        when(project.getProperties()).thenReturn(new Properties());
+
+        var mojo = new DockerNativeMojo(project, null, null, null, session, execution) {
+            @Override
+            protected String graalVmArch() {
+                return "sparc64";
+            }
+        };
+
+        var ex = assertThrows(IllegalStateException.class, mojo::graalVmDownloadSha256);
+
+        assertEquals("Unsupported GraalVM architecture: sparc64", ex.getMessage());
     }
 
     @Test

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
@@ -249,11 +249,45 @@ class DockerfileMojoTest {
         );
         mojo.micronautRuntime = "netty";
 
-        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "RUN curl -4 -L ${GRAALVM_DOWNLOAD_URL} -o /tmp/graalvm.tar.gz");
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "RUN curl -4 -fsSL \"${GRAALVM_DOWNLOAD_URL}\" -o \"/tmp/graalvm.tar.gz\"");
 
         invokeProcessDockerfile(mojo, dockerfile);
 
-        assertTrue(Files.readString(dockerfile).contains("-L " + AbstractDockerMojo.shellLiteral("GraalVM download URL", mojo.graalVmDownloadUrl()) + " -o"));
+        assertTrue(Files.readString(dockerfile).contains("-fsSL \"" + mojo.graalVmDownloadUrl() + "\" -o \"/tmp/graalvm.tar.gz\""));
+    }
+
+    @Test
+    void processDockerfileInlinesLambdaDownloadChecksum(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        project.getProperties().setProperty("maven.compiler.release", "25");
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/example/builder:1.0"));
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "lambda";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), String.join(System.lineSeparator(),
+            "ARG GRAALVM_DOWNLOAD_SHA256",
+            "RUN echo \"${GRAALVM_DOWNLOAD_SHA256}  /tmp/graalvm.tar.gz\" | sha256sum -c -"
+        ));
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertEquals(
+            java.util.List.of(
+                "RUN echo \"" + mojo.graalVmDownloadSha256() + "  /tmp/graalvm.tar.gz\" | sha256sum -c -"
+            ),
+            Files.readAllLines(dockerfile)
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary

- pin the Lambda GraalVM download to a specific GitHub Community release and verify it with SHA-256
- tighten generated Lambda artifact permissions from `0777` to `0555`
- align the native Lambda invoker fixtures and targeted tests with the hardened template

## Verification

- `./mvnw -pl micronaut-maven-plugin -am -Dtest=DockerNativeMojoTest,DockerfileMojoTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-integration-tests -am -Dinvoker.test=dockerfile-docker-native-lambda verify`

Closes #1636
