### PR TITLE
Improve native image CI diagnostics

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -46,6 +46,7 @@ jobs:
       DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
       DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
       GRAALVM_QUICK_BUILD: true
+      NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -117,6 +118,7 @@ jobs:
           distribution: 'graalvm'
           java-version: '25'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
 
       - name: "🐳 Run Linux docker-native preflight"
         if: steps.preflight_scope.outputs.should_run == 'true'
@@ -153,6 +155,7 @@ jobs:
       OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
       OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
       GRAALVM_QUICK_BUILD: true
+      NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
     steps:
       - name: "🗑 Remove system JDKs"
         run: |
@@ -198,6 +201,7 @@ jobs:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
 
       - name: "⏬ Eagerly pull Docker images"
         run: |
@@ -299,6 +303,7 @@ jobs:
       DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
       DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
       GRAALVM_QUICK_BUILD: true
+      NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
     steps:
       - name: "🗑 Remove system JDKs"
         run: |
@@ -332,6 +337,7 @@ jobs:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
 
       - name: "⏬ Eagerly pull Docker images"
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -24,6 +24,8 @@ jobs:
   build:
     name: "build"
     runs-on: windows-latest
+    env:
+      NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
     strategy:
       matrix:
         java: ['25']
@@ -54,7 +56,6 @@ jobs:
           .\mvnw install -Dinvoker.skip=true && .\mvnw verify
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
-          NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -44,6 +44,7 @@ jobs:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
       - name: Windows wrapper preflight
         shell: cmd
         run: .github\scripts\windows-preflight.cmd
@@ -53,6 +54,7 @@ jobs:
           .\mvnw install -Dinvoker.skip=true && .\mvnw verify
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
+          NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}


### PR DESCRIPTION
## Summary

- Enable GraalVM native-image job reports for the Maven Plugin native-image CI jobs.
- Add native-image exception stack traces to Linux and Windows CI native builds.
- Preserve Maven-specific workflows and avoid importing Gradle-only template changes.

## Verification

- `git diff --check origin/5.0.x..HEAD`
- `bash .github/scripts/ci-sensitive-preflight.sh`

## Release metadata

- Target branch: `5.0.x`
- Release target: `5.0.x`
- Micronaut organization project: `5.0.1 Release`
- Project ambiguity: no open public `5.0.0 Release` board was visible during QA intake, so `5.0.1 Release` was the selected closest visible Micronaut Platform BOM release board. GitHub now reports `5.0.1 Release` as closed, but it accepted the live PR association and remains linked.
- Type label: `type: task`
- Linked GitHub issue: none; this is a Paperclip routine-maintenance issue, so no closing keyword is included.

## PR Assets

No rendered output or generated artifact changed. This is a workflow-only CI diagnostics update, so no PR-visible asset is required.

---
###### ✨ This message was AI-generated using openai/gpt-5.5