### PR TITLE
chore: add Maven vulnerability audit

### DIFF
--- a/.github/scripts/vulnerability-audit-filter.py
+++ b/.github/scripts/vulnerability-audit-filter.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+import json
+import sys
+from urllib.parse import parse_qs, urlparse
+
+
+DEFAULT_UPSTREAM_GROUP_PREFIXES = ("io.micronaut",)
+DEFAULT_LOCAL_GROUP_PREFIXES = ("io.micronaut.maven",)
+
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as json_file:
+        return json.load(json_file)
+
+
+def component_ref(component):
+    return component.get("bom-ref") or component.get("purl")
+
+
+def component_group_name(component):
+    group = component.get("group")
+    name = component.get("name")
+    if group and name:
+        return f"{group}:{name}"
+    return name
+
+
+def purl_has_project_path(component):
+    purl = component.get("purl") or component.get("bom-ref") or ""
+    parsed = urlparse(purl)
+    query = parse_qs(parsed.query)
+    return "project_path" in query
+
+
+def parse_prefixes(value):
+    prefixes = []
+    for prefix in value.split(","):
+        prefix = prefix.strip()
+        if prefix:
+            prefixes.append(prefix)
+    return tuple(prefixes)
+
+
+def group_matches_prefixes(group, prefixes):
+    return any(
+        group == prefix or group.startswith(f"{prefix}.")
+        for prefix in prefixes
+    )
+
+
+class AuditGraph:
+    def __init__(self, bom, local_group_prefixes, upstream_group_prefixes):
+        metadata_component = bom.get("metadata", {}).get("component", {})
+        self.components = []
+        if metadata_component:
+            self.components.append(metadata_component)
+        self.components.extend(bom.get("components", []))
+        self.local_group_prefixes = local_group_prefixes
+        self.upstream_group_prefixes = upstream_group_prefixes
+
+        self.component_by_ref = {
+            component_ref(component): component
+            for component in self.components
+            if component_ref(component)
+        }
+        self.refs_by_package = collections.defaultdict(list)
+        for component in self.components:
+            group_name = component_group_name(component)
+            version = component.get("version")
+            ref = component_ref(component)
+            if group_name and version and ref:
+                self.refs_by_package[(group_name, version)].append(ref)
+
+        self.dependencies = collections.defaultdict(set)
+        for dependency in bom.get("dependencies", []):
+            ref = dependency.get("ref")
+            if ref:
+                self.dependencies[ref].update(dependency.get("dependsOn", []))
+
+        self.local_roots = {
+            component_ref(component)
+            for component in self.components
+            if component_ref(component) and self.is_local_component(component)
+        }
+        if not self.local_roots and component_ref(metadata_component):
+            self.local_roots.add(component_ref(metadata_component))
+
+    def is_local_component(self, component):
+        group = component.get("group", "")
+        return purl_has_project_path(component) or group_matches_prefixes(group, self.local_group_prefixes)
+
+    def is_upstream_component(self, ref):
+        component = self.component_by_ref.get(ref)
+        if not component or self.is_local_component(component):
+            return False
+        group = component.get("group", "")
+        return group_matches_prefixes(group, self.upstream_group_prefixes)
+
+    def classify_package(self, package_name, version):
+        targets = set(self.refs_by_package.get((package_name, version), []))
+        if not targets:
+            return {
+                "classification": "actionable",
+                "reason": "package was not found in the CycloneDX dependency graph",
+                "via": [],
+            }
+        if not self.local_roots:
+            return {
+                "classification": "actionable",
+                "reason": "no local project roots were found in the CycloneDX dependency graph",
+                "via": [],
+            }
+
+        path_count = 0
+        upstream_via = set()
+        actionable_reasons = set()
+
+        for root in sorted(self.local_roots):
+            queue = collections.deque()
+            for child in sorted(self.dependencies.get(root, ())):
+                if child in targets:
+                    path_count += 1
+                    if self.is_upstream_component(child):
+                        upstream_via.add(child)
+                    else:
+                        actionable_reasons.add("direct local dependency")
+                    continue
+                first_upstream = child if self.is_upstream_component(child) else None
+                external_before_owner = child not in self.local_roots and first_upstream is None
+                queue.append((child, first_upstream, external_before_owner, {root, child}))
+
+            while queue:
+                node, first_upstream, external_before_owner, seen = queue.popleft()
+                children = self.dependencies.get(node, ())
+                if not children:
+                    continue
+                for child in sorted(children):
+                    if child in seen:
+                        continue
+                    child_first_upstream = first_upstream
+                    child_external_before_owner = external_before_owner
+                    if child_first_upstream is None and child not in self.local_roots:
+                        if self.is_upstream_component(child):
+                            child_first_upstream = child
+                        else:
+                            child_external_before_owner = True
+                    if child in targets:
+                        path_count += 1
+                        if child_first_upstream and not child_external_before_owner:
+                            upstream_via.add(child_first_upstream)
+                        else:
+                            actionable_reasons.add(
+                                "dependency path reaches a non-local, non-upstream component before a configured upstream owner"
+                            )
+                    else:
+                        queue.append((child, child_first_upstream, child_external_before_owner, seen | {child}))
+
+        if path_count == 0:
+            return {
+                "classification": "actionable",
+                "reason": "package was present but unreachable from local project roots",
+                "via": [],
+            }
+        if actionable_reasons:
+            return {
+                "classification": "actionable",
+                "reason": "; ".join(sorted(actionable_reasons)),
+                "via": sorted(upstream_via),
+            }
+        return {
+            "classification": "upstream",
+            "reason": "all dependency paths enter configured upstream Micronaut components before other external components",
+            "via": sorted(upstream_via),
+        }
+
+
+def vulnerability_ids(package):
+    ids = []
+    for group in package.get("groups", []):
+        ids.extend(group.get("ids", []))
+    if not ids:
+        ids.extend(vulnerability.get("id") for vulnerability in package.get("vulnerabilities", []))
+    return sorted({vulnerability_id for vulnerability_id in ids if vulnerability_id})
+
+
+def fixed_versions(package):
+    fixed = set()
+    for vulnerability in package.get("vulnerabilities", []):
+        for affected in vulnerability.get("affected", []):
+            for version_range in affected.get("ranges", []):
+                for event in version_range.get("events", []):
+                    if "fixed" in event:
+                        fixed.add(event["fixed"])
+    return sorted(fixed)
+
+
+def iter_packages(osv_results):
+    for result in osv_results.get("results", []):
+        source = result.get("source", {})
+        for package in result.get("packages", []):
+            yield source, package
+
+
+def print_finding(prefix, finding):
+    ids = ", ".join(finding["ids"]) if finding["ids"] else "unknown vulnerability"
+    fixed = ", ".join(finding["fixed_versions"]) if finding["fixed_versions"] else "unknown fixed version"
+    print(f"- {finding['name']}:{finding['version']} ({ids}; fixed: {fixed})")
+    print(f"  {prefix}: {finding['reason']}")
+    if finding["via"]:
+        print(f"  Via: {', '.join(finding['via'])}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Filter OSV findings that are owned by upstream Micronaut components.")
+    parser.add_argument("--sbom", required=True, help="CycloneDX JSON SBOM path")
+    parser.add_argument("--osv", required=True, help="OSV-Scanner JSON output path")
+    parser.add_argument(
+        "--local-group-prefixes",
+        default=",".join(DEFAULT_LOCAL_GROUP_PREFIXES),
+        help="Comma-separated Maven group prefixes treated as local project modules",
+    )
+    parser.add_argument(
+        "--upstream-group-prefixes",
+        default=",".join(DEFAULT_UPSTREAM_GROUP_PREFIXES),
+        help="Comma-separated Maven group prefixes treated as upstream-owned",
+    )
+    args = parser.parse_args()
+
+    local_group_prefixes = parse_prefixes(args.local_group_prefixes)
+    if not local_group_prefixes:
+        print("No local group prefixes configured; only project_path components will be treated as local.")
+
+    upstream_group_prefixes = parse_prefixes(args.upstream_group_prefixes)
+    if not upstream_group_prefixes:
+        print("No upstream group prefixes configured; no findings will be downgraded.")
+
+    graph = AuditGraph(load_json(args.sbom), local_group_prefixes, upstream_group_prefixes)
+    osv_results = load_json(args.osv)
+
+    actionable = []
+    upstream = []
+
+    for source, package_result in iter_packages(osv_results):
+        package = package_result.get("package", {})
+        ecosystem = package.get("ecosystem")
+        name = package.get("name")
+        version = package.get("version")
+        if ecosystem != "Maven" or not name or not version:
+            classification = {
+                "classification": "actionable",
+                "reason": f"unsupported or incomplete package metadata from {source.get('path', 'unknown source')}",
+                "via": [],
+            }
+        else:
+            classification = graph.classify_package(name, version)
+
+        finding = {
+            "name": name or "unknown",
+            "version": version or "unknown",
+            "ids": vulnerability_ids(package_result),
+            "fixed_versions": fixed_versions(package_result),
+            "reason": classification["reason"],
+            "via": classification["via"],
+        }
+        if classification["classification"] == "upstream":
+            upstream.append(finding)
+        else:
+            actionable.append(finding)
+
+    if upstream:
+        print("Upstream-owned vulnerability findings downgraded to informational:")
+        for finding in upstream:
+            print_finding("Reason", finding)
+
+    if actionable:
+        print("Actionable vulnerability findings:")
+        for finding in actionable:
+            print_finding("Reason", finding)
+        return 1
+
+    if not upstream:
+        print("No known vulnerabilities found.")
+    else:
+        print("No locally actionable vulnerabilities found after upstream ownership filtering.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly CYCLONEDX_MAVEN_PLUGIN_VERSION="${CYCLONEDX_MAVEN_PLUGIN_VERSION:-2.9.1}"
+readonly OSV_SCANNER_IMAGE="${OSV_SCANNER_IMAGE:-ghcr.io/google/osv-scanner:v2.3.5@sha256:4d3d1a42ba435ac706286fec518c044f049c9753d21260b5bae60bab8740ed97}"
+readonly SBOM_PATH="${SBOM_PATH:-target/bom.json}"
+readonly LOCAL_GROUP_PREFIXES="${LOCAL_GROUP_PREFIXES:-io.micronaut.maven}"
+readonly UPSTREAM_GROUP_PREFIXES="${UPSTREAM_GROUP_PREFIXES:-io.micronaut}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ ! -x ./mvnw ]]; then
+    echo "Maven wrapper not found or not executable at ${ROOT_DIR}/mvnw" >&2
+    exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required to run OSV-Scanner" >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+echo "Generating CycloneDX SBOM at ${SBOM_PATH}"
+./mvnw --batch-mode \
+    -DskipTests \
+    -DskipITs \
+    -Dinvoker.skip=true \
+    -Dcyclonedx.skipNotDeployed=false \
+    "org.cyclonedx:cyclonedx-maven-plugin:${CYCLONEDX_MAVEN_PLUGIN_VERSION}:makeAggregateBom"
+
+if [[ ! -s "${SBOM_PATH}" ]]; then
+    echo "CycloneDX SBOM was not generated at ${SBOM_PATH}" >&2
+    exit 1
+fi
+
+osv_args=(
+    run
+    --rm
+    -v "${ROOT_DIR}:/src:ro"
+    -w /src
+    "${OSV_SCANNER_IMAGE}"
+    scan
+    source
+    --experimental-no-default-plugins
+    --experimental-plugins
+    sbom
+    --lockfile
+    "/src/${SBOM_PATH}"
+    --format
+    json
+    --verbosity
+    warn
+)
+
+if [[ -f osv-scanner.toml ]]; then
+    echo "Using osv-scanner.toml for vulnerability audit exceptions"
+    osv_args+=(--config /src/osv-scanner.toml)
+fi
+
+osv_output="${tmp_dir}/osv-results.json"
+
+echo "Scanning CycloneDX SBOM with OSV-Scanner"
+set +e
+docker "${osv_args[@]}" > "${osv_output}"
+osv_status=$?
+set -e
+
+if [[ ${osv_status} -ne 0 && ${osv_status} -ne 1 ]]; then
+    echo "OSV-Scanner failed with exit code ${osv_status}" >&2
+    if [[ -s "${osv_output}" ]]; then
+        cat "${osv_output}" >&2
+    fi
+    exit "${osv_status}"
+fi
+
+python3 .github/scripts/vulnerability-audit-filter.py \
+    --sbom "${SBOM_PATH}" \
+    --osv "${osv_output}" \
+    --local-group-prefixes "${LOCAL_GROUP_PREFIXES}" \
+    --upstream-group-prefixes "${UPSTREAM_GROUP_PREFIXES}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,24 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
 
       - name: "🛡 Verify Maven wrapper checksum"
         run: bash .github/scripts/verify-maven-wrapper-checksum.sh
+
+      - name: "☕️ Install Java and Maven"
+        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+          cache: 'maven'
+
+      - name: "🔎 Vulnerability Audit"
+        env:
+          DEVELOCITY_ACCESS_KEY: ""
+          DEVELOCITY_CACHE_USERNAME: ""
+          DEVELOCITY_CACHE_PASSWORD: ""
+        run: .github/scripts/vulnerability-audit.sh
 
       - name: "🔐 Import GPG key"
         env:
@@ -38,12 +53,11 @@ jobs:
           echo "$GPG_FILE" | base64 -d | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
 
-      - name: "☕️ Install Java and Maven and set up Apache Maven Central"
+      - name: "☕️ Set up Apache Maven Central"
         uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
         with:
           distribution: 'temurin'
           java-version: '25'
-          cache: 'maven'
           server-id: central
           server-username: SONATYPE_USERNAME
           server-password: SONATYPE_PASSWORD
@@ -52,6 +66,11 @@ jobs:
         id: release_version
         run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
 
+      - name: "🔑 Setup SSH key"
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - name: "🪾 Setup git"
         env:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
@@ -59,15 +78,11 @@ jobs:
           git config --global --add safe.directory /github/workspace
           git config --global user.email "$MICRONAUT_BUILD_EMAIL"
           git config --global user.name "micronaut-build"
+          git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
           echo "Checking out ${{ github.event.release.target_commitish }}"
           git checkout ${{ github.event.release.target_commitish }}
           git tag -d v${{ steps.release_version.outputs.release_version }}
           git push origin :refs/tags/v${{ steps.release_version.outputs.release_version }}
-
-      - name: "🔑 Setup SSH key"
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: "❓ Figure out next version"
         id: next_version

--- a/micronaut-maven-plugin/pom.xml
+++ b/micronaut-maven-plugin/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -85,7 +84,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.20.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
         <plexus.utils.version>4.0.3</plexus.utils.version>
         <mojo.executor.version>2.4.1</mojo.executor.version>
         <commons.io.version>2.21.0</commons.io.version>
+        <commons.compress.version>1.28.0</commons.compress.version>
+        <commons.lang3.version>3.20.0</commons.lang3.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
         <jansi.version>2.4.2</jansi.version>
         <maven.plugin.testing.harness.version>3.5.1</maven.plugin.testing.harness.version>
 
@@ -173,6 +176,16 @@
                 <version>${commons.io.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons.compress.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons.lang3.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
                 <version>${jansi.version}</version>
@@ -202,6 +215,21 @@
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java-transport-zerodep</artifactId>
                 <version>${docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
## Summary

- Adds a Maven-native vulnerability audit script that generates a CycloneDX aggregate SBOM and scans it with the pinned OSV Scanner image.
- Adds an audit filter that keeps locally actionable Maven findings blocking while downgrading findings owned by upstream Micronaut components.
- Runs the release vulnerability audit before release signing, repository mutation, publishing, and close credentials are made available.
- Centralizes remediated Bouncycastle and Apache Commons dependency versions in dependency management.

## Routing and Metadata

- Paperclip issue: DEV-321
- Linked GitHub issue: none found for this maintenance routine, so no closing keyword applies and there is no issue creator to request as reviewer.
- Type label: `type: task`
- Organization project: `5.0.1 Release`, selected as the current matching Micronaut project for the `5.0.x` target branch. No QA intake artifact existed; this PR records that selection explicitly.

## Verification

- `git diff --check origin/5.0.x...HEAD`
- `git diff --check`
- `bash -n .github/scripts/vulnerability-audit.sh`
- `python3 -m py_compile .github/scripts/vulnerability-audit-filter.py`
- `bash .github/scripts/ci-sensitive-preflight.sh`

Windows wrapper preflight remains Windows-only and should be covered by the Windows workflow/preflight leg.

---
###### ✨ This message was AI-generated using gpt-5
