### PR TITLE
Pin CRaC checkpoint JDK downloads on 5.0.x

### DIFF
--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
@@ -2,35 +2,23 @@ FROM ubuntu:18.04
 
 ARG CRAC_ARCH
 ARG CRAC_JDK_VERSION
+ARG CRAC_JDK_SHA256
+ARG CRAC_JDK_URL
 ARG CRAC_OS
 WORKDIR /home/app
 
 # Add required libraries
 RUN apt-get update && apt-get install -y \
         curl \
-        jq \
         libnl-3-200 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install latest CRaC OpenJDK
-RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
-RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&os=${CRAC_OS}&arch=${CRAC_ARCH}&crac_supported=true&java_package_type=jdk&archive_type=tar.gz&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
-    && if [ "$release_id" = "null" ]; then \
-           echo "No CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH found"; \
-           exit 1; \
-       fi \
-    && details=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/$release_id" -H "accept: application/json") \
-    && name=$(echo "$details" | jq -r '.name') \
-    && url=$(echo "$details" | jq -r '.download_url') \
-    && hash=$(echo "$details" | jq -r '.sha256_hash') \
-    && echo "Downloading $name from $url" \
-    && curl -LJOH 'Accept: application/octet-stream' "$url" >&2 \
-    && file_sha=$(sha256sum -b "$name" | cut -d' ' -f 1) \
-    && if [ "$file_sha" != "$hash" ]; then \
-           echo "SHA256 hash mismatch: $file_sha != $hash"; \
-           exit 1; \
-       fi \
-    && echo "SHA256 hash matches: $file_sha == $hash" >&2 \
+# Install pinned CRaC OpenJDK
+RUN echo Installing pinned CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH from $CRAC_JDK_URL
+RUN name=$(basename "$CRAC_JDK_URL") \
+    && echo "Downloading $name from $CRAC_JDK_URL" \
+    && curl -fsSL "$CRAC_JDK_URL" -o "$name" \
+    && echo "$CRAC_JDK_SHA256  $name" | sha256sum -c - \
     && tar xzf "$name" \
     && mv ${name%%.tar.gz} /azul-crac-jdk \
     && rm "$name"

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
@@ -15,13 +15,21 @@ RUN apt-get update && apt-get install -y \
 
 # Install pinned CRaC OpenJDK
 RUN echo Installing pinned CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH from $CRAC_JDK_URL
-RUN name=$(basename "$CRAC_JDK_URL") \
-    && echo "Downloading $name from $CRAC_JDK_URL" \
-    && curl -fsSL "$CRAC_JDK_URL" -o "$name" \
-    && echo "$CRAC_JDK_SHA256  $name" | sha256sum -c - \
-    && tar xzf "$name" \
-    && mv ${name%%.tar.gz} /azul-crac-jdk \
-    && rm "$name"
+RUN archive=/tmp/crac-jdk.tar.gz \
+    && extract_dir=$(mktemp -d) \
+    && echo "Downloading CRaC JDK from $CRAC_JDK_URL" \
+    && curl -fsSL "$CRAC_JDK_URL" -o "$archive" \
+    && echo "$CRAC_JDK_SHA256  $archive" | sha256sum -c - \
+    && tar xzf "$archive" -C "$extract_dir" \
+    && top_level_count=$(find "$extract_dir" -mindepth 1 -maxdepth 1 | wc -l) \
+       && if [ "$top_level_count" -eq 1 ] && [ -d "$(find "$extract_dir" -mindepth 1 -maxdepth 1)" ]; then \
+           mv "$(find "$extract_dir" -mindepth 1 -maxdepth 1)" /azul-crac-jdk; \
+       else \
+           mkdir -p /azul-crac-jdk \
+           && find "$extract_dir" -mindepth 1 -maxdepth 1 -exec mv {} /azul-crac-jdk/ \; \
+       fi \
+    && rm -f "$archive" \
+    && rm -rf "$extract_dir"
 
 # Copy layers
 COPY classes /home/app/classes

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/Dockerfile.crac.checkpoint
@@ -26,7 +26,7 @@ RUN archive=/tmp/crac-jdk.tar.gz \
            mv "$(find "$extract_dir" -mindepth 1 -maxdepth 1)" /azul-crac-jdk; \
        else \
            mkdir -p /azul-crac-jdk \
