### PR TITLE
Add Micronaut info metadata generation

### DIFF
--- a/micronaut-maven-integration-tests/src/it/generate-info-git-disabled/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/generate-info-git-disabled/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -ntp mn:generate-info

--- a/micronaut-maven-integration-tests/src/it/generate-info-git-disabled/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/generate-info-git-disabled/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>generate-info-git-disabled</artifactId>
+  <version>0.1</version>
+  <name>Generate Info Git Disabled Example</name>
+
+  <properties>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+    <project.build.outputTimestamp>2026-01-02T03:04:05Z</project.build.outputTimestamp>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <version>${micronaut-maven-plugin.version}</version>
+        <configuration>
+          <gitEnabled>false</gitEnabled>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/micronaut-maven-integration-tests/src/it/generate-info-git-disabled/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/generate-info-git-disabled/verify.groovy
@@ -1,0 +1,13 @@
+Properties buildInfo = new Properties()
+File buildInfoFile = new File(basedir, 'target/classes/META-INF/build-info.properties')
+assert buildInfoFile.exists()
+buildInfoFile.withInputStream { buildInfo.load(it) }
+assert buildInfo.getProperty('build.artifact') == 'generate-info-git-disabled'
+assert buildInfo.getProperty('build.time') == '2026-01-02T03:04:05Z'
+
+File gitInfoFile = new File(basedir, 'target/classes/git.properties')
+assert !gitInfoFile.exists()
+
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert !log.text.contains('Generated Micronaut git info')

--- a/micronaut-maven-integration-tests/src/it/generate-info/invoker.properties
+++ b/micronaut-maven-integration-tests/src/it/generate-info/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -ntp process-resources

