### PR TITLE
Update JUnit report action pin from template

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: "📊 Publish Preflight Test Report"
         if: always() && steps.preflight_scope.outputs.should_run == 'true'
-        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         with:
           check_name: Linux Docker Native Preflight / Test Report
           report_paths: '**/target/invoker-reports/TEST-*.xml'
@@ -224,7 +224,7 @@ jobs:
 
       - name: "📊 Publish Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         with:
           check_name: Java CI / Test Report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -352,7 +352,7 @@ jobs:
 
       - name: "📊 Publish Invoker Test Report"
         if: always()
-        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         with:
           check_name: Java CI / Invoker Test Report (${{ matrix.shard.name }})
           report_paths: '**/target/invoker-reports/TEST-*.xml'


### PR DESCRIPTION
## Summary
- Update the three pinned `mikepenz/action-junit-report` v6 usages in `.github/workflows/snapshot.yml` to the current Micronaut Project Template digest.
- Preserve existing workflow permissions, triggers, Maven commands, report paths, and Maven-specific release/wrapper configuration.
- Confirmed the template `softprops/action-gh-release` digest update has no Maven-plugin counterpart because this repository does not use that action.

## Verification
- `git fetch origin 5.0.x DEV-1370-manually-apply-changes-from-the-micronaut-project-template`
- Branch update check: `origin/5.0.x` is already an ancestor of the work branch; no rebase conflicts.
- `git diff --check origin/5.0.x...HEAD`
- `bash .github/scripts/check-workflow-pinning.sh`
- `bash .github/scripts/ci-sensitive-preflight.sh` (workflow pinning passed; Linux environment reports the expected Windows-shell note for the Windows wrapper preflight)

## Release / routing notes
- Target branch: `5.0.x`
- Release target: Micronaut Maven Plugin 5.0.x / next 5.0.0 line; latest stable non-prerelease release recorded by QA is `v4.11.6`, so this target remains acceptable for CI-only maintenance.
- Type label: `type: dependency-upgrade`
- Micronaut organization project selection: `5.0.3 Release` (open public Micronaut Platform BOM release board found for the 5.0.x line). QA noted no separate `qa-intake` artifact on this routine issue; this selection matches the recent template-propagation PRs for the same repository line.
- Linked GitHub issue: none exists for this routine-origin Paperclip task, so there is no GitHub issue creator to request and no GitHub closing keyword to apply. The PR is linked to Paperclip issue `DEV-1370` through GitHub Sync.

Paperclip: DEV-1370

---
###### ✨ This pull request description was AI-generated using gpt-5.5