### PR TITLE
Resolve managed Jib plugin for docker packaging

### DIFF
--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/services/ExecutorService.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/services/ExecutorService.java
@@ -141,16 +141,12 @@ public class ExecutorService {
         if (pluginKey.equals(plugin.getKey())) {
             return true;
         }
-        String groupId = plugin.getGroupId();
         String artifactId = plugin.getArtifactId();
-        String version = plugin.getVersion();
-        if (groupId == null || artifactId == null) {
+        if (artifactId == null) {
             return false;
         }
-        if (pluginKey.equals(groupId + ":" + artifactId)) {
-            return true;
-        }
-        return version != null && pluginKey.equals(groupId + ":" + artifactId + ":" + version);
+        String version = plugin.getVersion();
+        return version != null && pluginKey.equals(plugin.getKey() + ":" + version);
     }
 
     /**

--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/services/ExecutorService.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/services/ExecutorService.java
@@ -90,7 +90,7 @@ public class ExecutorService {
 
     public final void executeGoal(MavenProject project, String pluginKey, String goal, Xpp3Dom overriddenConfiguration) throws MojoExecutionException {
         MavenProject targetProject = project == null ? mavenProject : project;
-        Plugin plugin = targetProject.getPlugin(pluginKey);
+        Plugin plugin = resolveBuildPlugin(targetProject, pluginKey);
         if (plugin != null) {
             String goalName = goal;
             AtomicReference<String> executionId = new AtomicReference<>(goalName);
@@ -117,6 +117,40 @@ public class ExecutorService {
         } else {
             throw new MojoExecutionException("Plugin not found: " + pluginKey);
         }
+    }
+
+    static Plugin resolveBuildPlugin(MavenProject targetProject, String pluginKey) {
+        Plugin plugin = targetProject.getPlugin(pluginKey);
+        if (plugin != null) {
+            return plugin;
+        }
+        if (targetProject.getBuild() == null || targetProject.getBuild().getPluginManagement() == null) {
+            return null;
+        }
+        return targetProject.getBuild().getPluginManagement().getPlugins()
+            .stream()
+            .filter(managedPlugin -> matchesPluginKey(managedPlugin, pluginKey))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private static boolean matchesPluginKey(Plugin plugin, String pluginKey) {
+        if (plugin == null) {
+            return false;
+        }
+        if (pluginKey.equals(plugin.getKey())) {
+            return true;
+        }
+        String groupId = plugin.getGroupId();
+        String artifactId = plugin.getArtifactId();
+        String version = plugin.getVersion();
+        if (groupId == null || artifactId == null) {
+            return false;
+        }
+        if (pluginKey.equals(groupId + ":" + artifactId)) {
+            return true;
+        }
+        return version != null && pluginKey.equals(groupId + ":" + artifactId + ":" + version);
     }
 
     /**

--- a/micronaut-maven-core/src/test/java/io/micronaut/maven/services/ExecutorServiceTest.java
+++ b/micronaut-maven-core/src/test/java/io/micronaut/maven/services/ExecutorServiceTest.java
@@ -3,6 +3,9 @@ package io.micronaut.maven.services;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.invoker.InvocationRequest;
@@ -96,13 +99,54 @@ class ExecutorServiceTest {
         Path projectDirectory = tempDir.resolve("project");
         Path buildDirectory = projectDirectory.resolve("target");
         MavenProject project = new MavenProject();
-        org.apache.maven.model.Build build = new org.apache.maven.model.Build();
+        Build build = new Build();
         build.setDirectory(buildDirectory.toString());
         project.setBuild(build);
         File alternatePom = projectDirectory.resolve("custom.xml").toFile();
         project.setFile(alternatePom);
 
         assertSame(alternatePom, ExecutorService.resolveOriginalPom(project));
+    }
+
+    @Test
+    void resolveBuildPluginFallsBackToManagedPlugin() {
+        MavenProject project = new MavenProject();
+        Build build = new Build();
+        PluginManagement pluginManagement = new PluginManagement();
+        Plugin plugin = new Plugin();
+        plugin.setGroupId("com.google.cloud.tools");
+        plugin.setArtifactId("jib-maven-plugin");
+        plugin.setVersion("3.5.1");
+        pluginManagement.addPlugin(plugin);
+        build.setPluginManagement(pluginManagement);
+        project.setBuild(build);
+
+        Plugin result = ExecutorService.resolveBuildPlugin(project, "com.google.cloud.tools:jib-maven-plugin");
+
+        assertSame(plugin, result);
+    }
+
+    @Test
+    void resolveBuildPluginPrefersDirectBuildPluginOverManagedPlugin() {
+        MavenProject project = new MavenProject();
+        Build build = new Build();
+        Plugin directPlugin = new Plugin();
+        directPlugin.setGroupId("com.google.cloud.tools");
+        directPlugin.setArtifactId("jib-maven-plugin");
+        directPlugin.setVersion("3.5.1");
+        build.addPlugin(directPlugin);
+        PluginManagement pluginManagement = new PluginManagement();
+        Plugin managedPlugin = new Plugin();
+        managedPlugin.setGroupId("com.google.cloud.tools");
+        managedPlugin.setArtifactId("jib-maven-plugin");
+        managedPlugin.setVersion("3.5.0");
+        pluginManagement.addPlugin(managedPlugin);
+        build.setPluginManagement(pluginManagement);
+        project.setBuild(build);
+
+        Plugin result = ExecutorService.resolveBuildPlugin(project, "com.google.cloud.tools:jib-maven-plugin");
+
+        assertSame(directPlugin, result);
     }
 
     private static MavenSession newSession(Path tempDir, boolean quiet, File settingsFile) {

--- a/micronaut-maven-core/src/test/java/io/micronaut/maven/services/ExecutorServiceTest.java
+++ b/micronaut-maven-core/src/test/java/io/micronaut/maven/services/ExecutorServiceTest.java
@@ -113,10 +113,7 @@ class ExecutorServiceTest {
         MavenProject project = new MavenProject();
         Build build = new Build();
         PluginManagement pluginManagement = new PluginManagement();
-        Plugin plugin = new Plugin();
-        plugin.setGroupId("com.google.cloud.tools");
-        plugin.setArtifactId("jib-maven-plugin");
-        plugin.setVersion("3.5.1");
+        Plugin plugin = plugin("com.google.cloud.tools", "jib-maven-plugin", "3.5.1");
         pluginManagement.addPlugin(plugin);
         build.setPluginManagement(pluginManagement);
         project.setBuild(build);
@@ -130,16 +127,10 @@ class ExecutorServiceTest {
     void resolveBuildPluginPrefersDirectBuildPluginOverManagedPlugin() {
         MavenProject project = new MavenProject();
         Build build = new Build();
-        Plugin directPlugin = new Plugin();
-        directPlugin.setGroupId("com.google.cloud.tools");
-        directPlugin.setArtifactId("jib-maven-plugin");
-        directPlugin.setVersion("3.5.1");
+        Plugin directPlugin = plugin("com.google.cloud.tools", "jib-maven-plugin", "3.5.1");
         build.addPlugin(directPlugin);
         PluginManagement pluginManagement = new PluginManagement();
-        Plugin managedPlugin = new Plugin();
-        managedPlugin.setGroupId("com.google.cloud.tools");
-        managedPlugin.setArtifactId("jib-maven-plugin");
-        managedPlugin.setVersion("3.5.0");
+        Plugin managedPlugin = plugin("com.google.cloud.tools", "jib-maven-plugin", "3.5.0");
         pluginManagement.addPlugin(managedPlugin);
         build.setPluginManagement(pluginManagement);
         project.setBuild(build);
@@ -147,6 +138,56 @@ class ExecutorServiceTest {
         Plugin result = ExecutorService.resolveBuildPlugin(project, "com.google.cloud.tools:jib-maven-plugin");
 
         assertSame(directPlugin, result);
+    }
+
+    @Test
+    void resolveBuildPluginReturnsNullWithoutPluginManagement() {
+        MavenProject project = new MavenProject();
+
+        assertNull(ExecutorService.resolveBuildPlugin(project, "com.google.cloud.tools:jib-maven-plugin"));
+
+        project.setBuild(new Build());
+
+        assertNull(ExecutorService.resolveBuildPlugin(project, "com.google.cloud.tools:jib-maven-plugin"));
+    }
+
+    @Test
+    void resolveBuildPluginIgnoresNullIncompleteAndNonMatchingManagedPlugins() {
+        MavenProject project = new MavenProject();
+        Build build = new Build();
+        PluginManagement pluginManagement = new PluginManagement();
+        pluginManagement.getPlugins().add(null);
+        pluginManagement.addPlugin(plugin("com.google.cloud.tools", null, "3.5.1"));
+        pluginManagement.addPlugin(plugin("com.google.cloud.tools", "other-maven-plugin", null));
+        build.setPluginManagement(pluginManagement);
+        project.setBuild(build);
+
+        Plugin result = ExecutorService.resolveBuildPlugin(project, "com.google.cloud.tools:jib-maven-plugin");
+
+        assertNull(result);
+    }
+
+    @Test
+    void resolveBuildPluginMatchesManagedPluginWithVersionedKey() {
+        MavenProject project = new MavenProject();
+        Build build = new Build();
+        PluginManagement pluginManagement = new PluginManagement();
+        Plugin plugin = plugin("com.google.cloud.tools", "jib-maven-plugin", "3.5.1");
+        pluginManagement.addPlugin(plugin);
+        build.setPluginManagement(pluginManagement);
+        project.setBuild(build);
+
+        Plugin result = ExecutorService.resolveBuildPlugin(project, "com.google.cloud.tools:jib-maven-plugin:3.5.1");
+
+        assertSame(plugin, result);
+    }
+
+    private static Plugin plugin(String groupId, String artifactId, String version) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(groupId);
+        plugin.setArtifactId(artifactId);
+        plugin.setVersion(version);
+        return plugin;
     }
 
     private static MavenSession newSession(Path tempDir, boolean quiet, File settingsFile) {

--- a/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -ntp package -Dpackaging=docker -Djib.buildGoal=buildTar

--- a/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/pom.xml
@@ -1,0 +1,133 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.micronaut.build.examples</groupId>
+    <artifactId>package-docker-managed-jib</artifactId>
+    <version>0.1</version>
+    <packaging>${packaging}</packaging>
+
+    <parent>
+        <groupId>io.micronaut.platform</groupId>
+        <artifactId>micronaut-parent</artifactId>
+        <version>@it.micronaut.version@</version>
+    </parent>
+
+    <properties>
+        <micronaut.version>@it.micronaut.version@</micronaut.version>
+        <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+        <exec.mainClass>io.micronaut.build.examples.Application</exec.mainClass>
+        <packaging>jar</packaging>
+        <micronaut.runtime>netty</micronaut.runtime>
+        <maven.native.plugin.version>@native-maven-plugin.version@</maven.native.plugin.version>
+        <jib-maven-plugin.version>@jib-maven-plugin.version@</jib-maven-plugin.version>
+        <maven.compiler.release>${java.specification.version}</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-server-netty</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.serde</groupId>
+            <artifactId>micronaut-serde-jackson</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.test</groupId>
+            <artifactId>micronaut-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <version>${jib-maven-plugin.version}</version>
+                    <configuration>
+                        <from>
+                            <platforms>
+                                <platform>
+                                    <architecture>amd64</architecture>
+                                    <os>linux</os>
+                                </platform>
+                            </platforms>
+                        </from>
+                        <to>
+                            <image>docker.io/alvarosanchez/${project.artifactId}:${project.version}</image>
+                        </to>
+                        <container>
+                            <mainClass>${exec.mainClass}</mainClass>
+                        </container>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>io.micronaut.maven</groupId>
+                <artifactId>micronaut-maven-plugin</artifactId>
+                <version>${micronaut-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Uncomment to enable incremental compilation -->
+                    <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+                    <annotationProcessorPaths combine.children="append">
+                        <path>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-http-validation</artifactId>
+                            <version>${micronaut.core.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.micronaut.serde</groupId>
+                            <artifactId>micronaut-serde-processor</artifactId>
+                            <version>${micronaut.serialization.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+                        <arg>-Amicronaut.processing.module=${project.artifactId}</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/main/java/io/micronaut/build/examples/Application.java
@@ -1,0 +1,9 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.run(Application.class);
+    }
+}

--- a/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/main/resources/application.yml
+++ b/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: package-docker-managed-jib

--- a/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/main/resources/logback.xml
+++ b/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/test/java/io/micronaut/build/examples/ApplicationTest.java
+++ b/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/src/test/java/io/micronaut/build/examples/ApplicationTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.build.examples;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+public class ApplicationTest {
+
+    @Inject
+    EmbeddedApplication application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/package-docker-managed-jib/verify.groovy
@@ -1,0 +1,5 @@
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains("Using base image: eclipse-temurin:${System.getProperty("java.specification.version")}-jre")
+assert new File(basedir, 'target/jib-image.tar').exists()
+assert !log.text.contains("Plugin not found: com.google.cloud.tools:jib-maven-plugin")


### PR DESCRIPTION
## Summary
- Resolve Maven plugin goal execution from direct build plugins first, then plugin management by Maven plugin coordinates.
- Add unit coverage for managed-plugin fallback and direct-plugin precedence.
- Add an invoker regression for `package -Dpackaging=docker -Djib.buildGoal=buildTar` with Jib declared only in plugin management.

## Tests
- `git diff --check origin/5.0.x...HEAD`
- `./mvnw -pl micronaut-maven-core -Dtest=io.micronaut.maven.services.ExecutorServiceTest test`
- `./mvnw -pl micronaut-maven-integration-tests -am verify -Dinvoker.test=package-docker-managed-jib`

Fixes #1647

Selected organization projects: `5.0.0-M3` and `5.0.0 Release`.

---
###### ✨ This message was AI-generated using gpt-5