### PR TITLE
Support daemonless Jib docker deploy

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/AbstractDockerMojo.java
@@ -19,6 +19,7 @@ import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.common.io.FileWriteMode;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.maven.core.DockerBuildStrategy;
 import io.micronaut.maven.core.MicronautRuntime;
 import io.micronaut.maven.core.MojoUtils;
 import io.micronaut.maven.jib.JibConfigurationService;
@@ -76,6 +77,14 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
     public static final String ORACLE_CLOUD_FUNCTION_DEFAULT_CMD = "CMD [\"io.micronaut.oraclecloud.function.http.HttpFunction::handleRequest\"]";
     public static final String GDS_DOWNLOAD_URL = "https://gds.oracle.com/download/graal/%s/latest-gftc/graalvm-jdk-%s_linux-%s_bin.tar.gz";
     public static final String LAMBDA_BOOTSTRAP_DOCKER_COMMAND_PLACEHOLDER = "${LAMBDA_BOOTSTRAP_DOCKER_COMMAND}";
+    protected static final String JIB_BUILD_GOAL_DOCKER_BUILD = "dockerBuild";
+    protected static final String JIB_BUILD_GOAL_BUILD = "build";
+    protected static final String JIB_BUILD_GOAL_BUILD_TAR = "buildTar";
+    protected static final List<String> SUPPORTED_JIB_BUILD_GOALS = List.of(
+        JIB_BUILD_GOAL_DOCKER_BUILD,
+        JIB_BUILD_GOAL_BUILD,
+        JIB_BUILD_GOAL_BUILD_TAR
+    );
     static final String JIB_FROM_IMAGE_PROPERTY = "jib.from.image";
     private static final String DEPENDENCY_DIRECTORY = "dependency";
     private static final String RELEASE_DEPENDENCY_DIRECTORY = "release";
