### PR TITLE
Update workflow action digests from template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: bash .github/scripts/verify-maven-wrapper-checksum.sh
 
       - name: "☕️ Install Java and Maven"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -68,7 +68,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: "☕️ Set up Apache Maven Central"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: "☕️ Install Java and Maven"
         if: steps.preflight_scope.outputs.should_run == 'true'
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -113,7 +113,7 @@ jobs:
 
       - name: "🔧 Setup GraalVM CE"
         if: steps.preflight_scope.outputs.should_run == 'true'
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
+        uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1
         with:
           distribution: 'graalvm'
           java-version: '25'
@@ -186,7 +186,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: "☕️ Install Java and Maven and set up Apache Maven Central"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -196,7 +196,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
+        uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
@@ -325,14 +325,14 @@ jobs:
           fetch-depth: 0
 
       - name: "☕️ Install Java and Maven"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
+        uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -41,7 +41,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Setup GraalVM
-        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f
+        uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/windows-preflight.yml
+++ b/.github/workflows/windows-preflight.yml
@@ -45,7 +45,7 @@ jobs:
       - name: "📥 Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: "☕️ Install Java"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
## Summary
- update pinned `actions/setup-java` v5 digests to the current Micronaut Project Template digest
- update pinned `graalvm/setup-graalvm` v1 digests to the current Micronaut Project Template digest
- preserve the Maven plugin repository's existing Maven-specific CI, release, wrapper, and workflow structure

## Verification
- `git diff --check origin/5.0.x..HEAD`
- `bash .github/scripts/ci-sensitive-preflight.sh`
- Windows Preflight workflow run 27804805030 succeeded on `cdd5664bfe7d7500bc430a707dad51e11f479f2b`

## Release / routing notes
- Target branch: `5.0.x`
- Release impact: workflow dependency maintenance only; no public API, runtime behavior, Maven coordinates, docs, or migration impact
- Micronaut organization project selection: `5.0.3 Release` (best-fit open Micronaut Platform release board for `5.0.x`; no upstream QA intake artifact selected a different board)
- Paperclip issue: DEV-1336. This routine has no linked GitHub issue number, so no GitHub issue closing keyword is applicable.

---
###### ✨ This message was AI-generated using gpt-5.5
