### PR TITLE
docs: remove empty test javadoc site report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -790,6 +790,14 @@
                     <maxmemory>512</maxmemory>
                     <failOnError>false</failOnError>
                 </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>aggregate</report>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- restrict the Maven Site Javadoc report set to aggregate/API docs
- remove empty test-Javadoc report entries that generated broken testapidocs links in the site navigation

## Validation

- ./mvnw -pl micronaut-maven-plugin -am clean site:site
- local generated-site link check: checked_html=182, missing_local_links=0
- ./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=configuration-validation-valid"
- git diff --check

Paperclip: DEV-1086

---
###### ✨ This message was AI-generated using gpt-5.5