### PR TITLE
Update Jackson to 2.21.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <checkstyle.config.dir.path>${maven.multiModuleProjectDirectory}/config/checkstyle</checkstyle.config.dir.path>
         <spotless.licenseHeader.path>${maven.multiModuleProjectDirectory}/config/spotless.license.java</spotless.licenseHeader.path>
         <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
-        <jackson.version>2.21.3</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

- upgrade the managed Jackson BOM from 2.21.3 to 2.21.5
- resolve the actionable `jackson-core` and `jackson-databind` findings that blocked the [5.0.1 release](https://github.com/micronaut-projects/micronaut-maven-plugin/actions/runs/29939877715/job/88990739114)

## Verification

- `.github/scripts/vulnerability-audit.sh`
  - passes with no locally actionable vulnerabilities
  - resolves `jackson-core` and `jackson-databind` to 2.21.5 in the generated SBOM
- `./mvnw --batch-mode -DskipITs -Dinvoker.skip=true verify`
  - 93 goals executed successfully
  - 176 plugin tests passed
- independent review: pass, no blocking findings