### PR TITLE
Add explicit CI build job names

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -133,6 +133,7 @@ jobs:
           check_retries: 'true'
 
   snapshot:
+    name: "snapshot"
     needs:
       - workflow-hardening
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   build:
+    name: "build"
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Add an explicit `name: "snapshot"` to the `snapshot` workflow job.
- Add an explicit `name: "build"` to the Windows CI `build` workflow job.
- Apply the current Micronaut Project Template build-job-name propagation in Maven-specific workflows only.

## Release And Routing
- Target branch: `5.0.x`.
- Release target: `5.0.x` patch-maintenance line; live org project target is `5.0.3 Release`.
- Type label: `type: task`.
- Linked GitHub issue: none. This is routine Paperclip template propagation work for `DEV-1105`, so no GitHub closing keyword or issue-creator reviewer applies.

## Verification
- `git fetch origin 5.0.x && git rebase origin/5.0.x`
- `git diff --check origin/5.0.x...HEAD`
- `bash .github/scripts/ci-sensitive-preflight.sh`

The CI-sensitive preflight passed workflow pinning. The Windows wrapper preflight requires a Windows shell and should be covered by the PR's Windows CI workflow.

## PR Assets
Not applicable; this changes workflow job display metadata only and does not alter rendered output or generated artifacts.

---
###### ✨ This message was AI-generated using GPT-5
