### PR TITLE
Update Micronaut dependency to 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <maven.compiler.target>${jdk.version}</maven.compiler.target>
 
         <maven.version>3.9.15</maven.version>
-        <micronaut.version>5.0.0</micronaut.version>
+        <micronaut.version>5.0.2</micronaut.version>
         <native-maven-plugin.version>1.1.0</native-maven-plugin.version>
         <micronaut.aot.version>3.0.0</micronaut.aot.version>
         <micronaut.test.resources.version>4.0.0</micronaut.test.resources.version>


### PR DESCRIPTION
## Summary

- Updates the root `pom.xml` `micronaut.version` property from `5.0.0` to `5.0.2`.
- Applies the Maven-relevant part of `micronaut-projects/micronaut-project-template#729` to the Micronaut Maven Plugin `5.0.x` line.
- Leaves source, CI, wrapper, release, docs, and example files unchanged.

## Verification

- `git fetch origin 5.0.x && git merge --ff-only origin/5.0.x`
- `git diff --check origin/5.0.x...HEAD`
- `./mvnw -q -DskipTests -Dinvoker.skip=true validate`
- `./mvnw -q help:evaluate -Dexpression=micronaut.version -DforceStdout`

## Paperclip

Closes DEV-1204 in Paperclip once merged through GitHub Sync.

- Implementation artifact: DEV-1204 `implementation`
- QA artifact: DEV-1204 `qa-verification`
- Security artifact: DEV-1204 `security-review`
- Organization project selection: upstream QA did not record an explicit project set; this PR targets `5.0.x`, and the active matching Micronaut Platform BOM release board is `5.0.3 Release`.
- PR-visible assets: none required; no rendered output or generated review artifact changed.

---
###### ✨ This message was AI-generated using openai/gpt-5.5
