### PR TITLE
ci: update JUnit report action digest

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: "📊 Publish Preflight Test Report"
         if: always() && steps.preflight_scope.outputs.should_run == 'true'
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           check_name: Linux Docker Native Preflight / Test Report
           report_paths: '**/target/invoker-reports/TEST-*.xml'
@@ -219,7 +219,7 @@ jobs:
 
       - name: "📊 Publish Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           check_name: Java CI / Test Report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -345,7 +345,7 @@ jobs:
 
       - name: "📊 Publish Invoker Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           check_name: Java CI / Invoker Test Report (${{ matrix.shard.name }})
           report_paths: '**/target/invoker-reports/TEST-*.xml'


### PR DESCRIPTION
## Summary
- update all three `mikepenz/action-junit-report` pins in `.github/workflows/snapshot.yml` to `3a81627bfac62268172037048872e8ebd4207e6d`
- keep the existing Maven CI jobs, permissions, report globs, wrappers, release files, docs, and source code unchanged

## Release Board Routing
- Target branch: `5.0.x`
- Release target: 5.0 line; current repository release data still shows `v5.0.0` GA as draft/unreleased
- Linked Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`
- `5.0.1 Release` is also open, but was not selected because this branch is still targeting the unreleased 5.0.0 line

## Verification
- `git diff --check origin/5.0.x...HEAD`
- `bash .github/scripts/ci-sensitive-preflight.sh`
- `gh api repos/mikepenz/action-junit-report/commits/3a81627bfac62268172037048872e8ebd4207e6d`

## Review Notes
Paperclip: DEV-803. There is no linked GitHub issue for this routine execution, so no GitHub closing keyword applies and there is no linked issue creator to request as reviewer.

Existing Renovate PR #1672 carries the same digest update, but it is stale behind the current `5.0.x` branch and has an old failing Windows Preflight run. This PR uses the approved Paperclip branch that was fetched and verified against current `5.0.x`.

## PR Assets
No rendered output or generated artifacts changed, so no PR-visible asset upload is required.

---
###### ✨ This message was AI-generated using gpt-5
