### PR TITLE
chore: apply relevant project template updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,15 +13,28 @@
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
-      "matchPackageNames": [
-        "/actions.*/"
-      ]
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions dependencies"
+    },{
+      "matchDatasources": [
+        "maven"
+      ],
+      "matchManagers": [
+        "maven",
+        "gradle"
+      ],
+      "allowedVersions": "!/.+-SNAPSHOT$/"
     },{
       "matchUpdateTypes": [
         "patch"
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },{
+      "matchPackageNames": [
+        "/.*micronaut.*/"
+      ],
+      "groupName": "Micronaut dependencies"
     },{
       "matchFileNames": [
         "src/it/package-docker-native-different-parent-version/pom.xml"

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ gradle-app.setting
 
 .idea
 *.iml
+
+# OpenCode files
+.sisyphus/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 


### PR DESCRIPTION
## Summary
- apply Maven-relevant template Renovate rules for grouped GitHub Actions and Micronaut dependency updates
- block automated Maven/Gradle SNAPSHOT dependency updates
- align propagated housekeeping entries for `.sisyphus/` and the Apache license HTTPS URL

## Verification
- `jq empty .github/renovate.json`
- `npx --yes --package renovate renovate-config-validator --strict --no-global .github/renovate.json`
- `bash .github/scripts/check-workflow-pinning.sh`
- `git diff --check origin/5.0.x...HEAD`

## Paperclip
- DEV-227
- No linked GitHub issue exists for this routine-created task, so no closing keyword is included.
- Selected Micronaut organization projects: `5.0.0-M3`, `5.0.0 Release`

---
###### ✨ This message was AI-generated using gpt-5