### PR TITLE
Update checkout action pin from template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '/usr/lib/jvm' | paste -sd:)
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: "🛡 Verify workflow pinning"
         run: bash .github/scripts/check-workflow-pinning.sh
       - name: "🛡 Verify Maven wrapper checksum"
@@ -49,7 +49,7 @@ jobs:
       NATIVE_IMAGE_OPTIONS: "-H:+ReportExceptionStackTraces"
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -172,7 +172,7 @@ jobs:
           df -h
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -279,7 +279,7 @@ jobs:
       shards: ${{ steps.shards.outputs.shards }}
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: "🧩 Generate invoker test shards"
         id: shards
         run: python3 .github/scripts/shard-invoker-tests.py --github-output "$GITHUB_OUTPUT"
@@ -320,7 +320,7 @@ jobs:
           df -h
 
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -367,7 +367,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         java: ['25']
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Verify Maven wrapper checksum
         shell: bash
         run: bash .github/scripts/verify-maven-wrapper-checksum.sh

--- a/.github/workflows/windows-preflight.yml
+++ b/.github/workflows/windows-preflight.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: "🛡 Verify workflow pinning"
         run: bash .github/scripts/check-workflow-pinning.sh
 
@@ -43,7 +43,7 @@ jobs:
         java: ['25']
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: "☕️ Install Java"
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:


### PR DESCRIPTION
## Summary
- Update every pinned `actions/checkout` usage from the v6 commit to the v7 commit selected by the Micronaut project template.
- Keep checkout references pinned to the full 40-character SHA and leave workflow permissions, triggers, secrets, shell commands, Maven configuration, source code, dependencies, and docs unchanged.
- Carry forward QA's release-board selection: `5.0.3 Release` is the open public Micronaut Platform BOM board found for the 5.0.x line; QA noted ambiguity because repository 5.0.0 draft/prerelease artifacts exist but no open public `5.0.0 Release` board was returned.

## Verification
- `bash .github/scripts/check-workflow-pinning.sh`
- `bash .github/scripts/verify-maven-wrapper-checksum.sh`
- `git diff --check origin/5.0.x...HEAD`
- QA-triggered Windows Preflight workflow run 27859775400 completed successfully on this branch.

## Issue linkage
- Paperclip: DEV-1342
- No linked GitHub issue exists for this routine-created maintenance task, so there is no GitHub issue closing keyword or issue creator reviewer to request.

---
###### ✨ This message was AI-generated using gpt-5.5
