### PR TITLE
Fix config validation processing metadata false positive

### DIFF
--- a/micronaut-maven-integration-tests/src/it/configuration-validation-valid/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/configuration-validation-valid/pom.xml
@@ -62,6 +62,16 @@
                     </configurationValidation>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Amicronaut.processing.group=io.micronaut.build.examples</arg>
+                        <arg>-Amicronaut.processing.module=${project.artifactId}</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojo.java
@@ -49,6 +49,9 @@ abstract class AbstractConfigurationValidationMojo extends AbstractMicronautMojo
         "logback.xml",
         "logback-test.xml"
     );
+    private static final List<String> DEFAULT_SUPPRESSIONS = List.of(
+        "micronaut.processing"
+    );
 
     protected final MavenProject project;
     protected final CompilerService compilerService;
@@ -107,7 +110,7 @@ abstract class AbstractConfigurationValidationMojo extends AbstractMicronautMojo
         throws MojoExecutionException, MojoFailureException, IOException {
 
         List<String> environments = computeEnvironments(set, defaultEnvironments());
-        List<String> suppressions = copyList(cfg.getSuppressions());
+        List<String> suppressions = effectiveSuppressions(cfg.getSuppressions());
         List<String> suppressInjectErrors = copyList(cfg.getSuppressInjectErrors());
         boolean failOnNotPresent = cfg.getFailOnNotPresent() == null || cfg.getFailOnNotPresent();
         boolean deduceEnvironments = cfg.getDeduceEnvironments() != null && cfg.getDeduceEnvironments();
@@ -168,6 +171,12 @@ abstract class AbstractConfigurationValidationMojo extends AbstractMicronautMojo
 
     private static <T> List<T> copyList(List<T> values) {
         return values == null ? List.of() : List.copyOf(values);
+    }
+
+    static List<String> effectiveSuppressions(List<String> configuredSuppressions) {
+        Set<String> suppressions = new LinkedHashSet<>(DEFAULT_SUPPRESSIONS);
+        addNonBlankElements(suppressions, configuredSuppressions);
+        return List.copyOf(suppressions);
     }
 
     private String computeClasspathFingerprint(boolean cacheEnabled,
@@ -389,7 +398,7 @@ abstract class AbstractConfigurationValidationMojo extends AbstractMicronautMojo
         return defaultClasspath(project);
     }
 
-    private void addNonBlankElements(Set<String> elements, List<String> candidates) {
+    private static void addNonBlankElements(Set<String> elements, List<String> candidates) {
         if (candidates == null) {
             return;
         }

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/configuration-validation.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/configuration-validation.adoc
@@ -102,6 +102,8 @@ The mojos share a `configurationValidation` block and expose options equivalent 
 ----
 
 If `<enabled>` is not set (or is set to `false`), validation does not run; set it to `true` to enable validation.
+The plugin always suppresses Micronaut annotation-processing metadata such as `micronaut.processing.*` because those
+compiler options are not application configuration keys.
 
 === Classpath configuration
 

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/jsonschema/AbstractConfigurationValidationMojoTest.java
@@ -125,6 +125,19 @@ class AbstractConfigurationValidationMojoTest {
         assertEquals(Boolean.FALSE, configuration.getEnabled());
     }
 
+    @Test
+    void effectiveSuppressionsIncludeMicronautProcessingMetadataByDefault() {
+        assertEquals(List.of("micronaut.processing"), AbstractConfigurationValidationMojo.effectiveSuppressions(null));
+    }
+
+    @Test
+    void effectiveSuppressionsAppendConfiguredValues() {
+        assertEquals(
+            List.of("micronaut.processing", "custom.property"),
+            AbstractConfigurationValidationMojo.effectiveSuppressions(List.of("custom.property", " "))
+        );
+    }
+
     private static String invokeSuppressionHint(AbstractConfigurationValidationMojo mojo,
                                                 Set<DependencyInjectionError> errors) throws Exception {
         Method method = AbstractConfigurationValidationMojo.class


### PR DESCRIPTION
## Summary
- Suppress Micronaut annotation-processing metadata from Maven configuration validation by default.
- Preserve user-configured configuration-validation suppressions as additive values.
- Add focused unit coverage, an invoker regression with `-Amicronaut.processing.*` compiler args, and documentation for the default suppression.

## Tests
- `git diff --check origin/5.0.x...HEAD`
- `./mvnw -pl micronaut-maven-plugin -am -Dtest=AbstractConfigurationValidationMojoTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=configuration-validation-valid"`

Fixes #1649

Selected organization projects: `5.0.0-M3` and `5.0.0 Release`.

---
###### ✨ This message was AI-generated using gpt-5
