### PR TITLE
Fix Maven test resources standalone service reuse

### DIFF
--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -269,7 +269,7 @@ public class TestResourcesHelper {
         }
         HttpURLConnection connection = null;
         try {
-            URL url = new URL("http://localhost:" + serverSettings.getPort() + TEST_RESOURCES_REQUIREMENTS_ENTRIES_PATH);
+            var url = URI.create("http://localhost:" + serverSettings.getPort() + TEST_RESOURCES_REQUIREMENTS_ENTRIES_PATH).toURL();
             connection = (HttpURLConnection) url.openConnection();
             connection.setConnectTimeout(SERVER_PROBE_TIMEOUT_MS);
             connection.setReadTimeout(SERVER_PROBE_TIMEOUT_MS);
@@ -285,7 +285,7 @@ public class TestResourcesHelper {
             try (InputStream input = connection.getInputStream()) {
                 return isJsonStringArray(new String(input.readAllBytes(), StandardCharsets.UTF_8));
             }
-        } catch (IOException e) {
+        } catch (IOException _) {
             return false;
         } finally {
             if (connection != null) {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -264,9 +264,6 @@ public class TestResourcesHelper {
     }
 
     private boolean isReusableTestResourcesServer(ServerSettings serverSettings) {
-        if (!isServerStarted(serverSettings.getPort())) {
-            return false;
-        }
         HttpURLConnection connection = null;
         try {
             var url = URI.create("http://localhost:" + serverSettings.getPort() + TEST_RESOURCES_REQUIREMENTS_ENTRIES_PATH).toURL();

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -217,25 +217,19 @@ public class TestResourcesHelper {
             setSystemProperties(serverSettings);
             return;
         }
+        Optional<ServerSettings> existingServerSettings = findReachableRecordedServer(serverSettingsDirectory);
+        if (existingServerSettings.isPresent()) {
+            useServerSettings(buildDir, serverSettingsDirectory, existingServerSettings.get(), false);
+            return;
+        }
         Optional<ServerSettings> optionalServerSettings = startOrConnectToExistingServer(accessToken, buildDir, serverSettingsDirectory, serverFactory);
         if (optionalServerSettings.isEmpty()) {
             return;
         }
         ServerSettings serverSettings = optionalServerSettings.get();
-        writePortFile(buildDir.resolve(PORT_FILE_NAME), serverSettings.getPort());
-        boolean sessionOwnedSharedServer = shared && registerSharedServerUse(serverSettingsDirectory, serverSettings.getPort(), serverStarted.get());
-        if (shared) {
-            logSharedMode(serverSettingsDirectory);
-            writeSharedScopeConfiguration();
-        }
-        setSystemProperties(serverSettings);
-        if (serverStarted.get()) {
-            if (isKeepAlive()) {
-                log.info("Micronaut Test Resources service is started in the background. To stop it, run the following command: 'mvn mn:" + StopTestResourcesServerMojo.NAME + "'");
-            }
-        } else if (!sessionOwnedSharedServer) {
-            // A server was already listening before this build started, so leave it running.
-            createKeepAliveFile();
+        useServerSettings(buildDir, serverSettingsDirectory, serverSettings, serverStarted.get());
+        if (serverStarted.get() && isKeepAlive()) {
+            log.info("Micronaut Test Resources service is started in the background. To stop it, run the following command: 'mvn mn:" + StopTestResourcesServerMojo.NAME + "'");
         }
     }
 
@@ -254,6 +248,26 @@ public class TestResourcesHelper {
             }
             return ServerUtils.readServerSettings(serverSettingsDirectory)
                 .filter(settings -> settings.getPort() == sharedServerState.port);
+        }
+    }
+
+    private Optional<ServerSettings> findReachableRecordedServer(Path serverSettingsDirectory) {
+        return ServerUtils.readServerSettings(serverSettingsDirectory)
+            .filter(serverSettings -> explicitPort == null || serverSettings.getPort() == explicitPort)
+            .filter(serverSettings -> isServerStarted(serverSettings.getPort()));
+    }
+
+    private void useServerSettings(Path buildDir, Path serverSettingsDirectory, ServerSettings serverSettings, boolean serverStarted) throws IOException {
+        writePortFile(buildDir.resolve(PORT_FILE_NAME), serverSettings.getPort());
+        boolean sessionOwnedSharedServer = shared && registerSharedServerUse(serverSettingsDirectory, serverSettings.getPort(), serverStarted);
+        if (shared) {
+            logSharedMode(serverSettingsDirectory);
+            writeSharedScopeConfiguration();
+        }
+        setSystemProperties(serverSettings);
+        if (!serverStarted && !sessionOwnedSharedServer) {
+            // A server was already listening before this build started, so leave it running.
+            createKeepAliveFile();
         }
     }
 

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/testresources/TestResourcesHelper.java
@@ -39,6 +39,9 @@ import java.nio.file.FileAlreadyExistsException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -76,6 +79,9 @@ public class TestResourcesHelper {
     private static final String APPLICATION_TEST_PROPERTIES = "application-test.properties";
     private static final String TEST_RESOURCES_SCOPE_PROPERTY = "micronaut.test.resources.scope";
     private static final String SCOPE_PREFIX = "mvn";
+    private static final String TEST_RESOURCES_REQUIREMENTS_ENTRIES_PATH = "/requirements/entries";
+    private static final String ACCESS_TOKEN_HEADER = "Access-Token";
+    private static final int SERVER_PROBE_TIMEOUT_MS = 1_000;
 
     private static final String TEST_RESOURCES_CLIENT_SYSTEM_PROP_PREFIX = "micronaut.test.resources.";
 
@@ -254,7 +260,50 @@ public class TestResourcesHelper {
     private Optional<ServerSettings> findReachableRecordedServer(Path serverSettingsDirectory) {
         return ServerUtils.readServerSettings(serverSettingsDirectory)
             .filter(serverSettings -> explicitPort == null || serverSettings.getPort() == explicitPort)
-            .filter(serverSettings -> isServerStarted(serverSettings.getPort()));
+            .filter(this::isReusableTestResourcesServer);
+    }
+
+    private boolean isReusableTestResourcesServer(ServerSettings serverSettings) {
+        if (!isServerStarted(serverSettings.getPort())) {
+            return false;
+        }
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL("http://localhost:" + serverSettings.getPort() + TEST_RESOURCES_REQUIREMENTS_ENTRIES_PATH);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(SERVER_PROBE_TIMEOUT_MS);
+            connection.setReadTimeout(SERVER_PROBE_TIMEOUT_MS);
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Accept", "application/json");
+            String accessToken = serverSettings.getAccessToken().orElse(null);
+            if (accessToken != null) {
+                connection.setRequestProperty(ACCESS_TOKEN_HEADER, accessToken);
+            }
+            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK || !isJsonContentType(connection.getContentType())) {
+                return false;
+            }
+            try (InputStream input = connection.getInputStream()) {
+                return isJsonStringArray(new String(input.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            return false;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private static boolean isJsonContentType(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        return contentType.equals("application/json") || contentType.startsWith("application/json;");
+    }
+
+    private static boolean isJsonStringArray(String body) {
+        String trimmed = body.trim();
+        return trimmed.length() >= 2 && trimmed.charAt(0) == '[' && trimmed.charAt(trimmed.length() - 1) == ']';
     }
 
     private void useServerSettings(Path buildDir, Path serverSettingsDirectory, ServerSettings serverSettings, boolean serverStarted) throws IOException {

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -11,12 +11,15 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
+import com.sun.net.httpserver.HttpServer;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -310,8 +313,9 @@ class TestResourcesHelperTest {
         Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
         Path buildDirectory = tempDir.resolve("build");
 
-        try (ServerSocket server = new ServerSocket(0)) {
-            int port = server.getLocalPort();
+        HttpServer server = startReusableTestResourcesServer("standalone-token");
+        try {
+            int port = server.getAddress().getPort();
             ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(port, "standalone-token", 45, 60));
             TestResourcesHelper helper = helperWithDependencyResolution(buildDirectory, null);
             AtomicBoolean serverStarted = new AtomicBoolean(false);
@@ -344,6 +348,21 @@ class TestResourcesHelperTest {
                 restoreSystemProperty("micronaut.test.resources.server.access.token", previousAccessToken);
                 restoreSystemProperty("micronaut.test.resources.server.client.read.timeout", previousReadTimeout);
             }
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void findReachableRecordedStandaloneServerRejectsRawListener() throws Exception {
+        Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
+
+        try (ServerSocket server = new ServerSocket(0)) {
+            int port = server.getLocalPort();
+            ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(port, "standalone-token", 45, 60));
+            TestResourcesHelper helper = helperWithDependencyResolution(tempDir.resolve("build"), null);
+
+            assertTrue(invokeFindReachableRecordedServer(helper, serverSettingsDirectory).isEmpty());
         }
     }
 
@@ -471,6 +490,21 @@ class TestResourcesHelperTest {
         }
     }
 
+    private static HttpServer startReusableTestResourcesServer(String accessToken) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/requirements/entries", exchange -> {
+            byte[] body = "[]".getBytes(StandardCharsets.UTF_8);
+            int status = accessToken.equals(exchange.getRequestHeaders().getFirst("Access-Token")) ? 200 : 401;
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, body.length);
+            try (var output = exchange.getResponseBody()) {
+                output.write(body);
+            }
+        });
+        server.start();
+        return server;
+    }
+
     private static Path invokeGetKeepAliveFile(TestResourcesHelper helper) throws Exception {
         Method method = TestResourcesHelper.class.getDeclaredMethod("getKeepAliveFile");
         method.setAccessible(true);
@@ -543,6 +577,13 @@ class TestResourcesHelperTest {
     @SuppressWarnings("unchecked")
     private static Optional<ServerSettings> invokeFindSessionSharedServer(TestResourcesHelper helper, Path serverSettingsDirectory) throws Exception {
         Method method = TestResourcesHelper.class.getDeclaredMethod("findSessionSharedServer", Path.class);
+        method.setAccessible(true);
+        return (Optional<ServerSettings>) method.invoke(helper, serverSettingsDirectory);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Optional<ServerSettings> invokeFindReachableRecordedServer(TestResourcesHelper helper, Path serverSettingsDirectory) throws Exception {
+        Method method = TestResourcesHelper.class.getDeclaredMethod("findReachableRecordedServer", Path.class);
         method.setAccessible(true);
         return (Optional<ServerSettings>) method.invoke(helper, serverSettingsDirectory);
     }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -367,6 +367,62 @@ class TestResourcesHelperTest {
     }
 
     @Test
+    void findReachableRecordedStandaloneServerRejectsWrongToken() throws Exception {
+        Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
+        HttpServer server = startReusableTestResourcesServer("expected-token");
+        try {
+            ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(server.getAddress().getPort(), "recorded-token", 45, 60));
+            TestResourcesHelper helper = helperWithDependencyResolution(tempDir.resolve("build"), null);
+
+            assertTrue(invokeFindReachableRecordedServer(helper, serverSettingsDirectory).isEmpty());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void findReachableRecordedStandaloneServerRejectsUnexpectedResponseShape() throws Exception {
+        Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
+        HttpServer server = startTestResourcesProbeServer("standalone-token", 200, "application/json", "{}");
+        try {
+            ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(server.getAddress().getPort(), "standalone-token", 45, 60));
+            TestResourcesHelper helper = helperWithDependencyResolution(tempDir.resolve("build"), null);
+
+            assertTrue(invokeFindReachableRecordedServer(helper, serverSettingsDirectory).isEmpty());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void findReachableRecordedStandaloneServerRejectsUnexpectedContentType() throws Exception {
+        Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
+        HttpServer server = startTestResourcesProbeServer("standalone-token", 200, "text/plain", "[]");
+        try {
+            ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(server.getAddress().getPort(), "standalone-token", 45, 60));
+            TestResourcesHelper helper = helperWithDependencyResolution(tempDir.resolve("build"), null);
+
+            assertTrue(invokeFindReachableRecordedServer(helper, serverSettingsDirectory).isEmpty());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void findReachableRecordedStandaloneServerHonorsExplicitPort() throws Exception {
+        Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
+        HttpServer server = startReusableTestResourcesServer("standalone-token");
+        try {
+            ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(server.getAddress().getPort(), "standalone-token", 45, 60));
+            TestResourcesHelper helper = helperWithDependencyResolution(tempDir.resolve("build"), availableTcpPort());
+
+            assertTrue(invokeFindReachableRecordedServer(helper, serverSettingsDirectory).isEmpty());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     void doStartFallsBackWhenRecordedStandaloneServerIsStale() throws Exception {
         Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
         Path buildDirectory = tempDir.resolve("build");
@@ -491,11 +547,15 @@ class TestResourcesHelperTest {
     }
 
     private static HttpServer startReusableTestResourcesServer(String accessToken) throws IOException {
+        return startTestResourcesProbeServer(accessToken, 200, "application/json; charset=utf-8", "[]");
+    }
+
+    private static HttpServer startTestResourcesProbeServer(String accessToken, int successStatus, String contentType, String responseBody) throws IOException {
         HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/requirements/entries", exchange -> {
-            byte[] body = "[]".getBytes(StandardCharsets.UTF_8);
-            int status = accessToken.equals(exchange.getRequestHeaders().getFirst("Access-Token")) ? 200 : 401;
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+            int status = accessToken.equals(exchange.getRequestHeaders().getFirst("Access-Token")) ? successStatus : 401;
+            exchange.getResponseHeaders().set("Content-Type", contentType);
             exchange.sendResponseHeaders(status, body.length);
             try (var output = exchange.getResponseBody()) {
                 output.write(body);

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -318,6 +318,7 @@ class TestResourcesHelperTest {
             int port = server.getAddress().getPort();
             ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(port, "standalone-token", 45, 60));
             TestResourcesHelper helper = helperWithDependencyResolution(buildDirectory, null);
+            assertTrue(invokeFindReachableRecordedServer(helper, serverSettingsDirectory).isPresent());
             AtomicBoolean serverStarted = new AtomicBoolean(false);
             ServerFactory serverFactory = new ServerFactory() {
                 @Override

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/testresources/TestResourcesHelperTest.java
@@ -2,6 +2,7 @@ package io.micronaut.maven.testresources;
 
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import io.micronaut.maven.services.DependencyResolutionService;
 import io.micronaut.testresources.buildtools.ServerFactory;
 import io.micronaut.testresources.buildtools.ServerSettings;
 import io.micronaut.testresources.buildtools.ServerUtils;
@@ -15,10 +16,13 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -32,6 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -300,6 +306,77 @@ class TestResourcesHelperTest {
     }
 
     @Test
+    void doStartReusesReachableRecordedStandaloneServerBeforeFallback() throws Exception {
+        Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
+        Path buildDirectory = tempDir.resolve("build");
+
+        try (ServerSocket server = new ServerSocket(0)) {
+            int port = server.getLocalPort();
+            ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(port, "standalone-token", 45, 60));
+            TestResourcesHelper helper = helperWithDependencyResolution(buildDirectory, null);
+            AtomicBoolean serverStarted = new AtomicBoolean(false);
+            ServerFactory serverFactory = new ServerFactory() {
+                @Override
+                public void startServer(ServerUtils.ProcessParameters processParameters) {
+                    throw new AssertionError("Reachable recorded standalone server should be reused before fallback");
+                }
+
+                @Override
+                public void waitFor(Duration timeout) {
+                    throw new AssertionError("Reachable recorded standalone server should be reused before fallback");
+                }
+            };
+
+            String previousServerUri = System.getProperty("micronaut.test.resources.server.uri");
+            String previousAccessToken = System.getProperty("micronaut.test.resources.server.access.token");
+            String previousReadTimeout = System.getProperty("micronaut.test.resources.server.client.read.timeout");
+            try {
+                invokeDoStart(helper, buildDirectory, serverSettingsDirectory, serverFactory, serverStarted);
+
+                assertFalse(serverStarted.get());
+                assertEquals(Integer.toString(port), Files.readString(buildDirectory.resolve("test-resources-port.txt")));
+                assertEquals("http://localhost:" + port, System.getProperty("micronaut.test.resources.server.uri"));
+                assertEquals("standalone-token", System.getProperty("micronaut.test.resources.server.access.token"));
+                assertEquals("45", System.getProperty("micronaut.test.resources.server.client.read.timeout"));
+                assertTrue(invokeIsKeepAlive(helper), "Ordinary builds must leave reused standalone servers alive during cleanup");
+            } finally {
+                restoreSystemProperty("micronaut.test.resources.server.uri", previousServerUri);
+                restoreSystemProperty("micronaut.test.resources.server.access.token", previousAccessToken);
+                restoreSystemProperty("micronaut.test.resources.server.client.read.timeout", previousReadTimeout);
+            }
+        }
+    }
+
+    @Test
+    void doStartFallsBackWhenRecordedStandaloneServerIsStale() throws Exception {
+        Path serverSettingsDirectory = tempDir.resolve("standalone-settings");
+        Path buildDirectory = tempDir.resolve("build");
+        int stalePort = availableTcpPort();
+        int fallbackPort = availableTcpPort();
+        ServerUtils.writeServerSettings(serverSettingsDirectory, new ServerSettings(stalePort, "stale-token", 45, 60));
+        TestResourcesHelper helper = helperWithDependencyResolution(buildDirectory, fallbackPort);
+        AtomicBoolean fallbackInvoked = new AtomicBoolean(false);
+        AtomicBoolean serverStarted = new AtomicBoolean(false);
+        ServerFactory serverFactory = new ServerFactory() {
+            @Override
+            public void startServer(ServerUtils.ProcessParameters processParameters) {
+                fallbackInvoked.set(true);
+                serverStarted.set(true);
+            }
+
+            @Override
+            public void waitFor(Duration timeout) {
+                // No-op; explicit fallback ports do not need a port-file wait.
+            }
+        };
+
+        invokeDoStart(helper, buildDirectory, serverSettingsDirectory, serverFactory, serverStarted);
+
+        assertTrue(fallbackInvoked.get());
+        assertEquals(Integer.toString(fallbackPort), Files.readString(buildDirectory.resolve("test-resources-port.txt")));
+    }
+
+    @Test
     void findSessionSharedServerRequiresSharedMode() throws Exception {
         TestResourcesHelper helper = new TestResourcesHelper(mock(MavenSession.class), true, false, tempDir.toFile());
 
@@ -357,6 +434,41 @@ class TestResourcesHelperTest {
         when(mavenSession.getRequest()).thenReturn(request);
 
         return new TestResourcesHelper(mavenSession, true, false, new File("."));
+    }
+
+    private static TestResourcesHelper helperWithDependencyResolution(Path buildDirectory, Integer explicitPort) throws Exception {
+        MavenExecutionRequest request = mock(MavenExecutionRequest.class);
+        when(request.getBuilderId()).thenReturn("builder-123");
+        MavenSession mavenSession = mock(MavenSession.class);
+        when(mavenSession.getRequest()).thenReturn(request);
+        when(mavenSession.getGoals()).thenReturn(List.of("test"));
+        DependencyResolutionService dependencyResolutionService = mock(DependencyResolutionService.class);
+        when(dependencyResolutionService.artifactResultsFor(any(), eq(true))).thenReturn(List.of());
+        return new TestResourcesHelper(
+            true,
+            false,
+            buildDirectory.toFile(),
+            explicitPort,
+            null,
+            null,
+            new MavenProject(),
+            mavenSession,
+            dependencyResolutionService,
+            null,
+            "4.0.0",
+            false,
+            null,
+            null,
+            false,
+            false,
+            Map.of()
+        );
+    }
+
+    private static int availableTcpPort() throws IOException {
+        try (ServerSocket server = new ServerSocket(0)) {
+            return server.getLocalPort();
+        }
     }
 
     private static Path invokeGetKeepAliveFile(TestResourcesHelper helper) throws Exception {
@@ -436,6 +548,10 @@ class TestResourcesHelperTest {
     }
 
     private static void invokeDoStart(TestResourcesHelper helper, Path buildDirectory, Path serverSettingsDirectory, ServerFactory serverFactory) throws Exception {
+        invokeDoStart(helper, buildDirectory, serverSettingsDirectory, serverFactory, new AtomicBoolean(false));
+    }
+
+    private static void invokeDoStart(TestResourcesHelper helper, Path buildDirectory, Path serverSettingsDirectory, ServerFactory serverFactory, AtomicBoolean serverStarted) throws Exception {
         Method method = TestResourcesHelper.class.getDeclaredMethod(
             "doStart",
             String.class,
@@ -445,7 +561,7 @@ class TestResourcesHelperTest {
             AtomicBoolean.class
         );
         method.setAccessible(true);
-        method.invoke(helper, "new-token", buildDirectory, serverSettingsDirectory, serverFactory, new AtomicBoolean(false));
+        method.invoke(helper, "new-token", buildDirectory, serverSettingsDirectory, serverFactory, serverStarted);
     }
 
     @FunctionalInterface

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>micronaut-projects</sonar.organization>
         <sonar.java.checkstyle.reportPaths>${project.basedir}/target/checkstyle-result.xml</sonar.java.checkstyle.reportPaths>
-        <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/micronaut-maven-integration-tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/**/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/micronaut-maven-integration-tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
         <jacoco.version>0.8.14</jacoco.version>
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
@@ -740,6 +740,13 @@
                         <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary
- reuse a recorded standalone Micronaut Test Resources server before Maven falls back to build-tools startup/connect logic
- validate the recorded server with the `/requirements/entries` HTTP endpoint and recorded `Access-Token` before applying persisted settings
- preserve stale-settings fallback, shared-server precedence, and ordinary build-owned shutdown behavior
- address PR quality-gate feedback by avoiding deprecated `URL` construction and adding coverage for failed probe cases

## Issue linkage and release metadata
Fixes DEV-1213 (Paperclip).
Related to micronaut-projects/micronaut-gradle-plugin#1342 / DEV-1135.

- Type: `type: bug`
- Target branch: `5.0.x`
- Release target: non-breaking bug fix for the 5.0 line
- Micronaut Platform BOM project: `5.0.3 Release` (https://github.com/orgs/micronaut-projects/projects/153)
- Project ambiguity preserved from QA: repository default/source now tracks `5.0.x` / `5.0.1-SNAPSHOT`, while the earliest open public Micronaut Platform BOM board matching the 5.0 line is `5.0.3 Release`.
- Linked GitHub issue reporter context: `melix` reported the related Gradle lifecycle regression in micronaut-projects/micronaut-gradle-plugin#1342.

## Tests
- `./mvnw -pl micronaut-maven-plugin -am -Dtest=io.micronaut.maven.testresources.TestResourcesHelperTest -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs` — 23 tests, 0 failures/errors/skips; involved Checkstyle/Spotless checks clean
- `git diff --check origin/5.0.x...HEAD`

## Documentation
No documentation change required. This restores the existing explicit `mn:start-testresources-service` / `mn:stop-testresources-service` standalone lifecycle contract without changing public goal names, parameters, persisted file format, or user-facing behavior.

---
###### ✨ This message was AI-generated using gpt-5.5
