### PR TITLE
Add SharedArenaSupport default for docker-native

### DIFF
--- a/micronaut-maven-core/src/main/java/io/micronaut/maven/core/MojoUtils.java
+++ b/micronaut-maven-core/src/main/java/io/micronaut/maven/core/MojoUtils.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 public final class MojoUtils {
 
     public static final String THIS_PLUGIN = "io.micronaut.maven:micronaut-maven-plugin";
+    public static final String SHARED_ARENA_SUPPORT = "-H:+SharedArenaSupport";
     private static final String JAVA = "java";
     private static final String MOSTLY_STATIC_NATIVE_IMAGE_GRAALVM_FLAG = "-H:+StaticExecutableWithDynamicLibC";
 
@@ -76,6 +77,10 @@ public final class MojoUtils {
     }
 
     public static List<String> computeNativeImageArgs(List<String> nativeImageBuildArgs, String baseImageRun, String argsFile) {
+        return computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile, false);
+    }
+
+    public static List<String> computeNativeImageArgs(List<String> nativeImageBuildArgs, String baseImageRun, String argsFile, boolean sharedArenaSupport) {
         var allNativeImageBuildArgs = new ArrayList<String>();
         if (nativeImageBuildArgs != null && !nativeImageBuildArgs.isEmpty()) {
             allNativeImageBuildArgs.addAll(nativeImageBuildArgs);
@@ -86,7 +91,33 @@ public final class MojoUtils {
 
         List<String> argsFileContent = parseNativeImageArgsFile(argsFile).toList();
         allNativeImageBuildArgs.addAll(argsFileContent);
+        if (sharedArenaSupport) {
+            if (allNativeImageBuildArgs.contains(SHARED_ARENA_SUPPORT)) {
+                removeDuplicateSharedArenaSupport(allNativeImageBuildArgs);
+            } else {
+                allNativeImageBuildArgs.add(SHARED_ARENA_SUPPORT);
+            }
+        }
         return allNativeImageBuildArgs;
+    }
+
+    public static boolean supportsSharedArena(int graalVmMajorVersion) {
+        return graalVmMajorVersion >= 25;
+    }
+
+    private static void removeDuplicateSharedArenaSupport(List<String> nativeImageBuildArgs) {
+        boolean found = false;
+        for (int i = 0; i < nativeImageBuildArgs.size(); i++) {
+            if (!SHARED_ARENA_SUPPORT.equals(nativeImageBuildArgs.get(i))) {
+                continue;
+            }
+            if (found) {
+                nativeImageBuildArgs.remove(i);
+                i--;
+            } else {
+                found = true;
+            }
+        }
     }
 
     public static String parseConfigurationFilesDirectoriesArg(String arg) {

--- a/micronaut-maven-core/src/test/java/io/micronaut/maven/core/MojoUtilsTest.java
+++ b/micronaut-maven-core/src/test/java/io/micronaut/maven/core/MojoUtilsTest.java
@@ -17,6 +17,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -171,5 +173,43 @@ class MojoUtilsTest {
         List<String> result = MojoUtils.computeNativeImageArgs(List.of(), "oraclelinux:9", argsFile.toString());
 
         assertIterableEquals(List.of("\\Q/home/app/libs/snapshot/demo-1.0-20260330.123456-1.jar\\E"), result);
+    }
+
+    @Test
+    void testComputeNativeImageArgsAddsSharedArenaSupportWhenSupported(@TempDir Path tempDir) throws IOException {
+        Path argsFile = tempDir.resolve("graalvm-native-image.args");
+        Files.write(argsFile, List.of("--no-fallback"));
+
+        List<String> result = MojoUtils.computeNativeImageArgs(List.of("-Ob"), "oraclelinux:9", argsFile.toString(), true);
+
+        assertIterableEquals(List.of("-Ob", "--no-fallback", MojoUtils.SHARED_ARENA_SUPPORT), result);
+    }
+
+    @Test
+    void testComputeNativeImageArgsSkipsSharedArenaSupportWhenUnsupported(@TempDir Path tempDir) throws IOException {
+        Path argsFile = tempDir.resolve("graalvm-native-image.args");
+        Files.write(argsFile, List.of("--no-fallback"));
+
+        List<String> result = MojoUtils.computeNativeImageArgs(List.of("-Ob"), "oraclelinux:9", argsFile.toString(), false);
+
+        assertFalse(result.contains(MojoUtils.SHARED_ARENA_SUPPORT));
+    }
+
+    @Test
+    void testComputeNativeImageArgsDoesNotDuplicateSharedArenaSupport(@TempDir Path tempDir) throws IOException {
+        Path argsFile = tempDir.resolve("graalvm-native-image.args");
+        Files.write(argsFile, List.of(MojoUtils.SHARED_ARENA_SUPPORT));
+
+        List<String> result = MojoUtils.computeNativeImageArgs(List.of(MojoUtils.SHARED_ARENA_SUPPORT), "oraclelinux:9", argsFile.toString(), true);
+
+        assertEquals(1, result.stream().filter(MojoUtils.SHARED_ARENA_SUPPORT::equals).count());
+    }
+
+    @Test
+    void testSupportsSharedArenaUsesGraalVm25Threshold() {
+        assertFalse(MojoUtils.supportsSharedArena(21));
+        assertFalse(MojoUtils.supportsSharedArena(24));
+        assertTrue(MojoUtils.supportsSharedArena(25));
+        assertTrue(MojoUtils.supportsSharedArena(26));
     }
 }

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base-jib-precedence/verify.groovy
@@ -4,6 +4,10 @@ String expectedDockerfileText = expectedDockerfile.text
 
 assert dockerfile.text == expectedDockerfileText
 
+File argsFile = new File("$basedir/target").listFiles().find { it.name.endsWith(".args") }
+assert argsFile != null
+assert argsFile.text.contains("-H:+SharedArenaSupport")
+
 File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS")

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty-custom-builder-base/verify.groovy
@@ -4,6 +4,10 @@ String expectedDockerfileText = expectedDockerfile.text
 
 assert dockerfile.text == expectedDockerfileText
 
+File argsFile = new File("$basedir/target").listFiles().find { it.name.endsWith(".args") }
+assert argsFile != null
+assert !argsFile.text.contains("-H:+SharedArenaSupport")
+
 File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("BUILD SUCCESS")

--- a/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/dockerfile-docker-native-netty/verify.groovy
@@ -4,6 +4,10 @@ String expectedDockerfileText = expectedDockerfile.text.replace("25", "${System.
 
 assert dockerfile.text == expectedDockerfileText
 
+File argsFile = new File("$basedir/target").listFiles().find { it.name.endsWith(".args") }
+assert argsFile != null
+assert argsFile.text.contains("-H:+SharedArenaSupport")
+
 File log = new File(basedir, 'build.log')
 assert log.exists()
 assert log.text.contains("io.micronaut.runtime.Micronaut - Startup completed")

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -295,7 +295,11 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         if (!matcher.matches()) {
             return Optional.empty();
         }
-        return Optional.of(Integer.parseInt(matcher.group(1)));
+        try {
+            return Optional.of(Integer.parseInt(matcher.group(1)));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 
     private static boolean isGraalVmNativeImageRepository(String repository) {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.common.io.FileWriteMode;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.maven.core.MicronautRuntime;
+import io.micronaut.maven.core.MojoUtils;
 import io.micronaut.maven.jib.JibConfigurationService;
 import io.micronaut.maven.jib.JibMicronautExtension;
 import io.micronaut.maven.services.ApplicationConfigurationService;
@@ -45,12 +46,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.micronaut.maven.services.ApplicationConfigurationService.DEFAULT_PORT;
 
@@ -76,6 +80,7 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     private static final String DEPENDENCY_DIRECTORY = "dependency";
     private static final String RELEASE_DEPENDENCY_DIRECTORY = "release";
     private static final String SNAPSHOT_DEPENDENCY_DIRECTORY = "snapshot";
+    private static final Pattern LEADING_MAJOR_VERSION = Pattern.compile("([1-9][0-9]*)(?:[.-].*)?");
     private static final NavigableSet<Integer> GRAALVM_VERSIONS = new TreeSet<>(Set.of(25));
     private static final List<String> DEFAULT_LAMBDA_BOOTSTRAP_ARGUMENTS = List.of(
         "-XX:MaximumHeapSizePercent=80",
@@ -248,6 +253,56 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
             .or(() -> Optional.ofNullable(baseImage).filter(StringUtils::hasText))
             .or(() -> getFromImage().filter(StringUtils::hasText))
             .orElse(DEFAULT_BASE_IMAGE_GRAALVM_BUILD + ":" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion));
+    }
+
+    /**
+     * @return whether the selected native-image builder is known to support {@code -H:+SharedArenaSupport}.
+     */
+    protected boolean supportsSharedArena() {
+        return sharedArenaBuilderMajorVersion()
+            .map(MojoUtils::supportsSharedArena)
+            .orElse(false);
+    }
+
+    private Optional<Integer> sharedArenaBuilderMajorVersion() {
+        return getJibFromImageSystemProperty()
+            .or(() -> Optional.ofNullable(baseImage).filter(StringUtils::hasText))
+            .or(() -> getFromImage().filter(StringUtils::hasText))
+            .map(AbstractDockerMojo::graalVmNativeImageBuilderMajorVersion)
+            .orElseGet(() -> Optional.of(resolveGraalVersion()));
+    }
+
+    static Optional<Integer> graalVmNativeImageBuilderMajorVersion(String image) {
+        if (!StringUtils.hasText(image)) {
+            return Optional.empty();
+        }
+
+        int digestStart = image.indexOf('@');
+        String imageWithoutDigest = digestStart >= 0 ? image.substring(0, digestStart) : image;
+        int lastSlash = imageWithoutDigest.lastIndexOf('/');
+        int tagSeparator = imageWithoutDigest.lastIndexOf(':');
+        if (tagSeparator <= lastSlash) {
+            return Optional.empty();
+        }
+
+        String repository = imageWithoutDigest.substring(0, tagSeparator).toLowerCase(Locale.ROOT);
+        if (!isGraalVmNativeImageRepository(repository)) {
+            return Optional.empty();
+        }
+
+        String tag = imageWithoutDigest.substring(tagSeparator + 1);
+        Matcher matcher = LEADING_MAJOR_VERSION.matcher(tag);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(Integer.parseInt(matcher.group(1)));
+    }
+
+    private static boolean isGraalVmNativeImageRepository(String repository) {
+        int lastSlash = repository.lastIndexOf('/');
+        String imageName = lastSlash >= 0 ? repository.substring(lastSlash + 1) : repository;
+        return (repository.startsWith("graalvm/") || repository.contains("/graalvm/"))
+            && imageName.startsWith("native-image");
     }
 
     /**

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -158,7 +158,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         // Starter sets the right class in pom.xml:
         //   - For applications: io.micronaut.function.aws.runtime.MicronautLambdaRuntime
         //   - For function apps: com.example.BookLambdaRuntime
-        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments, () -> dockerService.buildImageCmd()
+        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments, supportsSharedArena(), () -> dockerService.buildImageCmd()
             .withDockerfile(dockerfile)
             .withBuildArg("GRAALVM_DOWNLOAD_URL", graalVmDownloadUrl()));
         buildImageCmd.withBuildArg("CLASS_NAME", escapeClassNameBuildArg(mainClass));
@@ -205,7 +205,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
             oracleCloudFunctionCmd(dockerfile);
         }
 
-        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments(passClassName), () -> dockerService.buildImageCmd()
+        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments(passClassName), supportsSharedArena(), () -> dockerService.buildImageCmd()
             .withDockerfile(dockerfile)
             .withTags(tags)
             .withBuildArg("BASE_IMAGE", from)
@@ -222,7 +222,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         File targetDockerfile = new File(targetDir, providedDockerfile.getName());
         Files.copy(providedDockerfile.toPath(), targetDockerfile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
-        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments(passClassName), () -> dockerService.buildImageCmd()
+        BuildImageCmd buildImageCmd = addNativeImageBuildArgs(buildImageCmdArguments(passClassName), false, () -> dockerService.buildImageCmd()
             .withDockerfile(targetDockerfile)
             .withTags(tags)
             .withBaseDirectory(targetDir)
@@ -248,9 +248,9 @@ public class DockerNativeMojo extends AbstractDockerMojo {
         return buildImageCmdArguments;
     }
 
-    private BuildImageCmd addNativeImageBuildArgs(Map<String, String> buildImageCmdArguments, Supplier<BuildImageCmd> buildImageCmdSupplier) throws IOException {
+    private BuildImageCmd addNativeImageBuildArgs(Map<String, String> buildImageCmdArguments, boolean sharedArenaSupport, Supplier<BuildImageCmd> buildImageCmdSupplier) throws IOException {
         String argsFile = mavenProject.getProperties().getProperty(ARGS_FILE_PROPERTY_NAME);
-        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile, supportsSharedArena());
+        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile, sharedArenaSupport);
         //Remove extra main class argument
         allNativeImageBuildArgs.remove(mainClass);
         getLog().info("GraalVM native image build args: " + allNativeImageBuildArgs);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerNativeMojo.java
@@ -250,7 +250,7 @@ public class DockerNativeMojo extends AbstractDockerMojo {
 
     private BuildImageCmd addNativeImageBuildArgs(Map<String, String> buildImageCmdArguments, Supplier<BuildImageCmd> buildImageCmdSupplier) throws IOException {
         String argsFile = mavenProject.getProperties().getProperty(ARGS_FILE_PROPERTY_NAME);
-        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile);
+        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile, supportsSharedArena());
         //Remove extra main class argument
         allNativeImageBuildArgs.remove(mainClass);
         getLog().info("GraalVM native image build args: " + allNativeImageBuildArgs);

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerfileMojo.java
@@ -310,7 +310,7 @@ public class DockerfileMojo extends AbstractDockerMojo {
     }
 
     private void processNativeImageArgs(String argsFile) throws IOException, MojoExecutionException {
-        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile);
+        List<String> allNativeImageBuildArgs = MojoUtils.computeNativeImageArgs(nativeImageBuildArgs, baseImageRun, argsFile, supportsSharedArena());
         //Remove extra main class argument
         allNativeImageBuildArgs.remove(mainClass);
         getLog().info("GraalVM native image build args: " + allNativeImageBuildArgs);

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -110,6 +110,10 @@ For example, to add `--verbose` to the native image args, you should define:
 </plugin>
 ----
 
+For GraalVM/Java 25 or newer native images that need Netty's shared arena support, add
+`-H:+SharedArenaSupport` through the same upstream native plugin `<buildArgs>` configuration. Micronaut Maven Plugin
+does not rewrite the delegated `native-image` packaging configuration.
+
 ==== Windows users
 
 Sometimes, depending on how many classes are in the classpath you may see an error `The command line is too long` when
@@ -300,6 +304,12 @@ $ mvn package -Dpackaging=docker-native
 
 If the `<packaging>` is set to `docker-native`, this plugin will use a Docker client to build and tag custom Docker
 images. In this case, the `micronaut.runtime` property will also determine how the image is prepared.
+
+For Micronaut-managed `docker-native` builds and generated Dockerfiles, the plugin adds `-H:+SharedArenaSupport` to
+the native-image arguments by default when the selected builder is known to be a GraalVM/Java 25 or newer native-image
+builder. Current Netty native images require this flag on those builders. The plugin skips the default for older
+builders and for custom builder images whose GraalVM major version cannot be confidently detected; when you know a
+custom builder supports the option, add it explicitly with `nativeImageBuildArgs` or `micronaut.native-image.args`.
 
 * Default runtime.
 ** Default image (pinned immutable base): `mvn package -Dpackaging=docker-native`.

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -80,6 +80,59 @@ class AbstractDockerMojoTest {
     }
 
     @Test
+    void supportsSharedArenaForDefaultGraalVm25Builder(@TempDir Path tempDir) {
+        var project = mockProject(tempDir, Set.of());
+        project.getProperties().setProperty("maven.compiler.release", "25");
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+
+        assertTrue(mojo.supportsSharedArenaBuilder());
+    }
+
+    @Test
+    void skipsSharedArenaForOlderCustomGraalVmBuilder(@TempDir Path tempDir) {
+        var project = mockProject(tempDir, Set.of());
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+        mojo.baseImage = "container-registry.oracle.com/graalvm/native-image:21-ol8";
+
+        assertFalse(mojo.supportsSharedArenaBuilder());
+    }
+
+    @Test
+    void supportsSharedArenaForGraalVm25CustomBuilderTags(@TempDir Path tempDir) {
+        var project = mockProject(tempDir, Set.of());
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.of("ghcr.io/graalvm/native-image-community:25-muslib-ol9"));
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+
+        assertTrue(mojo.supportsSharedArenaBuilder());
+        assertEquals(Optional.of(25), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("container-registry.oracle.com/graalvm/native-image:25-ol9"));
+        assertEquals(Optional.of(25), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("ghcr.io/graalvm/native-image-community:25.0.1-ol9"));
+    }
+
+    @Test
+    void skipsSharedArenaForUnknownCustomBuilderTags(@TempDir Path tempDir) {
+        System.setProperty(AbstractDockerMojo.JIB_FROM_IMAGE_PROPERTY, "ghcr.io/example/native-image:25-ol9");
+
+        var project = mockProject(tempDir, Set.of());
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
+
+        var mojo = new TestDockerMojo(project, mockSession(project), jibConfigurationService);
+
+        assertFalse(mojo.supportsSharedArenaBuilder());
+        assertEquals(Optional.empty(), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("container-registry.oracle.com/graalvm/native-image@sha256:1234"));
+        assertEquals(Optional.empty(), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("container-registry.oracle.com/graalvm/native-image:latest"));
+        assertEquals(Optional.empty(), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("ghcr.io/example/native-image:25-ol9"));
+    }
+
+    @Test
     void copyDependenciesKeepsFlatLayoutAndAddsReleaseAndSnapshotLayers(@TempDir Path tempDir) throws IOException {
         var releaseJar = Files.writeString(tempDir.resolve("release.jar"), "release");
         var snapshotJar = Files.writeString(tempDir.resolve("snapshot.jar"), "snapshot");
@@ -193,6 +246,10 @@ class AbstractDockerMojoTest {
 
         private String defaultBuilderImage() {
             return DEFAULT_BASE_IMAGE_GRAALVM_BUILD + ":" + graalVmTag(graalVmJvmVersion(), staticNativeImage, oracleLinuxVersion);
+        }
+
+        private boolean supportsSharedArenaBuilder() {
+            return supportsSharedArena();
         }
 
         @Override

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/AbstractDockerMojoTest.java
@@ -130,6 +130,7 @@ class AbstractDockerMojoTest {
         assertEquals(Optional.empty(), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("container-registry.oracle.com/graalvm/native-image@sha256:1234"));
         assertEquals(Optional.empty(), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("container-registry.oracle.com/graalvm/native-image:latest"));
         assertEquals(Optional.empty(), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("ghcr.io/example/native-image:25-ol9"));
+        assertEquals(Optional.empty(), AbstractDockerMojo.graalVmNativeImageBuilderMajorVersion("container-registry.oracle.com/graalvm/native-image:999999999999999999999999999999999-ol9"));
     }
 
     @Test

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
@@ -1,6 +1,7 @@
 package io.micronaut.maven;
 
 import com.github.dockerjava.api.command.BuildImageCmd;
+import io.micronaut.maven.core.MojoUtils;
 import io.micronaut.maven.jib.JibConfigurationService;
 import io.micronaut.maven.services.ApplicationConfigurationService;
 import io.micronaut.maven.services.DockerService;
@@ -372,6 +373,32 @@ class DockerNativeMojoTest {
         verify(fixtures.dockerService).buildImage(fixtures.buildImageCmd);
     }
 
+    @Test
+    void buildDockerfileAddsSharedArenaSupportForDefaultGraalVm25Builder(@TempDir Path tempDir) throws Exception {
+        Path dockerfile = tempDir.resolve("DockerfileNative");
+        Files.writeString(dockerfile, "FROM builder\n");
+        Fixtures fixtures = new Fixtures(tempDir, dockerfile);
+        fixtures.properties.setProperty("maven.compiler.release", "25");
+
+        invokeBuildDockerfile(fixtures.mojo, DockerfileMojo.DOCKERFILE_NATIVE, true);
+
+        assertTrue(Files.readString(findConvertedArgsFile(fixtures.targetDir)).contains(MojoUtils.SHARED_ARENA_SUPPORT));
+        verify(fixtures.dockerService).buildImage(fixtures.buildImageCmd);
+    }
+
+    @Test
+    void buildDockerfileSkipsSharedArenaSupportForCustomGraalVm21Builder(@TempDir Path tempDir) throws Exception {
+        Path dockerfile = tempDir.resolve("DockerfileNative");
+        Files.writeString(dockerfile, "FROM builder\n");
+        Fixtures fixtures = new Fixtures(tempDir, dockerfile);
+        fixtures.mojo.baseImage = "container-registry.oracle.com/graalvm/native-image:21-ol8";
+
+        invokeBuildDockerfile(fixtures.mojo, DockerfileMojo.DOCKERFILE_NATIVE, true);
+
+        assertFalse(Files.readString(findConvertedArgsFile(fixtures.targetDir)).contains(MojoUtils.SHARED_ARENA_SUPPORT));
+        verify(fixtures.dockerService).buildImage(fixtures.buildImageCmd);
+    }
+
     private boolean supportsSymbolicLinks(Path tempDir) throws IOException {
         Path probeTarget = tempDir.resolve("symlink-probe-target");
         Path probeLink = tempDir.resolve("symlink-probe-link");
@@ -409,6 +436,15 @@ class DockerNativeMojoTest {
             return exception;
         }
         throw e;
+    }
+
+    private Path findConvertedArgsFile(Path targetDir) throws IOException {
+        try (var paths = Files.list(targetDir)) {
+            return paths
+                .filter(path -> path.getFileName().toString().endsWith(".args"))
+                .findFirst()
+                .orElseThrow();
+        }
     }
 
     private static final class Fixtures {

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerNativeMojoTest.java
@@ -374,6 +374,36 @@ class DockerNativeMojoTest {
     }
 
     @Test
+    void buildDockerfileSkipsSharedArenaSupportForProvidedDockerfile(@TempDir Path tempDir) throws Exception {
+        Path providedDockerfile = tempDir.resolve(DockerfileMojo.DOCKERFILE);
+        Files.writeString(providedDockerfile, "FROM builder\nENTRYPOINT [\"/app/application\"]\n");
+
+        Fixtures fixtures = new Fixtures(tempDir, tempDir.resolve("DockerfileNative"));
+        fixtures.properties.setProperty("maven.compiler.release", "25");
+
+        invokeBuildDockerfile(fixtures.mojo, DockerfileMojo.DOCKERFILE_NATIVE, true);
+
+        assertFalse(Files.readString(findConvertedArgsFile(fixtures.targetDir)).contains(MojoUtils.SHARED_ARENA_SUPPORT));
+        verify(fixtures.dockerService).buildImage(fixtures.buildImageCmd);
+    }
+
+    @Test
+    void buildDockerfilePreservesExplicitSharedArenaSupportForProvidedDockerfile(@TempDir Path tempDir) throws Exception {
+        Path providedDockerfile = tempDir.resolve(DockerfileMojo.DOCKERFILE);
+        Files.writeString(providedDockerfile, "FROM builder\nENTRYPOINT [\"/app/application\"]\n");
+
+        Fixtures fixtures = new Fixtures(tempDir, tempDir.resolve("DockerfileNative"));
+        fixtures.mojo.nativeImageBuildArgs = List.of(MojoUtils.SHARED_ARENA_SUPPORT);
+
+        invokeBuildDockerfile(fixtures.mojo, DockerfileMojo.DOCKERFILE_NATIVE, true);
+
+        String args = Files.readString(findConvertedArgsFile(fixtures.targetDir));
+        assertTrue(args.contains(MojoUtils.SHARED_ARENA_SUPPORT));
+        assertEquals(1, args.lines().filter(MojoUtils.SHARED_ARENA_SUPPORT::equals).count());
+        verify(fixtures.dockerService).buildImage(fixtures.buildImageCmd);
+    }
+
+    @Test
     void buildDockerfileAddsSharedArenaSupportForDefaultGraalVm25Builder(@TempDir Path tempDir) throws Exception {
         Path dockerfile = tempDir.resolve("DockerfileNative");
         Files.writeString(dockerfile, "FROM builder\n");

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerfileMojoTest.java
@@ -1,6 +1,7 @@
 package io.micronaut.maven;
 
 import io.micronaut.maven.jib.JibConfigurationService;
+import io.micronaut.maven.core.MojoUtils;
 import io.micronaut.maven.services.ApplicationConfigurationService;
 import io.micronaut.maven.services.DockerService;
 import io.micronaut.maven.services.ExecutorService;
@@ -369,6 +370,69 @@ class DockerfileMojoTest {
             ),
             Files.readAllLines(dockerfile)
         );
+    }
+
+    @Test
+    void processDockerfileAddsSharedArenaSupportForDefaultGraalVm25Builder(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        project.getProperties().setProperty("maven.compiler.release", "25");
+        Path argsFile = tempDir.resolve("target").resolve("native-image.args");
+        Files.writeString(argsFile, "--no-fallback\n");
+        project.getProperties().setProperty(DockerNativeMojo.ARGS_FILE_PROPERTY_NAME, argsFile.toString());
+        var mojo = newDockerfileMojo(project, Optional.empty());
+        mojo.baseImageRun = AbstractDockerMojo.DEFAULT_BASE_IMAGE_GRAALVM_RUN;
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "FROM builder");
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertTrue(Files.readString(findConvertedArgsFile(tempDir.resolve("target"))).contains(MojoUtils.SHARED_ARENA_SUPPORT));
+    }
+
+    @Test
+    void processDockerfileSkipsSharedArenaSupportForCustomGraalVm21Builder(@TempDir Path tempDir) throws IOException, MojoExecutionException {
+        var project = mockProject(tempDir);
+        Path argsFile = tempDir.resolve("target").resolve("native-image.args");
+        Files.writeString(argsFile, "--no-fallback\n");
+        project.getProperties().setProperty(DockerNativeMojo.ARGS_FILE_PROPERTY_NAME, argsFile.toString());
+        var mojo = newDockerfileMojo(project, Optional.empty());
+        mojo.baseImageRun = AbstractDockerMojo.DEFAULT_BASE_IMAGE_GRAALVM_RUN;
+        mojo.baseImage = "container-registry.oracle.com/graalvm/native-image:21-ol8";
+
+        var dockerfile = Files.writeString(tempDir.resolve("Dockerfile"), "FROM builder");
+
+        invokeProcessDockerfile(mojo, dockerfile);
+
+        assertFalse(Files.readString(findConvertedArgsFile(tempDir.resolve("target"))).contains(MojoUtils.SHARED_ARENA_SUPPORT));
+    }
+
+    private static DockerfileMojo newDockerfileMojo(MavenProject project, Optional<String> fromImage) {
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getFromImage()).thenReturn(fromImage);
+        when(jibConfigurationService.getPorts()).thenReturn(Optional.of("8080"));
+        var mojo = new DockerfileMojo(
+            project,
+            mock(DockerService.class),
+            jibConfigurationService,
+            mock(ApplicationConfigurationService.class),
+            mock(ExecutorService.class),
+            mockSession(project),
+            mock(MojoExecution.class)
+        );
+        mojo.micronautRuntime = "netty";
+        mojo.mainClass = "example.Application";
+        mojo.staticNativeImage = false;
+        mojo.oracleLinuxVersion = "ol9";
+        return mojo;
+    }
+
+    private static Path findConvertedArgsFile(Path targetDir) throws IOException {
+        try (var paths = Files.list(targetDir)) {
+            return paths
+                .filter(path -> path.getFileName().toString().endsWith(".args"))
+                .findFirst()
+                .orElseThrow();
+        }
     }
 
     private static MavenProject mockProject(Path tempDir) {


### PR DESCRIPTION
## Summary
- add `-H:+SharedArenaSupport` by default for Micronaut-managed `docker-native` native-image arguments when the selected builder is confidently GraalVM/Java 25+
- keep older, unknown, digest-only, and non-GraalVM custom builders on the existing explicit-opt-in path
- document the `docker-native` default and preserve the plain `native-image` delegation boundary to `native-maven-plugin`

## Issue Linkage
- Paperclip issue: DEV-221
- Related prior work: micronaut-projects/micronaut-gradle-plugin#1280 and micronaut-projects/micronaut-gradle-plugin#1212
- Linked GitHub issue: none; this was a manual Paperclip follow-up, so no GitHub closing keyword applies.

## Release Metadata
- Type: improvement
- Target branch/release: `5.0.x` / `5.0.0`
- Micronaut organization projects selected during QA intake: `5.0.0 Release` and `5.0.0-M3`
- Ambiguity note: `5.0.0-M3` remains open even though the prerelease was published on 2026-04-29; if maintainers treat post-M3 work as GA-only, `5.0.0 Release` is the practical primary board.

## Verification
- `./mvnw -pl micronaut-maven-core,micronaut-maven-plugin -Dtest=MojoUtilsTest,AbstractDockerMojoTest,DockerNativeMojoTest,DockerfileMojoTest test`
- Prior QA-accepted invoker proof: `./mvnw verify "-Dinvoker.test=dockerfile-docker-native-netty,dockerfile-docker-native-netty-custom-builder-base,dockerfile-docker-native-netty-custom-builder-base-jib-precedence"`

---
###### ✨ This message was AI-generated using GPT-5
