### PR TITLE
Align 5.0.x dependencies with Micronaut Platform 5.0.x targets

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 # Keep these Apache Maven Wrapper checksums aligned with the committed wrapper
 # JAR and distributionUrl whenever the wrapper is updated.
-distributionSha256Sum=55fadd669532a3205d5db95f490bf13971d8b0843526f407f29db0e61f074ab3
+distributionSha256Sum=b0d9292f06c5faded31ddcb6cb69099f316d6fea40a7778624b259bad9fed18a
 wrapperSha256Sum=e63a53cfb9c4d291ebe3c2b0edacb7622bbc480326beaa5a0456e412f52f066a

--- a/micronaut-maven-integration-tests/src/it/test-resources-start-kill-stop/setup.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-start-kill-stop/setup.groovy
@@ -12,19 +12,34 @@ p.waitFor()
 
 assert p.exitValue() == 0
 
-String port = new File(basedir, "target/test-resources-port.txt").text.trim()
+File portFile = new File(basedir, "target/test-resources-port.txt")
+String port = ""
 int retries = 10
 Optional<ProcessHandle> testResourcesProcess = Optional.empty()
+String lastLsofOutput = ""
+int lastLsofExitCode = 0
 while (retries-- > 0 && testResourcesProcess.isEmpty()) {
-    def pidCommand = new ProcessBuilder("lsof", "-ti", "tcp:${port}")
-            .directory(basedir as File)
-            .redirectErrorStream(true)
-            .start()
-    String pid = pidCommand.inputStream.text.trim()
-    pidCommand.waitFor()
-    if (!pid.isBlank()) {
-        testResourcesProcess = ProcessHandle.of(Long.parseLong(pid.readLines().first()))
-    } else {
+    if (portFile.exists()) {
+        port = portFile.text.trim()
+    }
+    if (!port.isBlank()) {
+        def pidCommand
+        try {
+            pidCommand = new ProcessBuilder("lsof", "-ti", "tcp:${port}")
+                    .directory(basedir as File)
+                    .redirectErrorStream(true)
+                    .start()
+        } catch (IOException e) {
+            assert false : "Failed to execute 'lsof' to locate the Test Resources Service process for port $port. Cause: ${e.message}"
+        }
+        lastLsofOutput = pidCommand.inputStream.text.trim()
+        lastLsofExitCode = pidCommand.waitFor()
+        String pid = lastLsofOutput.readLines().find { it ==~ /\d+/ }
+        if (pid != null) {
+            testResourcesProcess = ProcessHandle.of(Long.parseLong(pid))
+        }
+    }
+    if (testResourcesProcess.isEmpty()) {
         Thread.sleep(100L * (10 - retries))
     }
 }
@@ -32,5 +47,5 @@ while (retries-- > 0 && testResourcesProcess.isEmpty()) {
 if (testResourcesProcess.isPresent()) {
     testResourcesProcess.get().destroyForcibly();
 } else {
-    assert false : "Test Resources Service process not found for port $port"
+    assert false : "Test Resources Service process not found for port $port. lsof exit code: $lastLsofExitCode. Output: ${lastLsofOutput ?: '<empty>'}"
 }

--- a/micronaut-maven-integration-tests/src/it/test-resources-start-kill-stop/setup.groovy
+++ b/micronaut-maven-integration-tests/src/it/test-resources-start-kill-stop/setup.groovy
@@ -12,12 +12,25 @@ p.waitFor()
 
 assert p.exitValue() == 0
 
-def testResourcesProcess = ProcessHandle.allProcesses()
-        .filter(process -> process.info().commandLine().map(c -> c.contains("TestResourcesService")).orElse(false))
-        .findFirst();
+String port = new File(basedir, "target/test-resources-port.txt").text.trim()
+int retries = 10
+Optional<ProcessHandle> testResourcesProcess = Optional.empty()
+while (retries-- > 0 && testResourcesProcess.isEmpty()) {
+    def pidCommand = new ProcessBuilder("lsof", "-ti", "tcp:${port}")
+            .directory(basedir as File)
+            .redirectErrorStream(true)
+            .start()
+    String pid = pidCommand.inputStream.text.trim()
+    pidCommand.waitFor()
+    if (!pid.isBlank()) {
+        testResourcesProcess = ProcessHandle.of(Long.parseLong(pid.readLines().first()))
+    } else {
+        Thread.sleep(100L * (10 - retries))
+    }
+}
 
 if (testResourcesProcess.isPresent()) {
     testResourcesProcess.get().destroyForcibly();
 } else {
-    assert false : "Test Resources Service process not found"
+    assert false : "Test Resources Service process not found for port $port"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -65,13 +65,13 @@
         <maven.compiler.source>${jdk.version}</maven.compiler.source>
         <maven.compiler.target>${jdk.version}</maven.compiler.target>
 
-        <maven.version>3.9.14</maven.version>
-        <micronaut.version>5.0.0-M18</micronaut.version>
-        <native-maven-plugin.version>0.11.5</native-maven-plugin.version>
+        <maven.version>3.9.15</maven.version>
+        <micronaut.version>5.0.0-M24</micronaut.version>
+        <native-maven-plugin.version>1.0.0</native-maven-plugin.version>
         <micronaut.aot.version>3.0.0-M2</micronaut.aot.version>
-        <micronaut.test.resources.version>3.0.0-M6</micronaut.test.resources.version>
-        <micronaut.openapi.version>6.19.3</micronaut.openapi.version>
-        <micronaut.jsonschema.version>2.0.0-M7</micronaut.jsonschema.version>
+        <micronaut.test.resources.version>4.0.0-M1</micronaut.test.resources.version>
+        <micronaut.openapi.version>7.0.0-M2</micronaut.openapi.version>
+        <micronaut.jsonschema.version>2.0.0-M10</micronaut.jsonschema.version>
 
         <maven.resources-plugin.version>3.4.0</maven.resources-plugin.version>
         <maven.archiver-plugin.version>3.6.0</maven.archiver-plugin.version>


### PR DESCRIPTION
## Summary
- align the `5.0.x` root version properties with the requested Micronaut Platform-related targets
- update the Maven wrapper distribution URL and checksum to `3.9.15` so `./mvnw` matches the enforced Maven baseline
- keep the Test Resources invoker scenario working by resolving and killing the background service through the plugin-generated port file

## Verification
- `./mvnw -pl micronaut-maven-plugin -am test`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=jsonschema*"`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=openapi*"`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=test-resources*"`
- `bash .github/scripts/ci-sensitive-preflight.sh`
- `./mvnw -q -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=test-resources-start-kill-stop"`

Closes #1643.

Best-fit Micronaut organization project from QA intake: `5.0.0 Release`.
Ambiguity note: the upstream issue history showed two project-add events, but the public event payload did not expose both project names.

---
###### ✨ This message was AI-generated using gpt-5.4