--- a/micronaut-maven-integration-tests/src/it/generate-info/pom.xml
+++ b/micronaut-maven-integration-tests/src/it/generate-info/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.micronaut.build.examples</groupId>
+  <artifactId>generate-info</artifactId>
+  <version>0.1</version>
+  <name>Generate Info Example</name>
+
+  <properties>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
+    <micronaut.version>@it.micronaut.version@</micronaut.version>
+    <micronaut-maven-plugin.version>@project.version@</micronaut-maven-plugin.version>
+    <project.build.outputTimestamp>2026-01-02T03:04:05Z</project.build.outputTimestamp>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+        <version>${micronaut-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-info</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <additionalBuildProperties>
+            <build.environment>test</build.environment>
+          </additionalBuildProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/micronaut-maven-integration-tests/src/it/generate-info/setup.groovy
+++ b/micronaut-maven-integration-tests/src/it/generate-info/setup.groovy
@@ -1,0 +1,20 @@
+File readme = new File(basedir, 'README.md')
+readme.text = 'generate info test\n'
+
+def git(String... args) {
+    def command = ['git'] + args.toList()
+    def process = new ProcessBuilder(command)
+            .directory(basedir as File)
+            .redirectErrorStream(true)
+            .start()
+    def output = process.inputStream.text
+    process.waitFor()
+    assert process.exitValue() == 0: output
+}
+
+git('init')
+git('config', 'user.email', 'dev@example.com')
+git('config', 'user.name', 'Dev User')
+git('remote', 'add', 'origin', 'https://example.com/private/repo.git')
+git('add', 'README.md', 'pom.xml')
+git('commit', '-m', 'Initial commit')

--- a/micronaut-maven-integration-tests/src/it/generate-info/verify.groovy
+++ b/micronaut-maven-integration-tests/src/it/generate-info/verify.groovy
@@ -1,0 +1,43 @@
+Properties buildInfo = new Properties()
+File buildInfoFile = new File(basedir, 'target/classes/META-INF/build-info.properties')
+assert buildInfoFile.exists()
+buildInfoFile.withInputStream { buildInfo.load(it) }
+assert buildInfo.getProperty('build.group') == 'io.micronaut.build.examples'
+assert buildInfo.getProperty('build.artifact') == 'generate-info'
+assert buildInfo.getProperty('build.name') == 'Generate Info Example'
+assert buildInfo.getProperty('build.version') == '0.1'
+assert buildInfo.getProperty('build.time') == '2026-01-02T03:04:05Z'
+assert buildInfo.getProperty('build.java.source') == '25'
+assert buildInfo.getProperty('build.java.target') == '25'
+assert buildInfo.getProperty('build.micronaut.version') == '5.0.0-RC1'
+assert buildInfo.getProperty('build.environment') == 'test'
+
+String gitOutput(String... args) {
+    def command = ['git'] + args.toList()
+    def process = new ProcessBuilder(command)
+            .directory(basedir as File)
+            .redirectErrorStream(true)
+            .start()
+    def output = process.inputStream.text.trim()
+    process.waitFor()
+    assert process.exitValue() == 0: output
+    return output
+}
+
+Properties gitInfo = new Properties()
+File gitInfoFile = new File(basedir, 'target/classes/git.properties')
+assert gitInfoFile.exists()
+gitInfoFile.withInputStream { gitInfo.load(it) }
+assert gitInfo.getProperty('git.commit.id') == gitOutput('rev-parse', 'HEAD')
+assert gitInfo.getProperty('git.commit.id.abbrev') == gitOutput('rev-parse', '--short', 'HEAD')
+assert gitInfo.getProperty('git.commit.time')
+assert gitInfo.getProperty('git.branch')
+assert gitInfo.getProperty('git.dirty') == 'true'
+assert !gitInfo.containsKey('git.remote.origin.url')
+assert !gitInfo.containsKey('git.build.user.name')
+assert !gitInfo.containsKey('git.build.user.email')
+
+File log = new File(basedir, 'build.log')
+assert log.exists()
+assert log.text.contains('Generated Micronaut build info')
+assert log.text.contains('Generated Micronaut git info')

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/BuildInfoGenerator.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/BuildInfoGenerator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.info;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+/**
+ * Generates build metadata properties.
+ *
+ * @author Micronaut Authors
+ * @since 5.0.1
+ */
+final class BuildInfoGenerator {
+
+    private static final String OUTPUT_TIMESTAMP_PROPERTY = "project.build.outputTimestamp";
+    private static final String MICRONAUT_VERSION_PROPERTY = "micronaut.version";
+    private static final String MAVEN_COMPILER_RELEASE_PROPERTY = "maven.compiler.release";
+    private static final String MAVEN_COMPILER_SOURCE_PROPERTY = "maven.compiler.source";
+    private static final String MAVEN_COMPILER_TARGET_PROPERTY = "maven.compiler.target";
+
+    private BuildInfoGenerator() {
+    }
+
+    static Map<String, String> generate(MavenProject project, Instant buildTime, Map<String, String> additionalProperties) {
+        var properties = new TreeMap<String, String>();
+        putIfNotBlank(properties, "build.group", project.getGroupId());
+        putIfNotBlank(properties, "build.artifact", project.getArtifactId());
+        putIfNotBlank(properties, "build.name", project.getName());
+        putIfNotBlank(properties, "build.version", project.getVersion());
+        properties.put("build.time", buildTime.toString());
+
+        Properties projectProperties = project.getProperties();
+        putIfNotBlank(properties, "build.java.source", projectProperties.getProperty(MAVEN_COMPILER_SOURCE_PROPERTY));
+        putIfNotBlank(properties, "build.java.target", projectProperties.getProperty(MAVEN_COMPILER_TARGET_PROPERTY));
+        putIfNotBlank(properties, "build.java.release", projectProperties.getProperty(MAVEN_COMPILER_RELEASE_PROPERTY));
+        putIfNotBlank(properties, "build.micronaut.version", projectProperties.getProperty(MICRONAUT_VERSION_PROPERTY));
+        if (additionalProperties != null) {
+            additionalProperties.forEach((key, value) -> putIfNotBlank(properties, key, value));
+        }
+        return properties;
+    }
+
+    static Instant resolveBuildTime(String configuredTime, MavenProject project, MavenSession session) {
+        Instant configured = parseInstant(configuredTime);
+        if (configured != null) {
+            return configured;
+        }
+
+        Instant outputTimestamp = parseInstant(project.getProperties().getProperty(OUTPUT_TIMESTAMP_PROPERTY));
+        if (outputTimestamp != null) {
+            return outputTimestamp;
+        }
+
+        if (session != null && session.getRequest() != null) {
+            Date startTime = session.getRequest().getStartTime();
+            if (startTime != null) {
+                return startTime.toInstant();
+            }
+        }
+        return Instant.now();
+    }
+
+    private static Instant parseInstant(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value.trim());
+        } catch (DateTimeParseException e) {
+            try {
+                return Instant.ofEpochSecond(Long.parseLong(value.trim()));
+            } catch (NumberFormatException ignored) {
+                throw new IllegalArgumentException("Unsupported timestamp format: " + value, e);
+            }
+        }
+    }
+
+    private static void putIfNotBlank(Map<String, String> properties, String key, String value) {
+        if (key != null && !key.isBlank() && value != null && !value.isBlank()) {
+            properties.put(key, value);
+        }
+    }
+}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/BuildInfoGenerator.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/BuildInfoGenerator.java
@@ -90,7 +90,7 @@ final class BuildInfoGenerator {
         } catch (DateTimeParseException e) {
             try {
                 return Instant.ofEpochSecond(Long.parseLong(value.trim()));
-            } catch (NumberFormatException ignored) {
+            } catch (NumberFormatException _) {
                 throw new IllegalArgumentException("Unsupported timestamp format: " + value, e);
             }
         }

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/GenerateInfoMojo.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/GenerateInfoMojo.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.info;
+
+import io.micronaut.maven.AbstractMicronautMojo;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Generates Micronaut management info endpoint build and git metadata.
+ *
+ * @author Micronaut Authors
+ * @since 5.0.1
+ */
+@Mojo(name = GenerateInfoMojo.MOJO_NAME, defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public class GenerateInfoMojo extends AbstractMicronautMojo {
+
+    /**
+     * Name of the generate info mojo.
+     */
+    public static final String MOJO_NAME = "generate-info";
+
+    private static final String MICRONAUT_INFO_PREFIX = "micronaut.info";
+
+    /**
+     * Reference to the Maven project on which the plugin is invoked.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    /**
+     * Reference to the Maven session.
+     */
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    /**
+     * Whether to skip metadata generation.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".skip", defaultValue = "false")
+    private boolean skip;
+
+    /**
+     * Whether to generate build metadata.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".build.enabled", defaultValue = "true")
+    private boolean buildEnabled;
+
+    /**
+     * Whether to generate git metadata.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".git.enabled", defaultValue = "true")
+    private boolean gitEnabled;
+
+    /**
+     * Whether to fail the build when git metadata is enabled but unavailable.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".failOnNoGit", defaultValue = "false")
+    private boolean failOnNoGit;
+
+    /**
+     * Whether to include a boolean dirty-state flag in generated git metadata.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".includeDirty", defaultValue = "true")
+    private boolean includeDirty;
+
+    /**
+     * Whether to include the configured origin remote URL in generated git metadata.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".includeRemoteUrl", defaultValue = "false")
+    private boolean includeRemoteUrl;
+
+    /**
+     * Whether to include local git user identity in generated git metadata.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".includeUser", defaultValue = "false")
+    private boolean includeUser;
+
+    /**
+     * Build timestamp to use for build metadata. When unset, {@code project.build.outputTimestamp}
+     * is used if present, then the Maven session start time, then the current instant.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".time")
+    private String time;
+
+    /**
+     * Build metadata output file.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".build.outputFile", defaultValue = "${project.build.outputDirectory}/META-INF/build-info.properties", required = true)
+    private File buildOutputFile;
+
+    /**
+     * Git metadata output file.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = MICRONAUT_INFO_PREFIX + ".git.outputFile", defaultValue = "${project.build.outputDirectory}/git.properties", required = true)
+    private File gitOutputFile;
+
+    /**
+     * Additional build metadata properties. Keys are written as provided.
+     *
+     * @since 5.0.1
+     */
+    @Parameter
+    private Map<String, String> additionalBuildProperties;
+
+    /**
+     * Additional git metadata properties. Keys are written as provided.
+     *
+     * @since 5.0.1
+     */
+    @Parameter
+    private Map<String, String> additionalGitProperties;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("Skipping Micronaut info metadata generation");
+            return;
+        }
+
+        Instant buildTime;
+        try {
+            buildTime = BuildInfoGenerator.resolveBuildTime(time, project, session);
+        } catch (IllegalArgumentException e) {
+            throw new MojoExecutionException("Error resolving Micronaut build info timestamp", e);
+        }
+        if (buildEnabled) {
+            try {
+                PropertiesFileWriter.write(buildOutputFile.toPath(), BuildInfoGenerator.generate(project, buildTime, additionalBuildProperties));
+                getLog().info("Generated Micronaut build info at " + buildOutputFile.getAbsolutePath());
+            } catch (IOException e) {
+                throw new MojoExecutionException("Error generating Micronaut build info", e);
+            }
+        } else {
+            getLog().debug("Micronaut build info generation is disabled");
+        }
+
+        if (gitEnabled) {
+            GitInfoGenerator gitInfoGenerator = new GitInfoGenerator(project.getBasedir().toPath(), includeDirty, includeRemoteUrl, includeUser);
+            GitInfoGenerator.Result result = gitInfoGenerator.generate(additionalGitProperties);
+            if (result.properties().isEmpty()) {
+                String message = "Git metadata is unavailable: " + result.message();
+                if (failOnNoGit) {
+                    throw new MojoExecutionException(message);
+                }
+                getLog().warn(message + "; skipping git.properties generation");
+                return;
+            }
+            try {
+                PropertiesFileWriter.write(gitOutputFile.toPath(), result.properties());
+                getLog().info("Generated Micronaut git info at " + gitOutputFile.getAbsolutePath());
+            } catch (IOException e) {
+                throw new MojoExecutionException("Error generating Micronaut git info", e);
+            }
+        } else {
+            getLog().debug("Micronaut git info generation is disabled");
+        }
+    }
+}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/GitInfoGenerator.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/GitInfoGenerator.java
@@ -34,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 final class GitInfoGenerator {
 
     private static final Duration COMMAND_TIMEOUT = Duration.ofSeconds(10);
+    private static final String CONFIG = "config";
+    private static final String CONFIG_GET = "--get";
+    private static final String REV_PARSE = "rev-parse";
 
     private final Path workingDirectory;
     private final boolean includeDirty;
@@ -48,17 +51,17 @@ final class GitInfoGenerator {
     }
 
     Result generate(Map<String, String> additionalProperties) {
-        CommandResult root = runGit("rev-parse", "--show-toplevel");
+        CommandResult root = runGit(REV_PARSE, "--show-toplevel");
         if (!root.isSuccess()) {
             return Result.unavailable(root.message());
         }
-        CommandResult commitId = runGit("rev-parse", "HEAD");
+        CommandResult commitId = runGit(REV_PARSE, "HEAD");
         if (!commitId.isSuccess()) {
             return Result.unavailable(commitId.message());
         }
         var properties = new TreeMap<String, String>();
         properties.put("git.commit.id", commitId.output());
-        putIfPresent(properties, "git.commit.id.abbrev", runGit("rev-parse", "--short", "HEAD"));
+        putIfPresent(properties, "git.commit.id.abbrev", runGit(REV_PARSE, "--short", "HEAD"));
         putIfPresent(properties, "git.commit.time", runGit("show", "-s", "--format=%cI", "HEAD"));
         putBranch(properties);
         if (includeDirty) {
@@ -68,11 +71,11 @@ final class GitInfoGenerator {
             }
         }
         if (includeRemoteUrl) {
-            putIfPresent(properties, "git.remote.origin.url", runGit("config", "--get", "remote.origin.url"));
+            putIfPresent(properties, "git.remote.origin.url", runGit(CONFIG, CONFIG_GET, "remote.origin.url"));
         }
         if (includeUser) {
-            putIfPresent(properties, "git.build.user.name", runGit("config", "--get", "user.name"));
-            putIfPresent(properties, "git.build.user.email", runGit("config", "--get", "user.email"));
+            putIfPresent(properties, "git.build.user.name", runGit(CONFIG, CONFIG_GET, "user.name"));
+            putIfPresent(properties, "git.build.user.email", runGit(CONFIG, CONFIG_GET, "user.email"));
         }
         if (additionalProperties != null) {
             additionalProperties.forEach((key, value) -> putIfNotBlank(properties, key, value));
@@ -81,7 +84,7 @@ final class GitInfoGenerator {
     }
 
     private void putBranch(Map<String, String> properties) {
-        CommandResult branch = runGit("rev-parse", "--abbrev-ref", "HEAD");
+        CommandResult branch = runGit(REV_PARSE, "--abbrev-ref", "HEAD");
         if (branch.isSuccess() && !"HEAD".equals(branch.output())) {
             properties.put("git.branch", branch.output());
         }
@@ -115,7 +118,7 @@ final class GitInfoGenerator {
             return CommandResult.success(output);
         } catch (IOException e) {
             return CommandResult.failure(e.toString());
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
             Thread.currentThread().interrupt();
             return CommandResult.failure("git command was interrupted");
         } finally {

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/GitInfoGenerator.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/GitInfoGenerator.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.info;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Generates git metadata properties.
+ *
+ * @author Micronaut Authors
+ * @since 5.0.1
+ */
+final class GitInfoGenerator {
+
+    private static final Duration COMMAND_TIMEOUT = Duration.ofSeconds(10);
+
+    private final Path workingDirectory;
+    private final boolean includeDirty;
+    private final boolean includeRemoteUrl;
+    private final boolean includeUser;
+
+    GitInfoGenerator(Path workingDirectory, boolean includeDirty, boolean includeRemoteUrl, boolean includeUser) {
+        this.workingDirectory = workingDirectory;
+        this.includeDirty = includeDirty;
+        this.includeRemoteUrl = includeRemoteUrl;
+        this.includeUser = includeUser;
+    }
+
+    Result generate(Map<String, String> additionalProperties) {
+        CommandResult root = runGit("rev-parse", "--show-toplevel");
+        if (!root.isSuccess()) {
+            return Result.unavailable(root.message());
+        }
+        CommandResult commitId = runGit("rev-parse", "HEAD");
+        if (!commitId.isSuccess()) {
+            return Result.unavailable(commitId.message());
+        }
+        var properties = new TreeMap<String, String>();
+        properties.put("git.commit.id", commitId.output());
+        putIfPresent(properties, "git.commit.id.abbrev", runGit("rev-parse", "--short", "HEAD"));
+        putIfPresent(properties, "git.commit.time", runGit("show", "-s", "--format=%cI", "HEAD"));
+        putBranch(properties);
+        if (includeDirty) {
+            CommandResult status = runGit("status", "--porcelain");
+            if (status.isSuccess()) {
+                properties.put("git.dirty", Boolean.toString(!status.output().isBlank()));
+            }
+        }
+        if (includeRemoteUrl) {
+            putIfPresent(properties, "git.remote.origin.url", runGit("config", "--get", "remote.origin.url"));
+        }
+        if (includeUser) {
+            putIfPresent(properties, "git.build.user.name", runGit("config", "--get", "user.name"));
+            putIfPresent(properties, "git.build.user.email", runGit("config", "--get", "user.email"));
+        }
+        if (additionalProperties != null) {
+            additionalProperties.forEach((key, value) -> putIfNotBlank(properties, key, value));
+        }
+        return Result.available(properties);
+    }
+
+    private void putBranch(Map<String, String> properties) {
+        CommandResult branch = runGit("rev-parse", "--abbrev-ref", "HEAD");
+        if (branch.isSuccess() && !"HEAD".equals(branch.output())) {
+            properties.put("git.branch", branch.output());
+        }
+    }
+
+    private void putIfPresent(Map<String, String> properties, String key, CommandResult result) {
+        if (result.isSuccess() && !result.output().isBlank()) {
+            properties.put(key, result.output());
+        }
+    }
+
+    private CommandResult runGit(String... arguments) {
+        var command = new java.util.ArrayList<String>();
+        command.add("git");
+        command.addAll(List.of(arguments));
+        Process process = null;
+        try {
+            process = new ProcessBuilder(command)
+                .directory(workingDirectory.toFile())
+                .redirectErrorStream(true)
+                .start();
+            boolean finished = process.waitFor(COMMAND_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                return CommandResult.failure("git command timed out: " + String.join(" ", command));
+            }
+            String output = read(process).trim();
+            if (process.exitValue() != 0) {
+                return CommandResult.failure(output.isBlank() ? "git command failed" : output);
+            }
+            return CommandResult.success(output);
+        } catch (IOException e) {
+            return CommandResult.failure(e.toString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return CommandResult.failure("git command was interrupted");
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+
+    private String read(Process process) throws IOException {
+        var output = new ByteArrayOutputStream();
+        process.getInputStream().transferTo(output);
+        return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private void putIfNotBlank(Map<String, String> properties, String key, String value) {
+        if (key != null && !key.isBlank() && value != null && !value.isBlank()) {
+            properties.put(key, value);
+        }
+    }
+
+    record Result(Map<String, String> properties, String message) {
+
+        static Result available(Map<String, String> properties) {
+            return new Result(properties, null);
+        }
+
+        static Result unavailable(String message) {
+            return new Result(Map.of(), message);
+        }
+    }
+
+    private record CommandResult(boolean isSuccess, String output, String message) {
+
+        static CommandResult success(String output) {
+            return new CommandResult(true, output, null);
+        }
+
+        static CommandResult failure(String message) {
+            return new CommandResult(false, null, message);
+        }
+    }
+}

--- a/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/PropertiesFileWriter.java
+++ b/micronaut-maven-plugin/src/main/java/io/micronaut/maven/info/PropertiesFileWriter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.info;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Writes sorted Java properties files without timestamp comments.
+ *
+ * @author Micronaut Authors
+ * @since 5.0.1
+ */
+final class PropertiesFileWriter {
+
+    private PropertiesFileWriter() {
+    }
+
+    static void write(Path outputFile, Map<String, String> properties) throws IOException {
+        Path parent = outputFile.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        var content = new StringBuilder();
+        new TreeMap<>(properties).forEach((key, value) -> content
+            .append(escape(key, true))
+            .append('=')
+            .append(escape(value, false))
+            .append('\n'));
+        Files.writeString(outputFile, content.toString(), StandardCharsets.UTF_8);
+    }
+
+    static String escape(String value, boolean key) {
+        var escaped = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\' -> escaped.append("\\\\");
+                case '\t' -> escaped.append("\\t");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\f' -> escaped.append("\\f");
+                case '=', ':', '#', '!' -> escaped.append('\\').append(c);
+                case ' ' -> {
+                    if (key || i == 0) {
+                        escaped.append("\\ ");
+                    } else {
+                        escaped.append(c);
+                    }
+                }
+                default -> escaped.append(c);
+            }
+        }
+        return escaped.toString();
+    }
+}

--- a/micronaut-maven-plugin/src/site/asciidoc/examples/generate-info.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/examples/generate-info.adoc
@@ -1,0 +1,143 @@
+= Generating build and git info
+
+The `mn:generate-info` goal generates metadata resources that Micronaut Management can expose from the `/info` endpoint.
+The goal is opt-in: existing builds do not generate new files unless you invoke the goal directly or bind it in your build.
+
+== Enable the goal
+
+Bind the goal to `generate-resources` so the files are available under `target/classes` before packaging:
+
+[source,xml]
+----
+<plugin>
+    <groupId>io.micronaut.maven</groupId>
+    <artifactId>micronaut-maven-plugin</artifactId>
+    <executions>
+        <execution>
+            <phase>generate-resources</phase>
+            <goals>
+                <goal>generate-info</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+----
+
+You can also run it directly:
+
+[source,bash]
+----
+./mvnw mn:generate-info
+----
+
+By default the goal writes:
+
+* `target/classes/META-INF/build-info.properties`
+* `target/classes/git.properties`, when the project is inside a git checkout
+
+These locations match the default locations used by Micronaut Management's build and git info sources.
+If your application uses different management locations, configure the corresponding output files for this goal as well.
+
+== Runtime `/info` endpoint
+
+Generating the files does not enable the HTTP endpoint by itself.
+Your application must include `micronaut-management` and enable the info endpoint according to the Micronaut Management documentation.
+For example, a development configuration may include:
+
+[source,yaml]
+----
+endpoints:
+  info:
+    enabled: true
+    sensitive: false
+----
+
+After packaging and running the application, verify the generated data by querying `/info` or by inspecting the generated files under `target/classes`.
+
+== Configuration
+
+[cols="1,1,3"]
+|===
+|Parameter |Property |Description
+
+|`skip`
+|`micronaut.info.skip`
+|Skips all info metadata generation. Defaults to `false`.
+
+|`buildEnabled`
+|`micronaut.info.build.enabled`
+|Generates `META-INF/build-info.properties`. Defaults to `true`.
+
+|`gitEnabled`
+|`micronaut.info.git.enabled`
+|Generates `git.properties` when git metadata is available. Defaults to `true`.
+
+|`failOnNoGit`
+|`micronaut.info.failOnNoGit`
+|Fails the build when git metadata is enabled but unavailable. Defaults to `false`, so source archives and non-git checkouts still generate build info.
+
+|`includeDirty`
+|`micronaut.info.includeDirty`
+|Includes `git.dirty` as a boolean. Defaults to `true`; file names are never written.
+
+|`includeRemoteUrl`
+|`micronaut.info.includeRemoteUrl`
+|Includes `git.remote.origin.url`. Defaults to `false` because remote URLs may expose private hosts or repository names.
+
+|`includeUser`
+|`micronaut.info.includeUser`
+|Includes local git user name and email as `git.build.user.*`. Defaults to `false`.
+
+|`time`
+|`micronaut.info.time`
+|Overrides `build.time`. Use an ISO-8601 instant such as `2026-01-02T03:04:05Z`.
+
+|`buildOutputFile`
+|`micronaut.info.build.outputFile`
+|Build metadata output file. Defaults to `${project.build.outputDirectory}/META-INF/build-info.properties`.
+
+|`gitOutputFile`
+|`micronaut.info.git.outputFile`
+|Git metadata output file. Defaults to `${project.build.outputDirectory}/git.properties`.
+|===
+
+You may add extra properties with `additionalBuildProperties` or `additionalGitProperties`:
+
+[source,xml]
+----
+<configuration>
+    <additionalBuildProperties>
+        <build.environment>production</build.environment>
+    </additionalBuildProperties>
+</configuration>
+----
+
+== Reproducible build time
+
+`build.time` is chosen in this order:
+
+1. `micronaut.info.time`, when set.
+2. Maven's `project.build.outputTimestamp`, when set.
+3. The Maven session start time.
+4. The current instant as a final fallback.
+
+Set `project.build.outputTimestamp` or `micronaut.info.time` when you need reproducible metadata.
+
+== Git metadata and sensitive data
+
+The default git metadata is conservative and local-only.
+It includes commit id, abbreviated commit id, commit time, branch, and the boolean dirty state when available.
+It does not read CI variables, perform network calls, include dirty file names, include remote URLs, or include local user identity by default.
+
+Only enable `includeRemoteUrl` or `includeUser` after reviewing whether the `/info` endpoint is exposed and whether those values are safe for your deployment.
+You can disable git metadata completely with:
+
+[source,xml]
+----
+<configuration>
+    <gitEnabled>false</gitEnabled>
+</configuration>
+----
+
+Outside a git checkout, the default `failOnNoGit=false` behavior logs a warning, skips `git.properties`, and still writes build metadata.
+Set `failOnNoGit=true` if your release process requires git provenance to be present.

--- a/micronaut-maven-plugin/src/site/asciidoc/index.adoc
+++ b/micronaut-maven-plugin/src/site/asciidoc/index.adoc
@@ -14,6 +14,7 @@ This plugin has the following features:
 8. link:examples/bean-import.html[Importing beans from project dependencies].
 9. link:examples/jsonschema.html[Generating Sources from JSON Schema].
 10. link:examples/configuration-validation.html[Validating Micronaut configuration and dependency injection].
+11. link:examples/generate-info.html[Generating build and git info] for the management info endpoint.
 
 == Usage
 

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/BuildInfoGeneratorTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/BuildInfoGeneratorTest.java
@@ -1,0 +1,90 @@
+package io.micronaut.maven.info;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuildInfoGeneratorTest {
+
+    @Test
+    void generatesConservativeBuildProperties() {
+        MavenProject project = project();
+        project.getProperties().setProperty("maven.compiler.source", "17");
+        project.getProperties().setProperty("maven.compiler.target", "17");
+        project.getProperties().setProperty("micronaut.version", "5.0.2");
+
+        Map<String, String> properties = BuildInfoGenerator.generate(
+            project,
+            Instant.parse("2026-01-02T03:04:05Z"),
+            Map.of("build.number", "42")
+        );
+
+        assertEquals("io.micronaut.test", properties.get("build.group"));
+        assertEquals("demo", properties.get("build.artifact"));
+        assertEquals("Demo", properties.get("build.name"));
+        assertEquals("1.0.0", properties.get("build.version"));
+        assertEquals("2026-01-02T03:04:05Z", properties.get("build.time"));
+        assertEquals("17", properties.get("build.java.source"));
+        assertEquals("17", properties.get("build.java.target"));
+        assertEquals("5.0.2", properties.get("build.micronaut.version"));
+        assertEquals("42", properties.get("build.number"));
+    }
+
+    @Test
+    void ignoresAdditionalBuildPropertiesWithBlankKeys() {
+        Map<String, String> properties = BuildInfoGenerator.generate(
+            project(),
+            Instant.parse("2026-01-02T03:04:05Z"),
+            Map.of(" ", "ignored", "build.valid", "included")
+        );
+
+        assertFalse(properties.containsKey(" "));
+        assertEquals("included", properties.get("build.valid"));
+    }
+
+    @Test
+    void outputTimestampTakesPrecedenceForReproducibleBuilds() {
+        MavenProject project = project();
+        project.getProperties().setProperty("project.build.outputTimestamp", "2026-02-03T04:05:06Z");
+
+        assertEquals(Instant.parse("2026-02-03T04:05:06Z"), BuildInfoGenerator.resolveBuildTime(null, project, null));
+    }
+
+    @Test
+    void writesSortedPropertiesWithoutTimestampComment(@TempDir Path tempDir) throws IOException {
+        Path output = tempDir.resolve("build-info.properties");
+
+        PropertiesFileWriter.write(output, Map.of(
+            "z", "last",
+            "a key", "value:with=special#chars"
+        ));
+
+        String content = Files.readString(output);
+        assertTrue(content.startsWith("a\\ key=value\\:with\\=special\\#chars"));
+        assertTrue(content.contains(System.lineSeparator() + "z=last"));
+        assertFalse(content.startsWith("#"));
+    }
+
+    private MavenProject project() {
+        var project = new MavenProject();
+        project.setGroupId("io.micronaut.test");
+        project.setArtifactId("demo");
+        project.setName("Demo");
+        project.setVersion("1.0.0");
+        var build = new Build();
+        build.setOutputDirectory("target/classes");
+        project.setBuild(build);
+        return project;
+    }
+}

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/BuildInfoGeneratorTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/BuildInfoGeneratorTest.java
@@ -72,7 +72,7 @@ class BuildInfoGeneratorTest {
 
         String content = Files.readString(output);
         assertTrue(content.startsWith("a\\ key=value\\:with\\=special\\#chars"));
-        assertTrue(content.contains(System.lineSeparator() + "z=last"));
+        assertTrue(content.contains("\nz=last"));
         assertFalse(content.startsWith("#"));
     }
 

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/BuildInfoGeneratorTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/BuildInfoGeneratorTest.java
@@ -76,6 +76,15 @@ class BuildInfoGeneratorTest {
         assertFalse(content.startsWith("#"));
     }
 
+    @Test
+    void escapesAllPropertiesSpecialCharacters() {
+        assertEquals("a\\ b", PropertiesFileWriter.escape("a b", true));
+        assertEquals("a b", PropertiesFileWriter.escape("a b", false));
+        assertEquals("\\ leading", PropertiesFileWriter.escape(" leading", false));
+        assertEquals("tab\\tnewline\\nreturn\\rform\\f", PropertiesFileWriter.escape("tab\tnewline\nreturn\rform\f", false));
+        assertEquals("key\\\\value\\=x\\:y\\#z\\!", PropertiesFileWriter.escape("key\\value=x:y#z!", true));
+    }
+
     private MavenProject project() {
         var project = new MavenProject();
         project.setGroupId("io.micronaut.test");

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/GenerateInfoMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/GenerateInfoMojoTest.java
@@ -23,7 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -95,6 +97,48 @@ class GenerateInfoMojoTest {
         assertTrue(exception.getMessage().startsWith("Git metadata is unavailable:"));
     }
 
+    @Test
+    void missingGitMetadataIsSkippedWhenFailureIsDisabled(@TempDir Path tempDir) throws Exception {
+        GenerateInfoMojo mojo = mojo(tempDir);
+        File gitInfo = tempDir.resolve("classes/git.properties").toFile();
+        set(mojo, "buildEnabled", false);
+        set(mojo, "gitEnabled", true);
+        set(mojo, "failOnNoGit", false);
+        set(mojo, "gitOutputFile", gitInfo);
+
+        mojo.execute();
+
+        assertFalse(gitInfo.exists());
+    }
+
+    @Test
+    void generatesGitInfoWhenGitRepositoryIsAvailable(@TempDir Path tempDir) throws Exception {
+        git(tempDir, "init");
+        git(tempDir, "config", "user.email", "dev@example.com");
+        git(tempDir, "config", "user.name", "Dev User");
+        Files.writeString(tempDir.resolve("README.md"), "test");
+        git(tempDir, "add", "README.md");
+        git(tempDir, "commit", "-m", "Initial commit");
+
+        GenerateInfoMojo mojo = mojo(tempDir);
+        File gitInfo = tempDir.resolve("classes/git.properties").toFile();
+        set(mojo, "buildEnabled", false);
+        set(mojo, "gitEnabled", true);
+        set(mojo, "gitOutputFile", gitInfo);
+        set(mojo, "includeDirty", true);
+        set(mojo, "includeRemoteUrl", false);
+        set(mojo, "includeUser", false);
+
+        mojo.execute();
+
+        Properties properties = new Properties();
+        try (var reader = Files.newBufferedReader(gitInfo.toPath())) {
+            properties.load(reader);
+        }
+        assertEquals(gitOutput(tempDir, "rev-parse", "HEAD"), properties.getProperty("git.commit.id"));
+        assertTrue(properties.containsKey("git.commit.time"));
+    }
+
     private GenerateInfoMojo mojo(Path tempDir) throws Exception {
         var mojo = new GenerateInfoMojo();
         mojo.setLog(new SystemStreamLog());
@@ -119,5 +163,31 @@ class GenerateInfoMojoTest {
         Field field = GenerateInfoMojo.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(mojo, value);
+    }
+
+    private void git(Path directory, String... args) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder(command(args))
+            .directory(directory.toFile())
+            .redirectErrorStream(true)
+            .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(0, process.waitFor(), output);
+    }
+
+    private String gitOutput(Path directory, String... args) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder(command(args))
+            .directory(directory.toFile())
+            .redirectErrorStream(true)
+            .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        assertEquals(0, process.waitFor(), output);
+        return output;
+    }
+
+    private String[] command(String... args) {
+        String[] command = new String[args.length + 1];
+        command[0] = "git";
+        System.arraycopy(args, 0, command, 1, args.length);
+        return command;
     }
 }

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/GenerateInfoMojoTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/GenerateInfoMojoTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.maven.info;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GenerateInfoMojoTest {
+
+    @Test
+    void generatesBuildInfoWhenGitInfoIsDisabled(@TempDir Path tempDir) throws Exception {
+        GenerateInfoMojo mojo = mojo(tempDir);
+        File buildInfo = tempDir.resolve("classes/META-INF/build-info.properties").toFile();
+        File gitInfo = tempDir.resolve("classes/git.properties").toFile();
+        set(mojo, "buildOutputFile", buildInfo);
+        set(mojo, "gitOutputFile", gitInfo);
+        set(mojo, "buildEnabled", true);
+        set(mojo, "gitEnabled", false);
+
+        mojo.execute();
+
+        Properties properties = new Properties();
+        try (var reader = Files.newBufferedReader(buildInfo.toPath())) {
+            properties.load(reader);
+        }
+        assertEquals("demo", properties.getProperty("build.artifact"));
+        assertEquals("1.0.0", properties.getProperty("build.version"));
+        assertTrue(properties.containsKey("build.time"));
+        assertFalse(gitInfo.exists());
+    }
+
+    @Test
+    void skipDoesNotWriteInfoFiles(@TempDir Path tempDir) throws Exception {
+        GenerateInfoMojo mojo = mojo(tempDir);
+        File buildInfo = tempDir.resolve("classes/META-INF/build-info.properties").toFile();
+        set(mojo, "buildOutputFile", buildInfo);
+        set(mojo, "skip", true);
+        set(mojo, "buildEnabled", true);
+        set(mojo, "gitEnabled", true);
+
+        mojo.execute();
+
+        assertFalse(buildInfo.exists());
+    }
+
+    @Test
+    void invalidBuildTimeFailsTheMojo(@TempDir Path tempDir) throws Exception {
+        GenerateInfoMojo mojo = mojo(tempDir);
+        set(mojo, "time", "not-a-timestamp");
+        set(mojo, "buildEnabled", true);
+        set(mojo, "gitEnabled", false);
+        set(mojo, "buildOutputFile", tempDir.resolve("build-info.properties").toFile());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, mojo::execute);
+        assertEquals("Error resolving Micronaut build info timestamp", exception.getMessage());
+    }
+
+    @Test
+    void failOnNoGitTurnsUnavailableGitMetadataIntoMojoFailure(@TempDir Path tempDir) throws Exception {
+        GenerateInfoMojo mojo = mojo(tempDir);
+        set(mojo, "buildEnabled", false);
+        set(mojo, "gitEnabled", true);
+        set(mojo, "failOnNoGit", true);
+        set(mojo, "gitOutputFile", tempDir.resolve("git.properties").toFile());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, mojo::execute);
+        assertTrue(exception.getMessage().startsWith("Git metadata is unavailable:"));
+    }
+
+    private GenerateInfoMojo mojo(Path tempDir) throws Exception {
+        var mojo = new GenerateInfoMojo();
+        mojo.setLog(new SystemStreamLog());
+        set(mojo, "project", project(tempDir));
+        return mojo;
+    }
+
+    private MavenProject project(Path baseDir) {
+        var project = new MavenProject();
+        project.setGroupId("io.micronaut.test");
+        project.setArtifactId("demo");
+        project.setName("Demo");
+        project.setVersion("1.0.0");
+        project.setFile(baseDir.resolve("pom.xml").toFile());
+        var build = new Build();
+        build.setOutputDirectory(baseDir.resolve("classes").toString());
+        project.setBuild(build);
+        return project;
+    }
+
+    private void set(GenerateInfoMojo mojo, String fieldName, Object value) throws ReflectiveOperationException {
+        Field field = GenerateInfoMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+}

--- a/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/GitInfoGeneratorTest.java
+++ b/micronaut-maven-plugin/src/test/java/io/micronaut/maven/info/GitInfoGeneratorTest.java
@@ -1,0 +1,105 @@
+package io.micronaut.maven.info;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GitInfoGeneratorTest {
+
+    @Test
+    void returnsUnavailableOutsideGitRepository(@TempDir Path tempDir) {
+        GitInfoGenerator.Result result = new GitInfoGenerator(tempDir, true, false, false).generate(null);
+
+        assertTrue(result.properties().isEmpty());
+        assertFalse(result.message().isBlank());
+    }
+
+    @Test
+    void generatesConservativeGitProperties(@TempDir Path tempDir) throws IOException, InterruptedException {
+        git(tempDir, "init");
+        git(tempDir, "config", "user.email", "dev@example.com");
+        git(tempDir, "config", "user.name", "Dev User");
+        git(tempDir, "remote", "add", "origin", "https://example.com/private/repo.git");
+        Files.writeString(tempDir.resolve("README.md"), "test");
+        git(tempDir, "add", "README.md");
+        git(tempDir, "commit", "-m", "Initial commit");
+
+        Map<String, String> properties = new GitInfoGenerator(tempDir, true, false, false).generate(null).properties();
+
+        assertEquals(gitOutput(tempDir, "rev-parse", "HEAD"), properties.get("git.commit.id"));
+        assertEquals(gitOutput(tempDir, "rev-parse", "--short", "HEAD"), properties.get("git.commit.id.abbrev"));
+        assertEquals("false", properties.get("git.dirty"));
+        assertTrue(properties.containsKey("git.commit.time"));
+        assertFalse(properties.containsKey("git.remote.origin.url"));
+        assertFalse(properties.containsKey("git.build.user.name"));
+        assertFalse(properties.containsKey("git.build.user.email"));
+    }
+
+    @Test
+    void includesSensitiveFieldsOnlyWhenEnabled(@TempDir Path tempDir) throws IOException, InterruptedException {
+        git(tempDir, "init");
+        git(tempDir, "config", "user.email", "dev@example.com");
+        git(tempDir, "config", "user.name", "Dev User");
+        git(tempDir, "remote", "add", "origin", "https://example.com/private/repo.git");
+        Files.writeString(tempDir.resolve("README.md"), "test");
+        git(tempDir, "add", "README.md");
+        git(tempDir, "commit", "-m", "Initial commit");
+
+        Map<String, String> properties = new GitInfoGenerator(tempDir, false, true, true).generate(null).properties();
+
+        assertEquals("https://example.com/private/repo.git", properties.get("git.remote.origin.url"));
+        assertEquals("Dev User", properties.get("git.build.user.name"));
+        assertEquals("dev@example.com", properties.get("git.build.user.email"));
+        assertFalse(properties.containsKey("git.dirty"));
+    }
+
+    @Test
+    void ignoresAdditionalGitPropertiesWithBlankKeys(@TempDir Path tempDir) throws IOException, InterruptedException {
+        git(tempDir, "init");
+        git(tempDir, "config", "user.email", "dev@example.com");
+        git(tempDir, "config", "user.name", "Dev User");
+        Files.writeString(tempDir.resolve("README.md"), "test");
+        git(tempDir, "add", "README.md");
+        git(tempDir, "commit", "-m", "Initial commit");
+
+        Map<String, String> properties = new GitInfoGenerator(tempDir, false, false, false).generate(Map.of(" ", "ignored", "git.valid", "included")).properties();
+
+        assertFalse(properties.containsKey(" "));
+        assertEquals("included", properties.get("git.valid"));
+    }
+
+    private void git(Path directory, String... args) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder(command(args))
+            .directory(directory.toFile())
+            .redirectErrorStream(true)
+            .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(0, process.waitFor(), output);
+    }
+
+    private String gitOutput(Path directory, String... args) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder(command(args))
+            .directory(directory.toFile())
+            .redirectErrorStream(true)
+            .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        assertEquals(0, process.waitFor(), output);
+        return output;
+    }
+
+    private String[] command(String... args) {
+        String[] command = new String[args.length + 1];
+        command[0] = "git";
+        System.arraycopy(args, 0, command, 1, args.length);
+        return command;
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in `mn:generate-info` goal that writes Micronaut-compatible build metadata and conservative git metadata for the management `/info` endpoint
- generate deterministic `META-INF/build-info.properties` and `git.properties` with configurable build/git switches, output paths, timestamp handling, and sensitive-field opt-ins
- document enablement, `/info` verification, reproducible timestamps, no-git behavior, and sensitive metadata defaults

## Tests
- `./mvnw -pl micronaut-maven-plugin -am -Dtest=io.micronaut.maven.info.* -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl micronaut-maven-integration-tests -am verify "-Dinvoker.test=generate-info*"`

## Release and routing
- Target branch: `5.0.x`
- Release target: 5.0.x major line; QA recorded that the latest stable is `v4.11.6` and that 5.0 prereleases do not count as shipped
- Type label: `type: enhancement`
- Micronaut organization project: `5.0.3 Release` (QA ambiguity note preserved: this repository is currently `5.0.1-SNAPSHOT`, while the best matching open Micronaut Platform BOM release board is `5.0.3 Release`)
- Paperclip issue: DEV-1071
- Closing keyword: Fixes DEV-1071 (Paperclip-origin issue; no linked GitHub issue existed at PR creation time)

## Security and compatibility
- The feature is opt-in; existing build, packaging, run, AOT, OpenAPI, Test Resources, JSON Schema, and validation behavior remains unchanged unless users invoke or bind `mn:generate-info`.
- Git metadata generation uses fixed `ProcessBuilder` argument arrays, performs no network calls, and excludes remote URL and local git user identity unless explicitly enabled.
- Outside a git checkout, the default `failOnNoGit=false` path skips `git.properties` and still writes build metadata.

---
###### ✨ This message was AI-generated using gpt-5.5
