### PR TITLE
chore: enable checkstyle wildcard import rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -116,7 +116,7 @@
 
         <!-- Checks for imports                              -->
         <!-- See https://checkstyle.org/config_import.html -->
-        <!-- <module name="AvoidStarImport"/> -->
+        <module name="AvoidStarImport"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
         <module name="UnusedImports">

--- a/micronaut-maven-integration-tests/src/it/openapi-generate-server-mapped-types/src/main/java/io/micronaut/openapi/controller/MappedController.java
+++ b/micronaut-maven-integration-tests/src/it/openapi-generate-server-mapped-types/src/main/java/io/micronaut/openapi/controller/MappedController.java
@@ -1,6 +1,6 @@
 package io.micronaut.openapi.controller;
 
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Controller;
 import reactor.core.publisher.Mono;
 import io.micronaut.openapi.dated.DatedResponse;
 import io.micronaut.openapi.filter.MyFilter;
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/micronaut-maven-integration-tests/src/it/package-native-image-aot/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/package-native-image-aot/src/main/java/io/micronaut/build/examples/Application.java
@@ -2,8 +2,8 @@ package io.micronaut.build.examples;
 
 import io.micronaut.runtime.Micronaut;
 
-import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.info.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
 @OpenAPIDefinition(
     info = @Info(

--- a/micronaut-maven-integration-tests/src/it/package-native-image/src/main/java/io/micronaut/build/examples/Application.java
+++ b/micronaut-maven-integration-tests/src/it/package-native-image/src/main/java/io/micronaut/build/examples/Application.java
@@ -2,8 +2,8 @@ package io.micronaut.build.examples;
 
 import io.micronaut.runtime.Micronaut;
 
-import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.info.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
 @OpenAPIDefinition(
     info = @Info(

--- a/micronaut-maven-jib-integration/src/main/java/io/micronaut/maven/jib/JibConfigurationService.java
+++ b/micronaut-maven-jib-integration/src/main/java/io/micronaut/maven/jib/JibConfigurationService.java
@@ -26,6 +26,10 @@ import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
 import com.google.cloud.tools.jib.maven.MavenProjectProperties;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
+import io.micronaut.maven.jib.JibConfiguration.AuthConfiguration;
+import io.micronaut.maven.jib.JibConfiguration.ContainerConfiguration;
+import io.micronaut.maven.jib.JibConfiguration.FromConfiguration;
+import io.micronaut.maven.jib.JibConfiguration.ToConfiguration;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.maven.model.Plugin;
@@ -39,8 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import static io.micronaut.maven.jib.JibConfiguration.*;
 
 /**
  * Exposes the Jib plugin configuration so that it can be read by other mojos.

--- a/micronaut-maven-jib-integration/src/test/java/io/micronaut/maven/jib/JibConfigurationServiceTest.java
+++ b/micronaut-maven-jib-integration/src/test/java/io/micronaut/maven/jib/JibConfigurationServiceTest.java
@@ -22,7 +22,9 @@ import java.io.StringReader;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/DefaultServerFactoryTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/DefaultServerFactoryTest.java
@@ -10,9 +10,14 @@ import org.mockito.MockedStatic;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 class DefaultServerFactoryTest {
 

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/StartTestResourcesServerMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/StartTestResourcesServerMojoTest.java
@@ -15,8 +15,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test for StartTestResourcesServerMojo.


### PR DESCRIPTION
## Summary
- Enable Checkstyle's `AvoidStarImport` rule to match the Maven-relevant template style policy.
- Replace existing Java wildcard imports with explicit imports in plugin, Jib integration, and invoker sample sources.
- Preserve Maven-specific CI, wrapper, release, and build behavior; no source behavior or dependency changes are intended.

## Verification
- `git rebase origin/5.0.x` -> already up to date.
- `git diff --check origin/5.0.x...HEAD`
- `rg -n '^import\s+.*\.\*;' --glob '*.java' --glob '!target/**' .` -> no matches.
- `./mvnw spotless:check checkstyle:check`
- `./mvnw -pl micronaut-maven-jib-integration,micronaut-maven-plugin -am test`

## Release Metadata
- Target branch: `5.0.x`
- Type label: `type: task`
- Linked GitHub issue: none found for this Paperclip routine, so no GitHub closing keyword is required.
- Organization projects selected for the 5.0 line: `5.0.0-M3` and `5.0.0 Release`.
- Project-selection note: no QA intake artifact existed for this routine; selection is inferred from the repository default branch/version (`5.0.x` / `5.0.0-SNAPSHOT`) and the active Micronaut organization release boards.

## PR Assets
No rendered UI, generated documentation, images, PDFs, or other PR-visible assets changed.

---
###### ✨ This message was AI-generated using gpt-5
