### PR TITLE
Allow advisory vulnerability audit for prereleases

### DIFF
--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -6,9 +6,15 @@ readonly OSV_SCANNER_IMAGE="${OSV_SCANNER_IMAGE:-ghcr.io/google/osv-scanner:v2.3
 readonly SBOM_PATH="${SBOM_PATH:-target/bom.json}"
 readonly LOCAL_GROUP_PREFIXES="${LOCAL_GROUP_PREFIXES:-io.micronaut.maven}"
 readonly UPSTREAM_GROUP_PREFIXES="${UPSTREAM_GROUP_PREFIXES:-io.micronaut}"
+readonly VULNERABILITY_AUDIT_ENFORCEMENT="${VULNERABILITY_AUDIT_ENFORCEMENT:-fail}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT_DIR}"
+
+if [[ "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "fail" && "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "advisory" ]]; then
+    echo "VULNERABILITY_AUDIT_ENFORCEMENT must be 'fail' or 'advisory'" >&2
+    exit 1
+fi
 
 if [[ ! -x ./mvnw ]]; then
     echo "Maven wrapper not found or not executable at ${ROOT_DIR}/mvnw" >&2
@@ -76,8 +82,32 @@ if [[ ${osv_status} -ne 0 && ${osv_status} -ne 1 ]]; then
     exit "${osv_status}"
 fi
 
+set +e
 python3 .github/scripts/vulnerability-audit-filter.py \
     --sbom "${SBOM_PATH}" \
     --osv "${osv_output}" \
     --local-group-prefixes "${LOCAL_GROUP_PREFIXES}" \
     --upstream-group-prefixes "${UPSTREAM_GROUP_PREFIXES}"
+filter_status=$?
+set -e
+
+if [[ ${filter_status} -eq 0 ]]; then
+    exit 0
+fi
+
+if [[ ${filter_status} -eq 1 && "${VULNERABILITY_AUDIT_ENFORCEMENT}" == "advisory" ]]; then
+    message="Actionable vulnerabilities were found, but this milestone/RC release keeps the vulnerability audit advisory."
+    echo "::warning title=Vulnerability audit advisory::${message}"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        {
+            echo "### Vulnerability audit advisory"
+            echo
+            echo "${message}"
+            echo
+            echo "GA releases and pull request audits remain blocking."
+        } >> "${GITHUB_STEP_SUMMARY}"
+    fi
+    exit 0
+fi
+
+exit "${filter_status}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,24 @@ jobs:
           java-version: '25'
           cache: 'maven'
 
+      - name: "🟰 Set the current release version"
+        id: release_version
+        run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+
       - name: "🔎 Vulnerability Audit"
         env:
           DEVELOCITY_ACCESS_KEY: ""
           DEVELOCITY_CACHE_USERNAME: ""
           DEVELOCITY_CACHE_PASSWORD: ""
-        run: .github/scripts/vulnerability-audit.sh
+          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+        run: |
+          release_version="${RELEASE_VERSION}"
+          if [[ "${release_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-(M|RC)[0-9]+$ ]]; then
+            echo "Running vulnerability audit in advisory mode for ${release_version}"
+            VULNERABILITY_AUDIT_ENFORCEMENT=advisory .github/scripts/vulnerability-audit.sh
+          else
+            .github/scripts/vulnerability-audit.sh
+          fi
 
       - name: "🔐 Import GPG key"
         env:
@@ -61,10 +73,6 @@ jobs:
           server-id: central
           server-username: SONATYPE_USERNAME
           server-password: SONATYPE_PASSWORD
-
-      - name: "🟰 Set the current release version"
-        id: release_version
-        run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
 
       - name: "🔑 Setup SSH key"
         uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
 
       - name: "🟰 Set the current release version"
         id: release_version
-        run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+        run: |
+          tag_name="${GITHUB_REF#refs/tags/}"
+          echo "release_version=${tag_name#v}" >> "$GITHUB_OUTPUT"
 
       - name: "🔎 Vulnerability Audit"
         env:


### PR DESCRIPTION
## Summary
- Allow the Maven vulnerability audit to run in advisory mode only when explicitly requested, while failing closed for unsupported enforcement values and scanner infrastructure failures.
- Use advisory mode in the release workflow only for concrete milestone or release-candidate tags such as `5.0.0-M3` and `5.0.0-RC1`; GA and default audits remain blocking.
- Preserve the Maven-specific CycloneDX/OSV audit path already present in this repository instead of copying the Gradle template script.
- Normalize release tag extraction so both `v`-prefixed and unprefixed release tags produce the unprefixed Maven release version.

## Verification
- `git rebase origin/5.0.x` (branch already up to date)
- `bash -n .github/scripts/vulnerability-audit.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'`
- `bash .github/scripts/check-workflow-pinning.sh`
- `bash .github/scripts/ci-sensitive-preflight.sh` (workflow pinning passed; Linux runner noted the Windows-only preflight must run separately)
- Release-version extraction and classifier smoke test for `v`-prefixed, unprefixed, milestone/RC, GA, and malformed tags
- Invalid `VULNERABILITY_AUDIT_ENFORCEMENT=bogus` smoke test fails closed before Docker/Maven work
- `git diff --check`
- PR `Windows Preflight` checks passed for head `8a417210419f0d685aacc4dcb3e936a0048a77b0`

## Paperclip
- Issue: `DEV-346`
- Upstream template reference: `micronaut-projects/micronaut-project-template#712`
- QA and Security review artifacts are approved.
- No linked GitHub issue exists for this routine-maintenance work, so no closing keyword or issue-creator reviewer is applicable.
- Organization-project selection: QA did not have a separate intake document for this routine run; based on the `5.0.x` target line and open Micronaut release boards, this PR is linked to both `5.0.0-M3` and `5.0.0 Release`.

---
###### ✨ This message was AI-generated using gpt-5
