### PR TITLE
chore: align Renovate config formatting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,13 @@
 {
-  "extends": ["config:recommended"],
-  "addLabels": ["type: dependency-upgrade"],
-  "schedule": ["after 10pm"],
+  "extends": [
+    "config:recommended"
+  ],
+  "addLabels": [
+    "type: dependency-upgrade"
+  ],
+  "schedule": [
+    "after 10pm"
+  ],
   "prHourlyLimit": 1,
   "prConcurrentLimit": 20,
   "timezone": "Europe/Prague",
@@ -13,9 +19,12 @@
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "GitHub Actions dependencies"
-    },{
+    },
+    {
       "matchDatasources": [
         "maven"
       ],
@@ -24,26 +33,37 @@
         "gradle"
       ],
       "allowedVersions": "!/.+-SNAPSHOT$/"
-    },{
+    },
+    {
       "matchUpdateTypes": [
         "patch"
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
-    },{
+    },
+    {
       "matchPackageNames": [
         "/.*micronaut.*/"
       ],
       "groupName": "Micronaut dependencies"
-    },{
+    },
+    {
       "matchFileNames": [
         "src/it/package-docker-native-different-parent-version/pom.xml"
       ],
-      "matchPackageNames": ["io.micronaut:micronaut-parent"],
+      "matchPackageNames": [
+        "io.micronaut:micronaut-parent"
+      ],
       "enabled": false
-    },{
-      "matchFileNames": ["src/main/resources/dockerfiles/Dockerfile*"],
-      "matchPackageNames": ["eclipse-temurin", "amazonlinux"],
+    },
+    {
+      "matchFileNames": [
+        "src/main/resources/dockerfiles/Dockerfile*"
+      ],
+      "matchPackageNames": [
+        "eclipse-temurin",
+        "amazonlinux"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Align `.github/renovate.json` formatting with the current template layout.
- Preserve the existing Renovate behavior; normalized JSON is unchanged from `origin/5.0.x`.

## Review Notes
- Paperclip routine: DEV-378.
- Linked GitHub issue: none recorded for this routine item, so no closing keyword applies.
- PR-visible assets: not applicable; this is repository metadata formatting only.

## Verification
- `jq empty .github/renovate.json`
- `git diff --check origin/5.0.x...HEAD`
- Normalized comparison: `diff -u <(git show origin/5.0.x:.github/renovate.json | jq -S .) <(jq -S . .github/renovate.json)`

---
###### ✨ This message was AI-generated using gpt-5