-           && find "$extract_dir" -mindepth 1 -maxdepth 1 -exec mv {} /azul-crac-jdk/ \; \
+           && find "$extract_dir" -mindepth 1 -maxdepth 1 -exec mv {} /azul-crac-jdk/ \; ; \
        fi \
     && rm -f "$archive" \
     && rm -rf "$extract_dir"

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-crac/verify.groovy
@@ -2,6 +2,8 @@ File checkpointDockerfile = new File("$basedir/target", "Dockerfile.crac.checkpo
 File expectedCheckpointDockerfile = new File(basedir, "Dockerfile.crac.checkpoint")
 
 assert checkpointDockerfile.text == expectedCheckpointDockerfile.text
+assert !checkpointDockerfile.text.contains("api.azul.com/metadata")
+assert !checkpointDockerfile.text.contains("latest=true")
 
 File dockerfile = new File("$basedir/target", "Dockerfile")
 File expectedDockerfile = new File(basedir, "Dockerfile")

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -498,6 +498,9 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
             if (!uri.isAbsolute()) {
                 throw new MojoExecutionException(source + " must be an absolute URL: " + sanitized);
             }
+            if (uri.getUserInfo() != null) {
+                throw new MojoExecutionException(source + " must not include embedded credentials");
+            }
         } catch (URISyntaxException e) {
             throw new MojoExecutionException(source + " is not a valid URL: " + sanitized, e);
         }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerCracMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerCracMojo.java
@@ -256,10 +256,10 @@ public class DockerCracMojo extends AbstractDockerMojo {
         if (architecture == null) {
             return null;
         }
-        if (ARM_ARCH.equals(architecture)) {
-            return architecture;
-        }
-        return X86_64_ARCH;
+        return switch (architecture) {
+            case ARM_ARCH, "arm64" -> ARM_ARCH;
+            default -> X86_64_ARCH;
+        };
     }
 
     private String buildCheckpointDockerfile() throws IOException, MavenFilteringException, MojoExecutionException {
@@ -358,7 +358,14 @@ public class DockerCracMojo extends AbstractDockerMojo {
                 "Unsupported CRaC JDK version '" + cracJavaVersion + "'. Expected a numeric Java major version or release."
             );
         }
-        return Integer.parseInt(majorVersion.toString());
+        try {
+            return Integer.parseInt(majorVersion.toString());
+        } catch (NumberFormatException e) {
+            throw new MojoExecutionException(
+                "Unsupported CRaC JDK version '" + cracJavaVersion + "'. Expected a numeric Java major version or release.",
+                e
+            );
+        }
     }
 
     private static boolean hasText(String value) {
@@ -435,7 +442,11 @@ public class DockerCracMojo extends AbstractDockerMojo {
                 try (Writer writer = Files.newBufferedWriter(outputPath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
                     IOUtils.copy(mavenReaderFilter.filter(req), writer);
                 }
-                Files.setPosixFilePermissions(outputPath, POSIX_FILE_PERMISSIONS);
+                try {
+                    Files.setPosixFilePermissions(outputPath, POSIX_FILE_PERMISSIONS);
+                } catch (UnsupportedOperationException ignored) {
+                    // Non-POSIX file systems such as Windows cannot apply POSIX permissions locally.
+                }
             }
         }
     }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerCracMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerCracMojo.java
