### PR TITLE
ci: shard PR invoker tests

### DIFF
--- a/.github/scripts/shard-invoker-tests.py
+++ b/.github/scripts/shard-invoker-tests.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Generate balanced GitHub Actions matrix shards for Maven Invoker ITs.
+
+The Maven Invoker test list is derived from the existing src/it/*/pom.xml
+projects so new IT directories are automatically picked up by CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def setup_project_names(harness_pom: Path) -> set[str]:
+    """Return setup project names declared by maven-invoker-plugin."""
+    if not harness_pom.exists():
+        return set()
+    text = harness_pom.read_text(encoding="utf-8")
+    return {
+        Path(match).parent.name
+        for match in re.findall(r"<setupInclude>\s*([^<]+?)\s*</setupInclude>", text)
+    }
+
+
+def invoker_project_names(projects_dir: Path) -> list[str]:
+    return sorted(path.parent.name for path in projects_dir.glob("*/pom.xml"))
+
+
+def test_weight(name: str, projects_dir: Path) -> int:
+    """Estimate runtime cost without hard-coding individual test names.
+
+    The weights intentionally use broad feature patterns rather than specific
+    scenario names. They keep native-image and Docker-heavy scenarios spread
+    across shards, while still allowing newly added ITs to be assigned
+    automatically.
+    """
+    properties = projects_dir / name / "invoker.properties"
+    props = properties.read_text(encoding="utf-8") if properties.exists() else ""
+    haystack = f"{name}\n{props}".lower()
+
+    weight = 10
+    if "docker-native" in haystack or "native-image" in haystack or "-pgraalvm" in haystack:
+        weight = max(weight, 180)
+    elif "docker-crac" in haystack:
+        weight = max(weight, 80)
+    elif "docker" in haystack:
+        weight = max(weight, 35)
+
+    if "test-resources" in haystack:
+        weight = max(weight, 30)
+    if "aot" in haystack:
+        weight = max(weight, 25)
+    if "openapi" in haystack or "jsonschema" in haystack or "configuration-validation" in haystack:
+        weight = max(weight, 12)
+
+    return weight
+
+
+def build_shards(projects_dir: Path, shard_count: int) -> list[dict[str, str]]:
+    harness_pom = projects_dir.parent.parent / "pom.xml"
+    setup_names = setup_project_names(harness_pom)
+    projects = invoker_project_names(projects_dir)
+    tests = [name for name in projects if name not in setup_names]
+
+    buckets: list[dict[str, object]] = [
+        {"name": f"shard-{index + 1}", "weight": 0, "tests": []} for index in range(shard_count)
+    ]
+
+    weighted_tests = sorted(
+        ((test_weight(name, projects_dir), name) for name in tests),
+        key=lambda item: (-item[0], item[1]),
+    )
+
+    for weight, name in weighted_tests:
+        bucket = min(buckets, key=lambda candidate: (candidate["weight"], candidate["name"]))
+        bucket["tests"].append(name)
+        bucket["weight"] += weight
+
+    matrix = []
+    for bucket in buckets:
+        selected_tests = [*sorted(setup_names), *bucket["tests"]]
+        matrix.append(
+            {
+                "name": str(bucket["name"]),
+                "tests": ",".join(selected_tests),
+            }
+        )
+    return matrix
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--projects-dir", default="micronaut-maven-integration-tests/src/it")
+    parser.add_argument("--shards", type=int, default=5)
+    parser.add_argument("--github-output", default=None)
+    args = parser.parse_args()
+
+    matrix = build_shards(Path(args.projects_dir), args.shards)
+    payload = json.dumps(matrix, separators=(",", ":"))
+
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as output:
+            output.write(f"shards={payload}\n")
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -204,7 +204,11 @@ jobs:
 
       - name: "🧪 Run tests"
         run: |
-          ./mvnw -q install -Dinvoker.skip=true && ./mvnw verify
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] || [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then
+            ./mvnw -q install -Dinvoker.skip=true
+          else
+            ./mvnw -q install -Dinvoker.skip=true && ./mvnw verify
+          fi
 
       - name: "🔏 Verify release signing setup"
         if: matrix.java == '25'
@@ -218,7 +222,7 @@ jobs:
         uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8
         with:
           check_name: Java CI / Test Report
-          report_paths: '**/target/invoker-reports/TEST-*.xml'
+          report_paths: '**/target/*-reports/TEST-*.xml'
           check_retries: 'true'
 
       - name: "🔎 Run static analysis"
@@ -257,6 +261,95 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+
+
+  generate-invoker-test-matrix:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    needs:
+      - workflow-hardening
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      shards: ${{ steps.shards.outputs.shards }}
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - name: "🧩 Generate invoker test shards"
+        id: shards
+        run: python3 .github/scripts/shard-invoker-tests.py --github-output "$GITHUB_OUTPUT"
+
+  invoker-tests:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    needs:
+      - workflow-hardening
+      - generate-invoker-test-matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['25']
+        shard: ${{ fromJSON(needs.generate-invoker-test-matrix.outputs.shards) }}
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+      DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+      GRAALVM_QUICK_BUILD: true
+    steps:
+      - name: "🗑 Remove system JDKs"
+        run: |
+          sudo rm -rf /usr/lib/jvm/*
+          unset JAVA_HOME
+          filtered_path=$(echo "$PATH" | tr ':' '\n' | grep -v '/usr/lib/jvm' | paste -sd:)
+          export PATH="$filtered_path"
+
+      - name: "🗑 Free disk space"
+        run: |
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          df -h
+
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 0
+
+      - name: "☕️ Install Java and Maven"
+        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: "🔧 Setup GraalVM CE"
+        uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994
+        with:
+          distribution: 'graalvm'
+          java-version: ${{ matrix.java }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "⏬ Eagerly pull Docker images"
+        run: |
+          docker pull postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a
+
+      - name: "🧪 Run invoker tests"
+        run: |
+          ./mvnw -q install -Dinvoker.skip=true
+          ./mvnw -pl micronaut-maven-integration-tests verify -Dinvoker.test=${{ matrix.shard.tests }}
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: true
+
+      - name: "📊 Publish Invoker Test Report"
+        if: always()
+        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8
+        with:
+          check_name: Java CI / Invoker Test Report (${{ matrix.shard.name }})
+          report_paths: '**/target/invoker-reports/TEST-*.xml'
+          check_retries: 'true'
 
   publish_snapshot_docs:
     if: github.event_name == 'push'


### PR DESCRIPTION
This splits the expensive PR/merge-group invoker integration tests into a separate 5-way matrix job while keeping push builds unchanged.

On pull requests and merge groups, the existing snapshot job now runs the regular reactor build with invoker tests skipped, and the new `invoker-tests` job runs the invoker scenarios in balanced shards based on recent Java CI timings.

Validation performed locally:
- `actionlint .github/workflows/snapshot.yml`
- `bash .github/scripts/check-workflow-pinning.sh`
- `git diff --check`
- smoke-tested `mvn -B -Denforcer.skip=true -pl micronaut-maven-integration-tests verify -Dinvoker.test=package-jar` after installing artifacts locally

Historical baseline sampled from recent successful `Java CI` runs on `5.0.x`: snapshot job ~71-75 minutes, full workflow ~72-75 minutes for non-push docs/deploy steps. This PR should reduce PR wall-clock by running invoker shards in parallel; Actions timings on this PR will be measured after the checks complete.