@@ -213,6 +222,30 @@ public abstract class AbstractDockerMojo extends AbstractMicronautMojo {
         var properties = project.getProperties();
         var projectProperty = Optional.of(propertName).map(properties::getProperty);
         return systemProperty.or(() -> projectProperty);
+    }
+
+    protected final void validateJibBuildGoal() throws MojoExecutionException {
+        if (!SUPPORTED_JIB_BUILD_GOALS.contains(jibBuildGoal)) {
+            throw new MojoExecutionException("Unsupported jib.buildGoal '" + jibBuildGoal
+                + "'. Supported values are: " + String.join(", ", SUPPORTED_JIB_BUILD_GOALS));
+        }
+    }
+
+    protected final Optional<String> getConfiguredToImage() {
+        return jibConfigurationService.getToImage().filter(StringUtils::hasText);
+    }
+
+    protected final String requireConfiguredToImageForJibRegistryBuild() throws MojoExecutionException {
+        return getConfiguredToImage()
+            .orElseThrow(() -> new MojoExecutionException("jib.buildGoal=build requires a configured target image. "
+                + "Set jib.to.image to the registry image to publish, and configure registry credentials with "
+                + "Jib-supported options such as jib.to.auth.*, jib.to.credHelper, Maven settings, or environment-backed "
+                + "configuration."));
+    }
+
+    protected final boolean shouldBuildWithDockerfile(File providedDockerfile) {
+        var runtime = MicronautRuntime.valueOf(micronautRuntime.toUpperCase());
+        return providedDockerfile.exists() || runtime.getBuildStrategy() == DockerBuildStrategy.ORACLE_FUNCTION;
     }
 
     /**

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerMojo.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.StandardCopyOption;
-import java.util.List;
 
 import static io.micronaut.maven.DockerfileMojo.DOCKERFILE_ORACLE_CLOUD;
 
@@ -54,7 +53,6 @@ import static io.micronaut.maven.DockerfileMojo.DOCKERFILE_ORACLE_CLOUD;
 public class DockerMojo extends AbstractDockerMojo {
 
     public static final String DOCKER_PACKAGING = "docker";
-    private static final List<String> SUPPORTED_JIB_BUILD_GOALS = List.of("dockerBuild", "build", "buildTar");
 
     private final ExecutorService executorService;
 
@@ -76,17 +74,13 @@ public class DockerMojo extends AbstractDockerMojo {
             buildDockerfile(dockerfile, providedDockerfile.exists());
         } else {
             validateJibBuildGoal();
+            if (JIB_BUILD_GOAL_BUILD.equals(jibBuildGoal)) {
+                requireConfiguredToImageForJibRegistryBuild();
+            }
             if (jibConfigurationService.getFromImage().isEmpty()) {
                 mavenProject.getProperties().setProperty(PropertyNames.FROM_IMAGE, getBaseImage());
             }
             executorService.executeGoal(mavenProject, "com.google.cloud.tools:jib-maven-plugin", jibBuildGoal);
-        }
-    }
-
-    private void validateJibBuildGoal() throws MojoExecutionException {
-        if (!SUPPORTED_JIB_BUILD_GOALS.contains(jibBuildGoal)) {
-            throw new MojoExecutionException("Unsupported jib.buildGoal '" + jibBuildGoal
-                + "'. Supported values are: " + String.join(", ", SUPPORTED_JIB_BUILD_GOALS));
         }
     }
 
@@ -99,11 +93,6 @@ public class DockerMojo extends AbstractDockerMojo {
         } catch (IOException e) {
             throw new MojoExecutionException("Error loading Dockerfile", e);
         }
-    }
-
-    private boolean shouldBuildWithDockerfile(File providedDockerfile) {
-        var runtime = MicronautRuntime.valueOf(micronautRuntime.toUpperCase());
-        return providedDockerfile.exists() || runtime.getBuildStrategy() == DockerBuildStrategy.ORACLE_FUNCTION;
     }
 
     private void buildDockerfile(File dockerfile, boolean providedDockerfileExists) throws MojoExecutionException {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerPushMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerPushMojo.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.io.File;
 import java.util.Optional;
 
 /**
@@ -60,12 +61,17 @@ public class DockerPushMojo extends AbstractDockerMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         Packaging packaging = Packaging.of(mavenProject.getPackaging());
         if (packaging == Packaging.DOCKER || packaging == Packaging.DOCKER_NATIVE || packaging == Packaging.DOCKER_CRAC) {
+            if (packaging == Packaging.DOCKER && !shouldBuildWithDockerfile(new File(mavenProject.getBasedir(), DockerfileMojo.DOCKERFILE))) {
+                if (validateJibDeployBuildGoal()) {
+                    return;
+                }
+            }
             var images = getTags();
 
             // getTags() will automatically generate an image name if none is specified
             // To maintain error compatibility, check that an image name has been
             // manually specified.
-            if (jibConfigurationService.getToImage().isPresent()) {
+            if (getConfiguredToImage().isPresent()) {
                 for (String taggedImage : images) {
                     getLog().info("Pushing image: " + taggedImage);
                     try (PushImageCmd pushImageCmd = dockerService.pushImageCmd(taggedImage)) {
@@ -91,6 +97,20 @@ public class DockerPushMojo extends AbstractDockerMojo {
         } else {
             throw new MojoFailureException("The <packaging> must be set to either [" + Packaging.DOCKER.id() + "] or [" + Packaging.DOCKER_NATIVE.id() + "]");
         }
+    }
+
+    private boolean validateJibDeployBuildGoal() throws MojoExecutionException, MojoFailureException {
+        validateJibBuildGoal();
+        if (JIB_BUILD_GOAL_BUILD.equals(jibBuildGoal)) {
+            String toImage = requireConfiguredToImageForJibRegistryBuild();
+            getLog().info("Skipping Docker daemon push for " + toImage + " because jib.buildGoal=build publishes the image to the registry during the package phase.");
+            return true;
+        }
+        if (JIB_BUILD_GOAL_BUILD_TAR.equals(jibBuildGoal)) {
+            throw new MojoFailureException("jib.buildGoal=buildTar is not supported for deploy because it creates target/jib-image.tar instead of publishing to a registry. "
+                + "Use jib.buildGoal=build with jib.to.image for daemonless registry deploy, or omit jib.buildGoal/use dockerBuild for the Docker daemon push path.");
+        }
+        return false;
     }
 
 }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerPushMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/DockerPushMojo.java
@@ -95,7 +95,8 @@ public class DockerPushMojo extends AbstractDockerMojo {
                 throw new MojoFailureException("The plugin " + MavenProjectProperties.PLUGIN_KEY + " is misconfigured. Missing <to> tag");
             }
         } else {
-            throw new MojoFailureException("The <packaging> must be set to either [" + Packaging.DOCKER.id() + "] or [" + Packaging.DOCKER_NATIVE.id() + "]");
+            throw new MojoFailureException("The <packaging> must be set to either [" + Packaging.DOCKER.id() + "], ["
+                + Packaging.DOCKER_NATIVE.id() + "] or [" + Packaging.DOCKER_CRAC.id() + "]");
         }
     }
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/deploy.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/deploy.adoc
@@ -28,6 +28,39 @@ For example, to push an image to Docker Hub:
 
 Then, you can execute `mvn deploy -Dpackaging=docker` or `mvn deploy -Dpackaging=docker-native`.
 
+For JVM `docker` packaging, the `jib.buildGoal` value determines how the image is published:
+
+[cols="1,2", options="header"]
+|===
+| `jib.buildGoal`
+| Deploy behavior
+
+| Omitted or `dockerBuild`
+| Jib builds the image into the local Docker daemon during `package`, and `mn:docker-push` pushes that local image during
+`deploy`.
+
+| `build`
+| Jib publishes the image directly to the registry during `package`. Because Maven runs `package` before `deploy`,
+`mn:docker-push` logs that the Jib registry publish path was used and skips the Docker-daemon push.
+
+| `buildTar`
+| Unsupported for `deploy`. It creates `target/jib-image.tar` and does not publish to a registry.
+|===
+
+Use `build` for daemonless deploy from CI environments that do not have a local Docker daemon:
+
+[source,shell]
+----
+mvn deploy -Dpackaging=docker \
+  -Djib.buildGoal=build \
+  -Djib.to.image=registry.example.com/team/my-app:1.0.0
+----
+
+The command must include `jib.to.image` or equivalent Jib `<to><image>...</image></to>` configuration. Configure
+registry credentials with Jib-supported mechanisms such as Maven settings, `jib.to.credHelper`, environment-backed
+`jib.to.auth.username` and `jib.to.auth.password` properties, or standard registry credential helpers. Do not commit
+plain-text registry secrets to the POM.
+
 For JKube-backed deployments, declare the matching JKube plugin in your POM and run either:
 
 ----
@@ -37,11 +70,6 @@ $ mvn deploy -Dpackaging=openshift
 
 `k8s` maps `deploy` to `org.eclipse.jkube:kubernetes-maven-plugin:push`, while `openshift` maps `deploy` to
 `org.eclipse.jkube:openshift-maven-plugin:push`.
-
-For `docker` packaging, setting `-Djib.buildGoal=buildTar` or `-Djib.buildGoal=build` only affects the earlier
-`package` phase and prevents Jib from creating a local Docker-daemon image. The `deploy` phase still uses
-`mn:docker-push` to publish an image from the local Docker daemon, so `mvn deploy -Dpackaging=docker` currently
-requires `-Djib.buildGoal=dockerBuild` or the default behavior with no `jib.buildGoal` override.
 
 You can also omit the plugin declaration in your POM, and execute directly:
 

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/package.adoc
@@ -225,13 +225,15 @@ The Docker image is built to a local Docker daemon (the equivalent of executing 
 
 If you want daemonless packaging, set `-Djib.buildGoal=buildTar` to produce the standard Jib tarball at
 `target/jib-image.tar`, or `-Djib.buildGoal=build` to publish directly to the configured registry during the `package`
-phase.
+phase. The `build` goal is also the daemonless path for `mvn deploy -Dpackaging=docker`: Maven runs `package` before
+`deploy`, so Jib publishes the image during `package` and the later deploy step skips the Docker-daemon push.
 
 Depending on the `micronaut.runtime` property, the image built might be different. Options are:
 
 * Default runtime: `mvn package -Dpackaging=docker`.
 * JDK HTTP server runtime (Starter compatibility alias; same Docker image as the default runtime): `mvn package -Dpackaging=docker -Dmicronaut.runtime=http_server_jdk`.
 * Daemonless tarball: `mvn package -Dpackaging=docker -Djib.buildGoal=buildTar`.
+* Daemonless registry publish: `mvn package -Dpackaging=docker -Djib.buildGoal=build -Djib.to.image=registry.example.com/team/app:latest`.
 * Oracle Cloud Function: `mvn package -Dpackaging=docker -Dmicronaut.runtime=oracle_function`.
 * AWS Lambda (Java runtimes): `mvn package -Dpackaging=docker -Dmicronaut.runtime=lambda`.
 
@@ -480,10 +482,10 @@ command line:
 * `jib.to.auth.password`.
 * `jib.to.credHelper`.
 
-When using `jib.buildGoal=buildTar` or `jib.buildGoal=build`, only the `package` phase becomes daemonless. `deploy` for
-`docker` packaging still goes through `mn:docker-push`, which expects an image to exist in the local Docker daemon. As a
-result, `mvn deploy -Dpackaging=docker -Djib.buildGoal=buildTar` and `... -Djib.buildGoal=build` are not supported; for
-deployments, either omit `jib.buildGoal` or set it to `dockerBuild`.
+When using `jib.buildGoal=build`, set `jib.to.image` to the registry image to publish. Credentials can come from
+Jib-supported configuration such as `jib.to.auth.*`, `jib.to.credHelper`, Maven settings, environment-backed POM
+properties, or standard registry credential helpers. `jib.buildGoal=buildTar` only creates `target/jib-image.tar`; it
+does not publish to a registry and is not a deploy mode.
 
 Note that changing the builder image to a totally different one than the default might break image building, since the rest
 of the build steps expect a certain builder-stage base image. By default, that builder-stage base image comes from

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerMojoTest.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -40,6 +41,44 @@ class DockerMojoTest {
         mojo.execute();
 
         verify(executorService).executeGoal(project, "com.google.cloud.tools:jib-maven-plugin", "buildTar");
+    }
+
+    @Test
+    void rejectsJibRegistryBuildWithoutTargetImage(@TempDir Path tempDir) throws MojoExecutionException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        var executorService = mock(ExecutorService.class);
+        var session = mockSession(project);
+
+        var mojo = new DockerMojo(project, jibConfigurationService, null, null, session,
+            mock(MojoExecution.class), executorService);
+        mojo.micronautRuntime = "NONE";
+        mojo.jibBuildGoal = "build";
+
+        var ex = assertThrows(MojoExecutionException.class, mojo::execute);
+
+        assertTrue(ex.getMessage().contains("jib.buildGoal=build requires a configured target image"));
+        assertTrue(ex.getMessage().contains("jib.to.image"));
+        verify(executorService, never()).executeGoal(project, "com.google.cloud.tools:jib-maven-plugin", "build");
+    }
+
+    @Test
+    void executesJibRegistryBuildWithTargetImage(@TempDir Path tempDir) throws MojoExecutionException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getToImage()).thenReturn(Optional.of("registry.example.com/team/app:1.0"));
+        when(jibConfigurationService.getFromImage()).thenReturn(Optional.empty());
+        var executorService = mock(ExecutorService.class);
+        var session = mockSession(project);
+
+        var mojo = new DockerMojo(project, jibConfigurationService, null, null, session,
+            mock(MojoExecution.class), executorService);
+        mojo.micronautRuntime = "NONE";
+        mojo.jibBuildGoal = "build";
+
+        mojo.execute();
+
+        verify(executorService).executeGoal(project, "com.google.cloud.tools:jib-maven-plugin", "build");
     }
 
     @Test

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerMojoTest.java
@@ -10,7 +10,6 @@ import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Properties;

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerPushMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/DockerPushMojoTest.java
@@ -1,0 +1,99 @@
+package io.micronaut.maven;
+
+import io.micronaut.maven.jib.JibConfigurationService;
+import io.micronaut.maven.services.DockerService;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DockerPushMojoTest {
+
+    @Test
+    void skipsDockerPushForJibRegistryBuild(@TempDir Path tempDir) throws MojoExecutionException, MojoFailureException {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        when(jibConfigurationService.getToImage()).thenReturn(Optional.of("registry.example.com/team/app:1.0"));
+        var dockerService = mock(DockerService.class);
+        var mojo = new DockerPushMojo(project, jibConfigurationService, null, dockerService, mockSession(project),
+            mock(MojoExecution.class));
+        mojo.micronautRuntime = "NONE";
+        mojo.jibBuildGoal = "build";
+
+        mojo.execute();
+
+        verify(dockerService, never()).pushImageCmd(anyString());
+    }
+
+    @Test
+    void rejectsJibRegistryBuildWithoutTargetImage(@TempDir Path tempDir) {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        var dockerService = mock(DockerService.class);
+        var mojo = new DockerPushMojo(project, jibConfigurationService, null, dockerService, mockSession(project),
+            mock(MojoExecution.class));
+        mojo.micronautRuntime = "NONE";
+        mojo.jibBuildGoal = "build";
+
+        var ex = assertThrows(MojoExecutionException.class, mojo::execute);
+
+        assertTrue(ex.getMessage().contains("jib.buildGoal=build requires a configured target image"));
+        assertTrue(ex.getMessage().contains("jib.to.image"));
+        verify(dockerService, never()).pushImageCmd(anyString());
+    }
+
+    @Test
+    void rejectsJibTarballDeployBeforeDockerPush(@TempDir Path tempDir) {
+        var project = mockProject(tempDir);
+        var jibConfigurationService = mock(JibConfigurationService.class);
+        var dockerService = mock(DockerService.class);
+        var mojo = new DockerPushMojo(project, jibConfigurationService, null, dockerService, mockSession(project),
+            mock(MojoExecution.class));
+        mojo.micronautRuntime = "NONE";
+        mojo.jibBuildGoal = "buildTar";
+
+        var ex = assertThrows(MojoFailureException.class, mojo::execute);
+
+        assertTrue(ex.getMessage().contains("jib.buildGoal=buildTar is not supported for deploy"));
+        assertTrue(ex.getMessage().contains("tar"));
+        verify(dockerService, never()).pushImageCmd(anyString());
+    }
+
+    private static MavenProject mockProject(Path tempDir) {
+        var project = mock(MavenProject.class);
+        var build = mock(Build.class);
+        when(project.getBasedir()).thenReturn(tempDir.toFile());
+        when(project.getPackaging()).thenReturn(Packaging.DOCKER.id());
+        when(project.getArtifactId()).thenReturn("app");
+        when(project.getProperties()).thenReturn(new Properties());
+        when(project.getBuild()).thenReturn(build);
+        when(project.getArtifacts()).thenReturn(Set.of());
+        when(build.getDirectory()).thenReturn(tempDir.resolve("target").toString());
+        return project;
+    }
+
+    private static MavenSession mockSession(MavenProject project) {
+        var session = mock(MavenSession.class);
+        when(session.getCurrentProject()).thenReturn(project);
+        when(session.getSystemProperties()).thenReturn(new Properties());
+        when(session.getUserProperties()).thenReturn(new Properties());
+        return session;
+    }
+}


### PR DESCRIPTION
## Summary

- support `mvn deploy -Dpackaging=docker -Djib.buildGoal=build` by treating the package-phase Jib registry build as the daemonless publication step
- validate `jib.to.image` for Jib registry builds and keep `buildTar` explicitly unsupported for deploy
- keep the default Docker daemon path, custom Dockerfile path, Oracle Function path, `docker-native`, and `docker-crac` behavior unchanged
- document daemonless deploy configuration, credential options, and the `dockerBuild` / `build` / `buildTar` distinction

Fixes #1363.

## Testing

- `git diff --check origin/5.0.x...HEAD`
- `./mvnw -pl micronaut-maven-plugin -am -Dtest=DockerMojoTest,DockerPushMojoTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Paperclip Metadata

- Paperclip issue: DEV-331
- Type label: `type: improvement`, matching linked GitHub issue #1363
- Selected Micronaut organization projects: `5.0.0 Release` and `5.0.0-M3`
- Project ambiguity note: `5.0.0-M3` remains open as an organization project even though `v5.0.0-M3` was already published on 2026-04-29

---
###### ✨ This message was AI-generated using gpt-5
