### PR TITLE
docs: fix Maven plugin site navigation

### DIFF
--- a/micronaut-maven-plugin/src/site/asciidoc/examples/jsonschema.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/jsonschema.adoc
@@ -1,6 +1,6 @@
 === Integration with Micronaut JSON Schema Generator
 
-This plugins integrates with https://micronaut-projects.github.io/micronaut-json-schema/latest/guide/[Micronaut JSON Schema] in order to provide support for generating beans from https://json-schema.org[JSON Schema].
+This plugin integrates with https://micronaut-projects.github.io/micronaut-json-schema/latest/guide/[Micronaut JSON Schema] to provide support for generating beans from https://json-schema.org[JSON Schema].
 
 The link:../generate-jsonschema-mojo.html[mn:generate-jsonschema] goal is integrated into the `generate-sources` lifecycle phase and, if enabled, will generate sources in the `target` directory.
 
@@ -11,13 +11,13 @@ In order to generate Java Beans, the minimal thing to do is enable the goal and 
 <properties>
    ...
    <micronaut.jsonschema.generator.enabled>true</micronaut.jsonschema.generator.enabled>
-   <micronaut.jsonschema.generator.input-file>=src/main/resources/animal.schema.json</micronaut.jsonschema.generator.input-file>
+   <micronaut.jsonschema.generator.input-file>src/main/resources/animal.schema.json</micronaut.jsonschema.generator.input-file>
 </properties>
 ----
 
 Some important notes on configuration settings:
 
-- Default generation language is JAVA which can be modified. However, only the languages supported by  https://micronaut-projects.github.io/micronaut-sourcegen/latest/guide/[Micronaut SourceGen] are supported.
+- The default generation language is `JAVA`, but it can be changed. Only languages supported by https://micronaut-projects.github.io/micronaut-sourcegen/latest/guide/[Micronaut SourceGen] are supported.
 - The available input values are `input-url`, `input-file`, and `input-directory`. At least one type of input values needs to be provided. If more than one input value is given, only the first non-null value will be used in the aforementioned order.
 - The generator supports all remote references that obey at least one of the pattern rules given in `accepted-url-patterns` parameter. This parameter is configurable, and it's default value is `["^https://.*/.*.json"]`.
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/openapi.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/openapi.adoc
@@ -1,11 +1,11 @@
 === Integration with Micronaut OpenAPI
 
-This plugins integrates with https://micronaut-projects.github.io/micronaut-openapi/latest/guide/index.html[Micronaut OpenAPI] in order to provide support for generating https://www.openapis.org/[OpenAPI] clients or servers.
+This plugin integrates with https://micronaut-projects.github.io/micronaut-openapi/latest/guide/index.html[Micronaut OpenAPI] to provide support for generating https://www.openapis.org/[OpenAPI] clients or servers.
 
 The plugin adds a couple goals which can be used to generate code:
 
 - the link:../generate-openapi-client-mojo.html[mn:generate-openapi-client] goal can be used to generate a client from an OpenAPI definition
