### PR TITLE
docs: document release audit enforcement

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -99,5 +99,8 @@ tag such as `v5.0.0`, then monitor the `Release` workflow.
 The release workflow prepares the Maven release, publishes the generated site to GitHub Pages, and performs the Maven
 release. Do not replace it with the Gradle-oriented template release flow.
 
+The release workflow runs the vulnerability audit before publishing. Vulnerability findings are advisory for milestone
+and release-candidate tags such as `v5.0.0-M1` and `v5.0.0-RC1`, but they remain blocking for GA releases.
+
 If there is an issue with the release, do not publish artifacts to Maven Central again for the same version. Maven Central
 artifacts are immutable once released.


### PR DESCRIPTION
## Summary
- Document that the release workflow runs the vulnerability audit before publishing.
- Clarify that milestone and RC tags keep vulnerability findings advisory, while GA releases remain blocking.

## Verification
- `git diff --check origin/5.0.x...HEAD`
- Confirmed the change is limited to `MAINTAINING.md`.
- Confirmed the documented behavior matches `.github/workflows/release.yml` and `.github/scripts/vulnerability-audit.sh`.

## Issue Linkage
Paperclip issue: DEV-633. No linked GitHub issue was found for this routine-originated maintenance task, so no GitHub closing keyword applies.

## Project Routing
QA did not record a separate intake artifact for this routine issue. Based on the `5.0.x` target branch and currently open Micronaut organization projects, this PR should be linked to both `5.0.0-M3` and `5.0.0 Release`.

## Assets
No PR-visible assets are needed; this is a Markdown maintainer-documentation update with no rendered UI or generated artifact.

---
###### ✨ This message was AI-generated using gpt-5
