### PR TITLE
chore: update GraalVM setup action digest

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: "🔧 Setup GraalVM CE"
         if: steps.preflight_scope.outputs.should_run == 'true'
-        uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
         with:
           distribution: 'graalvm'
           java-version: '25'
@@ -192,7 +192,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
@@ -326,7 +326,7 @@ jobs:
           cache: 'maven'
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Setup GraalVM
-        uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
## Summary

- update all `graalvm/setup-graalvm` workflow pins from `60c26726de13f8b90771df4bc1641a52a3159994` to `bef4b0e916c7dd079bf60fb95d49139f67e32c5f`
- keep the existing full-SHA action pinning posture in the Linux snapshot and Windows CI workflows

## Context

Paperclip: DEV-356.

No linked public GitHub issue was attached to this internal maintenance task, so no GitHub closing keyword applies.

QA selected the Micronaut `5.0.0-M3` release board and noted ambiguity because `v5.0.0-M3` is already published and `5.0.1 Release` is also open. Code review also found a live `5.0.0 Release` board, so this PR should be linked to both `5.0.0-M3` and `5.0.0 Release` for the current `5.0.0-SNAPSHOT` branch.

## Verification

- `git rebase origin/5.0.x`
- `git diff --check origin/5.0.x...HEAD`
- `rg -n "graalvm/setup-graalvm|60c26726de13f8b90771df4bc1641a52a3159994|bef4b0e916c7dd079bf60fb95d49139f67e32c5f" .github/workflows`
- `bash .github/scripts/ci-sensitive-preflight.sh`

Windows wrapper preflight was not run locally because this Linux environment does not provide a Windows shell; the PR CI Windows workflow covers that leg.

---
###### ✨ This message was AI-generated using gpt-5