-- the link:../generate-openapi-server-mojo.html[mn:generate-openapi-server] goal can be used to generate server skeleton from an OpenAPI definition
+- the link:../generate-openapi-server-mojo.html[mn:generate-openapi-server] goal can be used to generate a server skeleton from an OpenAPI definition
 
 In both cases, the code is generated in your `target` directory and integrated into the build lifecycle.
 In particular, in case you are generating a server, the generated code will be interfaces that you will have to implement in your main sources.

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -495,7 +495,7 @@ $ mvn package -Dpackaging=docker-native -Dmicronaut.native-image.args="--verbose
 The CRaC (https://openjdk.org/projects/crac/[Coordinated Restore at Checkpoint]) Project researches coordination of Java programs with mechanisms to checkpoint (make an image of, snapshot) a Java instance while it is executing.
 Restoring from the image could be a solution to some problems with the start-up and warm-up times.
 
-Creation of a pre-warmed, checkpointed docker image cane be done with the following command:
+Creation of a pre-warmed, checkpointed docker image can be done with the following command:
 
 ----
 $ mvn package -Dpackaging=docker-crac
@@ -521,7 +521,7 @@ https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#configu
 
 ==== Checking an application is ready
 
-As part of the checkpointing process, the application will be tested until it is ready to recieve requests.
+As part of the checkpointing process, the application will be tested until it is ready to receive requests.
 This is by default done by executing the command `curl --output /dev/null --silent --head http://localhost:8080`, however you can override this by setting the `crac.readiness` property in your build.
 
 [source,xml]

--- a/micronaut-maven-plugin/src/site/asciidoc/index.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/index.adoc
@@ -50,7 +50,7 @@ Then, declare the plugin to your `build/plugins` section:
 WARNING: Since version 4.0.0 of this plugin (which is the version compatible with Micronaut 4.x), the group id is
 `io.micronaut.maven`. Earlier versions compatible with Micronaut 3.x used `io.micronaut.build`.
 
-The `<packaging>` part is important since the plugin support several packaging types. The default is `jar`.
+The `<packaging>` part is important since the plugin supports several packaging types. The default is `jar`.
 
 For snapshot versions, you need the Maven Central Portal Snapshot repository:
 

--- a/micronaut-maven-plugin/src/site/asciidoc/index.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/index.adoc
@@ -1,3 +1,5 @@
+= Micronaut Maven Plugin
+
 {site-description}.
 
 This plugin has the following features:
@@ -10,10 +12,10 @@ This plugin has the following features:
 6. link:examples/test-resources.html[Integration with Micronaut Test Resources].
 7. link:examples/openapi.html[Integration with Micronaut OpenAPI].
 8. link:examples/bean-import.html[Importing beans from project dependencies].
-9. link:examples/jsonschema.html[Generating Sources from JSON Schema]
-10. link:examples/configuration-validation.html[Validating Micronaut configuration and dependency injection]
+9. link:examples/jsonschema.html[Generating Sources from JSON Schema].
+10. link:examples/configuration-validation.html[Validating Micronaut configuration and dependency injection].
 
-=== Usage
+== Usage
 
 It is recommended to use this plugin in combination with the https://central.sonatype.com/artifact/io.micronaut.platform/micronaut-parent[Micronaut Parent POM].
 

--- a/micronaut-maven-plugin/src/site/site.xml
+++ b/micronaut-maven-plugin/src/site/site.xml
@@ -30,6 +30,7 @@
             <item name="Generating OpenAPI clients or servers" href="examples/openapi.html"/>
             <item name="Importing beans from project dependencies" href="examples/bean-import.html"/>
             <item name="Generating Sources from JSON Schema" href="examples/jsonschema.html"/>
+            <item name="Validating Micronaut configuration" href="examples/configuration-validation.html"/>
         </menu>
 
         <menu ref="reports"/>


### PR DESCRIPTION
Summary
- Add the configuration validation guide page to the Maven site Examples menu.
- Add a document title and correct heading level on the site index page.
- Correct OpenAPI and JSON Schema example copy, including the JSON Schema input-file value.
- Fix user-facing copy defects in the Maven site usage and CRaC packaging docs.

Validation
- `./mvnw site:site`
- `./mvnw -pl micronaut-maven-plugin site:site`
- Verified rendered output under `micronaut-maven-plugin/target/site/index.html` and `micronaut-maven-plugin/target/site/examples/package.html` contains the corrected text and no stale `cane be`, `recieve`, or `plugin support several` strings.
- Fact-checked CRaC properties and packaging claims against `DockerCracMojo`, `Packaging`, and the docker-crac invoker scenarios.

Paperclip
- DEV-301 Weekly User Guide Review: Micronaut Maven Plugin

---
###### ✨ This message was AI-generated using gpt-5.5
