### PR TITLE
ci: update GitHub Actions pins from template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '/usr/lib/jvm' | paste -sd:)
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
         run: bash .github/scripts/verify-maven-wrapper-checksum.sh
 
       - name: "☕️ Install Java and Maven"
-        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -68,7 +68,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: "☕️ Set up Apache Maven Central"
-        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: "🛡 Verify workflow pinning"
         run: bash .github/scripts/check-workflow-pinning.sh
       - name: "🛡 Verify Maven wrapper checksum"
@@ -48,7 +48,7 @@ jobs:
       GRAALVM_QUICK_BUILD: true
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: "☕️ Install Java and Maven"
         if: steps.preflight_scope.outputs.should_run == 'true'
-        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -126,7 +126,7 @@ jobs:
 
       - name: "📊 Publish Preflight Test Report"
         if: always() && steps.preflight_scope.outputs.should_run == 'true'
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
         with:
           check_name: Linux Docker Native Preflight / Test Report
           report_paths: '**/target/invoker-reports/TEST-*.xml'
@@ -168,7 +168,7 @@ jobs:
           df -h
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -182,7 +182,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: "☕️ Install Java and Maven and set up Apache Maven Central"
-        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: "📊 Publish Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
         with:
           check_name: Java CI / Test Report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -247,7 +247,7 @@ jobs:
 
       - name: "📤 Upload snapshot site"
         if: success() && github.event_name == 'push' && matrix.java == '25'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snapshot-site
           path: micronaut-maven-plugin/target/site
@@ -274,7 +274,7 @@ jobs:
       shards: ${{ steps.shards.outputs.shards }}
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: "🧩 Generate invoker test shards"
         id: shards
         run: python3 .github/scripts/shard-invoker-tests.py --github-output "$GITHUB_OUTPUT"
@@ -314,12 +314,12 @@ jobs:
           df -h
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: "☕️ Install Java and Maven"
-        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -345,7 +345,7 @@ jobs:
 
       - name: "📊 Publish Invoker Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
         with:
           check_name: Java CI / Invoker Test Report (${{ matrix.shard.name }})
           report_paths: '**/target/invoker-reports/TEST-*.xml'
@@ -360,7 +360,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
@@ -389,7 +389,7 @@ jobs:
 
       - name: "📥 Download snapshot site"
         if: steps.branch_freshness.outputs.fresh == 'true'
-        uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: snapshot-site
           path: micronaut-maven-plugin/target/site

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -27,12 +27,12 @@ jobs:
       matrix:
         java: ['25']
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Verify Maven wrapper checksum
         shell: bash
         run: bash .github/scripts/verify-maven-wrapper-checksum.sh
       - name: Cache Maven packages
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/windows-preflight.yml
+++ b/.github/workflows/windows-preflight.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: "🛡 Verify workflow pinning"
         run: bash .github/scripts/check-workflow-pinning.sh
 
@@ -43,9 +43,9 @@ jobs:
         java: ['25']
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: "☕️ Install Java"
-        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
## Summary

- Update Maven-relevant GitHub Action pins to match the current Micronaut Project Template refs.
- Preserve the existing Maven plugin workflow structure, permissions, release steps, commands, and Java 25 matrix.
- Keep the change limited to `.github/workflows/release.yml`, `.github/workflows/snapshot.yml`, `.github/workflows/windows-ci.yml`, and `.github/workflows/windows-preflight.yml`.

## Review Notes

- No linked GitHub issue was present for this Paperclip maintenance run, so no closing keyword is included and no issue-creator reviewer is applicable.
- Selected Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`, because this targets the `5.0.x` line and the live organization project set has both prerelease and GA release boards.
- PR-visible assets are not required because this is CI workflow metadata only; no rendered docs, generated files, screenshots, or reports changed.

## Verification

- `git diff --check origin/5.0.x...HEAD`
- `bash .github/scripts/check-workflow-pinning.sh`
- `bash .github/scripts/ci-sensitive-preflight.sh` (workflow pinning passed; local Windows shell unavailable)
- GitHub Actions `Windows Preflight` run `25980899634` passed on commit `50ae08af21bba48a608e88798ec7c0b6ea6d1715`

---
###### ✨ This message was AI-generated using GPT-5