@@ -48,7 +48,11 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * <p>Implementation of the <code>docker-crac</code> packaging.</p>
@@ -85,12 +89,57 @@ public class DockerCracMojo extends AbstractDockerMojo {
     public static final String CRAC_ARCHITECTURE = "crac.arch";
 
     public static final String CRAC_OS = "crac.os";
+    public static final String CRAC_JDK_DOWNLOAD_URL_PROPERTY = "crac.jdk.download.url";
+    public static final String CRAC_JDK_DOWNLOAD_SHA256_PROPERTY = "crac.jdk.download.sha256";
     public static final String DEFAULT_CRAC_OS = "linux-glibc";
 
     public static final String DEFAULT_BASE_IMAGE = "ubuntu:22.04";
 
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "amd64";
+    private static final Set<Integer> SUPPORTED_CRAC_JDK_VERSIONS = new TreeSet<>(Set.of(17, 21, 23, 25));
+    private static final Map<Integer, CracJdkRelease> CRAC_JDK_RELEASES = Map.of(
+        17, new CracJdkRelease(
+            Map.of(
+                X86_64_ARCH, "https://cdn.azul.com/zulu/bin/zulu17.64.17-ca-crac-jdk17.0.18-linux_x64.tar.gz",
+                ARM_ARCH, "https://cdn.azul.com/zulu/bin/zulu17.64.17-ca-crac-jdk17.0.18-linux_aarch64.tar.gz"
+            ),
+            Map.of(
+                X86_64_ARCH, "51f4cebe3832bb30a7cff905b1e7b94951ef221c93efe3379702fd726c4c5bc7",
+                ARM_ARCH, "7a9c373e3c2f1b714ad361a7ee73d3919b2ab568eb62d6ffa13864ec7c370ead"
+            )
+        ),
+        21, new CracJdkRelease(
+            Map.of(
+                X86_64_ARCH, "https://cdn.azul.com/zulu/bin/zulu21.48.17-ca-crac-jdk21.0.10-linux_x64.tar.gz",
+                ARM_ARCH, "https://cdn.azul.com/zulu/bin/zulu21.48.17-ca-crac-jdk21.0.10-linux_aarch64.tar.gz"
+            ),
+            Map.of(
+                X86_64_ARCH, "b8e4ab4f2919deda3737d381d921d1b6f7bf694348b22c14115a10daae7a91f6",
+                ARM_ARCH, "17c88f5112d9782255826fb860217a7d56686451e1629a98695ffd63718d3366"
+            )
+        ),
+        23, new CracJdkRelease(
+            Map.of(
+                X86_64_ARCH, "https://cdn.azul.com/zulu/bin/zulu23.32.11-ca-crac-jdk23.0.2-linux_x64.tar.gz",
+                ARM_ARCH, "https://cdn.azul.com/zulu/bin/zulu23.32.11-ca-crac-jdk23.0.2-linux_aarch64.tar.gz"
+            ),
+            Map.of(
+                X86_64_ARCH, "d94ad46ed2b8e9f10db01e2c5b09aef749e81c80e4179394fa37ccac4e2d709c",
+                ARM_ARCH, "ff22ab00c1f06fc0a9dc616f175e71ed3366e664a8827f87e3e69ac5590ffe07"
+            )
+        ),
+        25, new CracJdkRelease(
+            Map.of(
+                X86_64_ARCH, "https://cdn.azul.com/zulu/bin/zulu25.32.23-ca-crac-jdk25.0.2-linux_x64.tar.gz",
+                ARM_ARCH, "https://cdn.azul.com/zulu/bin/zulu25.32.23-ca-crac-jdk25.0.2-linux_aarch64.tar.gz"
+            ),
+            Map.of(
+                X86_64_ARCH, "2ebb784450f158e628f5717034aac3126591a6ef03498290297f2f46d8f886b1",
+                ARM_ARCH, "83f4621c04cf8f8d2ce8ce82e7505b85897d9e5b4cadb5472a1c679bc27a41bd"
+            )
+        )
+    );
 
     private static final EnumSet<PosixFilePermission> POSIX_FILE_PERMISSIONS = EnumSet.of(
         PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
@@ -135,6 +184,19 @@ public class DockerCracMojo extends AbstractDockerMojo {
     @Parameter(property = DockerCracMojo.CRAC_OS, defaultValue = DEFAULT_CRAC_OS)
     private String cracOs;
 
+    /**
+     * Explicit CRaC JDK download URL override. Must be paired with {@value #CRAC_JDK_DOWNLOAD_SHA256_PROPERTY}.
+     */
+    @Parameter(property = CRAC_JDK_DOWNLOAD_URL_PROPERTY)
+    private String cracJdkDownloadUrl;
+
+    /**
+     * Explicit SHA-256 checksum override for the CRaC JDK download. Must be paired with
+     * {@value #CRAC_JDK_DOWNLOAD_URL_PROPERTY}.
+     */
+    @Parameter(property = CRAC_JDK_DOWNLOAD_SHA256_PROPERTY)
+    private String cracJdkDownloadSha256;
+
     @SuppressWarnings("CdiInjectionPointsInspection")
     @Inject
     public DockerCracMojo(
@@ -175,7 +237,7 @@ public class DockerCracMojo extends AbstractDockerMojo {
         }
     }
 
-    private void buildDockerCrac() throws IOException, InvalidImageReferenceException, MavenFilteringException {
+    private void buildDockerCrac() throws IOException, InvalidImageReferenceException, MavenFilteringException, MojoExecutionException {
         String checkpointImage = buildCheckpointDockerfile();
         getLog().info("CRaC Checkpoint image: " + checkpointImage);
         File checkpointDir = new File(mavenProject.getBuild().getDirectory(), "cr");
@@ -200,7 +262,7 @@ public class DockerCracMojo extends AbstractDockerMojo {
         return X86_64_ARCH;
     }
 
-    private String buildCheckpointDockerfile() throws IOException, MavenFilteringException {
+    private String buildCheckpointDockerfile() throws IOException, MavenFilteringException, MojoExecutionException {
         String name = mavenProject.getArtifactId() + "-crac-checkpoint";
         var checkpointTags = Collections.singleton(name);
         copyScripts(CHECKPOINT_SCRIPT_NAME, WARMUP_SCRIPT_NAME, RUN_SCRIPT_NAME);
@@ -210,11 +272,13 @@ public class DockerCracMojo extends AbstractDockerMojo {
         String filteredCracArchitecture = limitArchitecture(cracArchitecture);
         String finalArchitecture = filteredCracArchitecture == null ? systemArchitecture : filteredCracArchitecture;
         String baseImage = getFromImage().orElse(DEFAULT_BASE_IMAGE);
+        CracJdkDownload cracJdkDownload = resolveCracJdkDownload(finalArchitecture);
 
         getLog().info("Using BASE_IMAGE: " + baseImage);
         getLog().info("Using CRAC_ARCH: " + finalArchitecture);
         getLog().info("Using CRAC_JDK_VERSION: " + cracJavaVersion);
         getLog().info("Using CRAC_OS: " + cracOs);
+        getLog().info("Using CRAC_JDK_DOWNLOAD_URL: " + cracJdkDownload.downloadUrl());
 
         BuildImageCmd buildImageCmd = dockerService.buildImageCmd()
             .withDockerfile(dockerfile)
@@ -222,10 +286,91 @@ public class DockerCracMojo extends AbstractDockerMojo {
             .withBuildArg("CRAC_ARCH", finalArchitecture)
             .withBuildArg("CRAC_OS", cracOs)
             .withBuildArg("CRAC_JDK_VERSION", cracJavaVersion)
+            .withBuildArg("CRAC_JDK_URL", cracJdkDownload.downloadUrl())
+            .withBuildArg("CRAC_JDK_SHA256", cracJdkDownload.sha256())
             .withTags(checkpointTags);
         getNetworkMode().ifPresent(buildImageCmd::withNetworkMode);
         dockerService.buildImage(buildImageCmd);
         return name;
+    }
+
+    private String cracJdkDownloadUrl(String architecture) throws MojoExecutionException {
+        return resolveCracJdkDownload(architecture).downloadUrl();
+    }
+
+    private String cracJdkDownloadSha256(String architecture) throws MojoExecutionException {
+        return resolveCracJdkDownload(architecture).sha256();
+    }
+
+    private CracJdkDownload resolveCracJdkDownload(String architecture) throws MojoExecutionException {
+        boolean hasCustomUrl = hasText(cracJdkDownloadUrl);
+        boolean hasCustomSha256 = hasText(cracJdkDownloadSha256);
+        if (hasCustomUrl || hasCustomSha256) {
+            if (!hasCustomUrl || !hasCustomSha256) {
+                throw new MojoExecutionException(
+                    CRAC_JDK_DOWNLOAD_URL_PROPERTY + " and " + CRAC_JDK_DOWNLOAD_SHA256_PROPERTY + " must be configured together"
+                );
+            }
+            return new CracJdkDownload(
+                validateDownloadUrl(CRAC_JDK_DOWNLOAD_URL_PROPERTY, cracJdkDownloadUrl),
+                validateSha256(CRAC_JDK_DOWNLOAD_SHA256_PROPERTY, cracJdkDownloadSha256)
+            );
+        }
+        if (!DEFAULT_CRAC_OS.equals(cracOs)) {
+            throw new MojoExecutionException(
+                "Unsupported CRaC OS '" + cracOs + "'. The pinned defaults only support " + DEFAULT_CRAC_OS
+                    + ". Override with " + CRAC_JDK_DOWNLOAD_URL_PROPERTY + " and " + CRAC_JDK_DOWNLOAD_SHA256_PROPERTY + "."
+            );
+        }
+
+        int javaVersion = resolveCracJdkVersion();
+        CracJdkRelease release = CRAC_JDK_RELEASES.get(javaVersion);
+        if (release == null) {
+            throw new MojoExecutionException(
+                "Unsupported CRaC JDK version '" + cracJavaVersion + "'. Supported pinned defaults are " + SUPPORTED_CRAC_JDK_VERSIONS
+                    + ". Override with " + CRAC_JDK_DOWNLOAD_URL_PROPERTY + " and " + CRAC_JDK_DOWNLOAD_SHA256_PROPERTY + "."
+            );
+        }
+
+        String downloadUrl = release.downloadUrlsByArch().get(architecture);
+        String sha256 = release.checksumsByArch().get(architecture);
+        if (downloadUrl == null || sha256 == null) {
+            throw new MojoExecutionException(
+                "Unsupported CRaC architecture '" + architecture + "'. Supported pinned defaults are "
+                    + release.downloadUrlsByArch().keySet() + ". Override with " + CRAC_JDK_DOWNLOAD_URL_PROPERTY + " and "
+                    + CRAC_JDK_DOWNLOAD_SHA256_PROPERTY + "."
+            );
+        }
+        return new CracJdkDownload(downloadUrl, sha256);
+    }
+
+    private int resolveCracJdkVersion() throws MojoExecutionException {
+        StringBuilder majorVersion = new StringBuilder();
+        for (int i = 0; i < cracJavaVersion.length(); i++) {
+            char character = cracJavaVersion.charAt(i);
+            if (!Character.isDigit(character)) {
+                break;
+            }
+            majorVersion.append(character);
+        }
+        if (majorVersion.isEmpty()) {
+            throw new MojoExecutionException(
+                "Unsupported CRaC JDK version '" + cracJavaVersion + "'. Expected a numeric Java major version or release."
+            );
+        }
+        return Integer.parseInt(majorVersion.toString());
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String validateSha256(String source, String value) throws MojoExecutionException {
+        String sanitized = validateDockerfileValue(source, value).trim();
+        if (!sanitized.matches("[0-9a-fA-F]{64}")) {
+            throw new MojoExecutionException(source + " must be a 64-character hexadecimal SHA-256 checksum");
+        }
+        return sanitized.toLowerCase(Locale.ROOT);
     }
 
     private void buildFinalDockerfile(String checkpointContainerId) throws IOException, InvalidImageReferenceException, MavenFilteringException {
@@ -293,5 +438,11 @@ public class DockerCracMojo extends AbstractDockerMojo {
                 Files.setPosixFilePermissions(outputPath, POSIX_FILE_PERMISSIONS);
             }
         }
+    }
+
+    private record CracJdkRelease(Map<String, String> downloadUrlsByArch, Map<String, String> checksumsByArch) {
+    }
+
+    private record CracJdkDownload(String downloadUrl, String sha256) {
     }
 }

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
@@ -27,7 +27,7 @@ RUN archive=/tmp/crac-jdk.tar.gz \
            mv "$(find "$extract_dir" -mindepth 1 -maxdepth 1)" /azul-crac-jdk; \
        else \
            mkdir -p /azul-crac-jdk \
-           && find "$extract_dir" -mindepth 1 -maxdepth 1 -exec mv {} /azul-crac-jdk/ \; \
+           && find "$extract_dir" -mindepth 1 -maxdepth 1 -exec mv {} /azul-crac-jdk/ \; ; \
        fi \
     && rm -f "$archive" \
     && rm -rf "$extract_dir"

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
@@ -3,35 +3,23 @@ FROM ${BASE_IMAGE}
 
 ARG CRAC_ARCH
 ARG CRAC_JDK_VERSION
+ARG CRAC_JDK_SHA256
+ARG CRAC_JDK_URL
 ARG CRAC_OS
 WORKDIR /home/app
 
 # Add required libraries
 RUN apt-get update && apt-get install -y \
         curl \
-        jq \
         libnl-3-200 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install latest CRaC OpenJDK
-RUN echo Locating latest CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH
-RUN release_id=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/?java_version=${CRAC_JDK_VERSION}&os=${CRAC_OS}&arch=${CRAC_ARCH}&crac_supported=true&java_package_type=jdk&archive_type=tar.gz&latest=true&release_status=ga&certifications=tck&page=1&page_size=100" -H "accept: application/json" | jq -r '.[0] | .package_uuid') \
-    && if [ "$release_id" = "null" ]; then \
-           echo "No CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH found"; \
-           exit 1; \
-       fi \
-    && details=$(curl -s "https://api.azul.com/metadata/v1/zulu/packages/$release_id" -H "accept: application/json") \
-    && name=$(echo "$details" | jq -r '.name') \
-    && url=$(echo "$details" | jq -r '.download_url') \
-    && hash=$(echo "$details" | jq -r '.sha256_hash') \
-    && echo "Downloading $name from $url" \
-    && curl -LJOH 'Accept: application/octet-stream' "$url" >&2 \
-    && file_sha=$(sha256sum -b "$name" | cut -d' ' -f 1) \
-    && if [ "$file_sha" != "$hash" ]; then \
-           echo "SHA256 hash mismatch: $file_sha != $hash"; \
-           exit 1; \
-       fi \
-    && echo "SHA256 hash matches: $file_sha == $hash" >&2 \
+# Install pinned CRaC OpenJDK
+RUN echo Installing pinned CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH from $CRAC_JDK_URL
+RUN name=$(basename "$CRAC_JDK_URL") \
+    && echo "Downloading $name from $CRAC_JDK_URL" \
+    && curl -fsSL "$CRAC_JDK_URL" -o "$name" \
+    && echo "$CRAC_JDK_SHA256  $name" | sha256sum -c - \
     && tar xzf "$name" \
     && mv ${name%%.tar.gz} /azul-crac-jdk \
     && rm "$name"

--- a/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
+++ b/micronaut-maven-plugin/src/main/resources/dockerfiles/DockerfileCracCheckpoint
@@ -16,13 +16,21 @@ RUN apt-get update && apt-get install -y \
 
 # Install pinned CRaC OpenJDK
 RUN echo Installing pinned CRaC OpenJDK $CRAC_JDK_VERSION for $CRAC_ARCH from $CRAC_JDK_URL
-RUN name=$(basename "$CRAC_JDK_URL") \
-    && echo "Downloading $name from $CRAC_JDK_URL" \
-    && curl -fsSL "$CRAC_JDK_URL" -o "$name" \
-    && echo "$CRAC_JDK_SHA256  $name" | sha256sum -c - \
-    && tar xzf "$name" \
-    && mv ${name%%.tar.gz} /azul-crac-jdk \
-    && rm "$name"
+RUN archive=/tmp/crac-jdk.tar.gz \
+    && extract_dir=$(mktemp -d) \
+    && echo "Downloading CRaC JDK from $CRAC_JDK_URL" \
+    && curl -fsSL "$CRAC_JDK_URL" -o "$archive" \
+    && echo "$CRAC_JDK_SHA256  $archive" | sha256sum -c - \
+    && tar xzf "$archive" -C "$extract_dir" \
+    && top_level_count=$(find "$extract_dir" -mindepth 1 -maxdepth 1 | wc -l) \
+       && if [ "$top_level_count" -eq 1 ] && [ -d "$(find "$extract_dir" -mindepth 1 -maxdepth 1)" ]; then \
+           mv "$(find "$extract_dir" -mindepth 1 -maxdepth 1)" /azul-crac-jdk; \
+       else \
+           mkdir -p /azul-crac-jdk \
+           && find "$extract_dir" -mindepth 1 -maxdepth 1 -exec mv {} /azul-crac-jdk/ \; \
+       fi \
+    && rm -f "$archive" \
+    && rm -rf "$extract_dir"
 
 # Copy layers
 COPY classes /home/app/classes

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -563,4 +563,18 @@ These can be overridden by passing properties to the build:
 </properties>
 ----
 
-NOTE: Currently only Java 25, and `amd64` and `aarch64` architectures are supported.
+NOTE: The pinned defaults currently support Java 17, 21, 23, and 25 on `amd64` and `aarch64` for `linux-glibc`.
+
+On `5.0.x`, the built-in CRaC defaults are pinned to repository-managed Azul tarballs for `linux-glibc`.
+The supported pinned Java versions are 17, 21, 23, and 25 on `amd64` and `aarch64`.
+
+If you need a different CRaC distribution, provide both the download URL and the expected checksum explicitly:
+
+[source,xml]
+.Example overriding the pinned CRaC JDK artifact
+----
+<properties>
+    <crac.jdk.download.url>https://example.invalid/custom-crac-jdk.tar.gz</crac.jdk.download.url>
+    <crac.jdk.download.sha256>0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef</crac.jdk.download.sha256>
+</properties>
+----

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerCracMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerCracMojoTest.java
@@ -114,6 +114,38 @@ class DockerCracMojoTest {
         );
     }
 
+    @Test
+    void buildCheckpointDockerfileUsesAarch64PinnedArtifactsForArm64Hosts(@TempDir Path tempDir) throws Exception {
+        var fixtures = new Fixtures(tempDir);
+        System.setProperty("os.arch", "arm64");
+        setField(fixtures.mojo, "cracArchitecture", null);
+
+        invokeBuildCheckpointDockerfile(fixtures.mojo);
+
+        verify(fixtures.buildImageCmd).withBuildArg(
+            "CRAC_JDK_URL",
+            "https://cdn.azul.com/zulu/bin/zulu25.32.23-ca-crac-jdk25.0.2-linux_aarch64.tar.gz"
+        );
+        verify(fixtures.buildImageCmd).withBuildArg(
+            "CRAC_JDK_SHA256",
+            "83f4621c04cf8f8d2ce8ce82e7505b85897d9e5b4cadb5472a1c679bc27a41bd"
+        );
+    }
+
+    @Test
+    void rejectsCracJdkOverrideWithEmbeddedCredentials(@TempDir Path tempDir) {
+        var fixtures = new Fixtures(tempDir);
+        setField(fixtures.mojo, "cracJdkDownloadUrl", "https://user:secret@example.com/custom-crac.tar.gz");
+        setField(fixtures.mojo, "cracJdkDownloadSha256", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        var exception = assertThrows(
+            MojoExecutionException.class,
+            () -> invokeStringMethod(fixtures.mojo, "cracJdkDownloadUrl", DockerCracMojo.X86_64_ARCH)
+        );
+
+        assertEquals("crac.jdk.download.url must not include embedded credentials", exception.getMessage());
+    }
+
     private static void invokeBuildCheckpointDockerfile(DockerCracMojo mojo) throws Exception {
         Method buildCheckpointDockerfile = DockerCracMojo.class.getDeclaredMethod("buildCheckpointDockerfile");
         buildCheckpointDockerfile.setAccessible(true);
@@ -193,6 +225,14 @@ class DockerCracMojoTest {
                 Path dockerfile = tempDir.resolve("DockerfileCracCheckpoint");
                 Files.writeString(dockerfile, "FROM ${BASE_IMAGE}\n");
                 when(dockerService.loadDockerfileAsResource(DockerfileMojo.DOCKERFILE_CRAC_CHECKPOINT)).thenReturn(dockerfile.toFile());
+                for (String scriptName : new String[] {
+                    DockerCracMojo.CHECKPOINT_SCRIPT_NAME,
+                    DockerCracMojo.WARMUP_SCRIPT_NAME,
+                    DockerCracMojo.RUN_SCRIPT_NAME
+                }) {
+                    Path script = tempDir.resolve(scriptName);
+                    Files.writeString(script, "#!/bin/sh\n");
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerCracMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerCracMojoTest.java
@@ -1,0 +1,216 @@
+package io.micronaut.maven;
+
+import com.github.dockerjava.api.command.BuildImageCmd;
+import io.micronaut.maven.jib.JibConfigurationService;
+import io.micronaut.maven.services.ApplicationConfigurationService;
+import io.micronaut.maven.services.DockerService;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.apache.maven.shared.filtering.MavenReaderFilter;
+import org.apache.maven.shared.filtering.MavenReaderFilterRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.RestoreSystemProperties;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RestoreSystemProperties
+class DockerCracMojoTest {
+
+    @Test
+    void resolvesPinnedCracJdkForJava25OnAmd64(@TempDir Path tempDir) throws MojoExecutionException {
+        var fixtures = new Fixtures(tempDir);
+
+        assertEquals(
+            "https://cdn.azul.com/zulu/bin/zulu25.32.23-ca-crac-jdk25.0.2-linux_x64.tar.gz",
+            invokeStringMethod(fixtures.mojo, "cracJdkDownloadUrl", DockerCracMojo.X86_64_ARCH)
+        );
+        assertEquals(
+            "2ebb784450f158e628f5717034aac3126591a6ef03498290297f2f46d8f886b1",
+            invokeStringMethod(fixtures.mojo, "cracJdkDownloadSha256", DockerCracMojo.X86_64_ARCH)
+        );
+    }
+
+    @Test
+    void resolvesPinnedCracJdkFromReleaseVersion(@TempDir Path tempDir) throws MojoExecutionException {
+        var fixtures = new Fixtures(tempDir);
+        setField(fixtures.mojo, "cracJavaVersion", "21.0.10");
+
+        assertEquals(
+            "https://cdn.azul.com/zulu/bin/zulu21.48.17-ca-crac-jdk21.0.10-linux_aarch64.tar.gz",
+            invokeStringMethod(fixtures.mojo, "cracJdkDownloadUrl", DockerCracMojo.ARM_ARCH)
+        );
+        assertEquals(
+            "17c88f5112d9782255826fb860217a7d56686451e1629a98695ffd63718d3366",
+            invokeStringMethod(fixtures.mojo, "cracJdkDownloadSha256", DockerCracMojo.ARM_ARCH)
+        );
+    }
+
+    @Test
+    void usesExplicitCracJdkOverride(@TempDir Path tempDir) throws MojoExecutionException {
+        var fixtures = new Fixtures(tempDir);
+        setField(fixtures.mojo, "cracJdkDownloadUrl", "https://example.com/custom-crac.tar.gz");
+        setField(fixtures.mojo, "cracJdkDownloadSha256", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        assertEquals(
+            "https://example.com/custom-crac.tar.gz",
+            invokeStringMethod(fixtures.mojo, "cracJdkDownloadUrl", DockerCracMojo.X86_64_ARCH)
+        );
+        assertEquals(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            invokeStringMethod(fixtures.mojo, "cracJdkDownloadSha256", DockerCracMojo.X86_64_ARCH)
+        );
+    }
+
+    @Test
+    void rejectsPartialCracJdkOverride(@TempDir Path tempDir) {
+        var fixtures = new Fixtures(tempDir);
+        setField(fixtures.mojo, "cracJdkDownloadUrl", "https://example.com/custom-crac.tar.gz");
+
+        var exception = assertThrows(
+            MojoExecutionException.class,
+            () -> invokeStringMethod(fixtures.mojo, "cracJdkDownloadUrl", DockerCracMojo.X86_64_ARCH)
+        );
+
+        assertEquals(
+            DockerCracMojo.CRAC_JDK_DOWNLOAD_URL_PROPERTY + " and " + DockerCracMojo.CRAC_JDK_DOWNLOAD_SHA256_PROPERTY
+                + " must be configured together",
+            exception.getMessage()
+        );
+    }
+
+    @Test
+    void buildCheckpointDockerfilePassesPinnedBuildArgs(@TempDir Path tempDir) throws Exception {
+        var fixtures = new Fixtures(tempDir);
+
+        invokeBuildCheckpointDockerfile(fixtures.mojo);
+
+        verify(fixtures.buildImageCmd).withBuildArg(
+            "CRAC_JDK_URL",
+            "https://cdn.azul.com/zulu/bin/zulu25.32.23-ca-crac-jdk25.0.2-linux_x64.tar.gz"
+        );
+        verify(fixtures.buildImageCmd).withBuildArg(
+            "CRAC_JDK_SHA256",
+            "2ebb784450f158e628f5717034aac3126591a6ef03498290297f2f46d8f886b1"
+        );
+    }
+
+    private static void invokeBuildCheckpointDockerfile(DockerCracMojo mojo) throws Exception {
+        Method buildCheckpointDockerfile = DockerCracMojo.class.getDeclaredMethod("buildCheckpointDockerfile");
+        buildCheckpointDockerfile.setAccessible(true);
+        try {
+            buildCheckpointDockerfile.invoke(mojo);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception exception) {
+                throw exception;
+            }
+            throw e;
+        }
+    }
+
+    private static String invokeStringMethod(DockerCracMojo mojo, String methodName, String argument) throws MojoExecutionException {
+        try {
+            Method method = DockerCracMojo.class.getDeclaredMethod(methodName, String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(mojo, argument);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof MojoExecutionException exception) {
+                throw exception;
+            }
+            throw new RuntimeException(cause);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class Fixtures {
+        private final BuildImageCmd buildImageCmd;
+        private final DockerCracMojo mojo;
+
+        private Fixtures(Path tempDir) {
+            MavenProject project = mock(MavenProject.class);
+            MavenSession session = mock(MavenSession.class);
+            MojoExecution execution = mock(MojoExecution.class);
+            JibConfigurationService jibConfigurationService = mock(JibConfigurationService.class);
+            ApplicationConfigurationService applicationConfigurationService = mock(ApplicationConfigurationService.class);
+            DockerService dockerService = mock(DockerService.class);
+            MavenReaderFilter mavenReaderFilter = mock(MavenReaderFilter.class);
+            buildImageCmd = mock(BuildImageCmd.class, RETURNS_SELF);
+
+            Build build = new Build();
+            build.setDirectory(tempDir.resolve("target").toString());
+
+            when(session.getCurrentProject()).thenReturn(project);
+            when(session.getUserProperties()).thenReturn(new Properties());
+            when(session.getSystemProperties()).thenReturn(new Properties());
+            when(project.getProperties()).thenReturn(new Properties());
+            when(project.getBuild()).thenReturn(build);
+            when(project.getBasedir()).thenReturn(tempDir.toFile());
+            when(project.getArtifactId()).thenReturn("demo");
+            when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
+            when(dockerService.buildImageCmd()).thenReturn(buildImageCmd);
+            when(dockerService.buildImage(buildImageCmd)).thenReturn("image-id");
+            try {
+                when(mavenReaderFilter.filter(any(MavenReaderFilterRequest.class))).thenAnswer(
+                    invocation -> invocation.getArgument(0, MavenReaderFilterRequest.class).getFrom()
+                );
+            } catch (MavenFilteringException e) {
+                throw new RuntimeException(e);
+            }
+
+            try {
+                Path dockerfile = tempDir.resolve("DockerfileCracCheckpoint");
+                Files.writeString(dockerfile, "FROM ${BASE_IMAGE}\n");
+                when(dockerService.loadDockerfileAsResource(DockerfileMojo.DOCKERFILE_CRAC_CHECKPOINT)).thenReturn(dockerfile.toFile());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            mojo = new DockerCracMojo(
+                project,
+                jibConfigurationService,
+                applicationConfigurationService,
+                dockerService,
+                mavenReaderFilter,
+                session,
+                execution
+            );
+            mojo.mainClass = "example.Application";
+            setField(mojo, "cracJavaVersion", "25");
+            setField(mojo, "cracOs", DockerCracMojo.DEFAULT_CRAC_OS);
+            setField(mojo, "cracArchitecture", DockerCracMojo.X86_64_ARCH);
+            setField(mojo, "readinessCommand", DockerCracMojo.DEFAULT_READINESS_COMMAND);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1638

## Summary
- replace the CRaC checkpoint Dockerfile's live Azul metadata lookup with repository-pinned Azul download URLs and committed SHA-256 values
- keep the `dockerfile-docker-crac` invoker fixture aligned and fail verification if `api.azul.com/metadata` or `latest=true` reappears
- add focused `DockerCracMojoTest` coverage for the pinned defaults and custom override validation

## Verification
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env && ./mvnw -pl micronaut-maven-plugin -am -Dtest=DockerCracMojoTest,DockerfileMojoTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env && ./mvnw -pl micronaut-maven-integration-tests -am verify -Dinvoker.test=dockerfile-docker-crac -Dsurefire.failIfNoSpecifiedTests=false`
