### PR TITLE
chore: align checkstyle config with project template

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -49,7 +49,7 @@
     <!-- Checks whether files end with a new line.                        -->
     <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
     <module name="NewlineAtEndOfFile">
-        <property name="lineSeparator" value="lf_cr_crlf"/>
+        <property name="lineSeparator" value="lf"/>
     </module>
 
     <!-- Checks that property files contain the same keys.         -->
@@ -171,8 +171,8 @@
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <!--<module name="MagicNumber">-->
-        <!--<property name="ignoreFieldDeclaration" value="true"/>-->
-        <!--<property name="ignoreHashCodeMethod" value="true"/>-->
+            <!--<property name="ignoreFieldDeclaration" value="true"/>-->
+            <!--<property name="ignoreHashCodeMethod" value="true"/>-->
         <!--</module>-->
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -6,7 +6,7 @@
 
 <suppressions>
     <!-- <suppress checks="FileLength" -->
-    <!-- files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java"/> -->
+              <!-- files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java"/> -->
 
     <suppress checks="MissingJavadocType" files=".*doc-examples.*" />
 </suppressions>


### PR DESCRIPTION
## Summary

- Align Checkstyle configuration with the Micronaut Project Template.
- Require LF line endings in `NewlineAtEndOfFile`.
- Normalize commented Checkstyle XML indentation to match the template.

## Issue Linkage

Closes DEV-725.

No linked GitHub issue exists for this Paperclip routine issue. The durable Paperclip PR link is recorded through GitHub Sync after PR creation.

## Verification

- `git merge-base --is-ancestor origin/5.0.x HEAD`
- `git diff --check origin/5.0.x..HEAD`
- `ruby -rrexml/document -e 'ARGV.each { |f| REXML::Document.new(File.read(f)); puts f }' config/checkstyle/checkstyle.xml config/checkstyle/suppressions.xml`
- Compared both Checkstyle files against `micronaut-projects/micronaut-project-template@0619fabc8e68dd05247234081d9ec3956f1fe27d`
- `./mvnw -pl micronaut-maven-plugin -am compile`

## PR Assets

No PR-visible assets are required for this configuration-only change.

## Project Routing

QA did not record a separate `qa-intake` project set for this routine-created repository-maintenance issue. The target branch is the unreleased `5.0.x` line; the selected and linked Micronaut organization projects are `5.0.0-M3` and `5.0.0 Release`. Ambiguity note: no `5.0.0-RC1` organization project was listed by GitHub tooling, and `5.0.1 Release` is a later patch-release board, so it was not selected.

---
###### ✨ This message was AI-generated using GPT-5